### PR TITLE
#5067: thread the token through the 12 snippet-free suites

### DIFF
--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -83,7 +83,7 @@ _host = await Host.CreateDefaultBuilder()
             .ApplyAllDatabaseChangesOnStartup();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_static_database_multitenancy.cs#L51-L80' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multi_tenanted_databases' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_static_database_multitenancy.cs#L52-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multi_tenanted_databases' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Single Instance Multi-Tenancy
@@ -124,7 +124,7 @@ _host = await Host.CreateDefaultBuilder()
         }).ApplyAllDatabaseChangesOnStartup();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_per_database_multitenancy.cs#L96-L123' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_single_server_multi_tenancy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_per_database_multitenancy.cs#L97-L124' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_single_server_multi_tenancy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: warning Rotating credentials (Entra ID / managed identity)
@@ -571,7 +571,7 @@ Assuming that we have a custom `ITenancy` model:
 // dispose all MartenDatabase objects
 public class MySpecialTenancy: ITenancy
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_per_database_multitenancy.cs#L29-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_myspecialtenancy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_per_database_multitenancy.cs#L30-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_myspecialtenancy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 We can utilize that by applying that model at configuration time:
@@ -587,7 +587,7 @@ var store = DocumentStore.For(opts =>
     opts.Tenancy = new MySpecialTenancy();
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_per_database_multitenancy.cs#L81-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_apply_custom_tenancy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_per_database_multitenancy.cs#L82-L92' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_apply_custom_tenancy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Administering Multiple Databases
@@ -616,7 +616,7 @@ var state = await database.FetchEventStoreStatistics();
 // Apply all outstanding database changes in just this database
 await database.ApplyAllConfiguredChangesToDatabaseAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_static_database_multitenancy.cs#L251-L272' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_administering_multiple_databases' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_static_database_multitenancy.cs#L252-L273' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_administering_multiple_databases' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 All remaining methods on `IDocumentStore.Advanced` apply to all databases.

--- a/src/CompiledQueryTests/CompiledQueryTests.csproj
+++ b/src/CompiledQueryTests/CompiledQueryTests.csproj
@@ -1,6 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <!-- Swept for xUnit1051 (#5067): every call taking a CancellationToken is handed
+             TestContext.Current.CancellationToken, so a hung test is cancelled and reported
+             instead of running until CI's own timeout. Keeping the rule ON guards the sweep.
+             Must be set before Tests.props is imported. -->
+        <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <IsPackable>false</IsPackable>
         <!-- This is the iteration-4 PoC harness for #4405. It deliberately
              opts INTO the source-generated compiled-query path:

--- a/src/CompiledQueryTests/CorrectnessGate.cs
+++ b/src/CompiledQueryTests/CorrectnessGate.cs
@@ -80,8 +80,8 @@ public class CorrectnessGate: IntegrationContext
     [Fact]
     public async Task shape_1_simple_where_matches_reference_linq()
     {
-        var compiled = await theSession.QueryAsync(new UserByUserNameShape { UserName = "bravo_b" });
-        var reference = await theSession.Query<User>().FirstOrDefaultAsync(x => x.UserName == "bravo_b");
+        var compiled = await theSession.QueryAsync(new UserByUserNameShape { UserName = "bravo_b" }, TestContext.Current.CancellationToken);
+        var reference = await theSession.Query<User>().FirstOrDefaultAsync(x => x.UserName == "bravo_b", TestContext.Current.CancellationToken);
 
         compiled.ShouldNotBeNull();
         compiled.Id.ShouldBe(reference!.Id);
@@ -91,7 +91,7 @@ public class CorrectnessGate: IntegrationContext
     [Fact]
     public async Task shape_1_returns_null_when_no_match()
     {
-        var compiled = await theSession.QueryAsync(new UserByUserNameShape { UserName = "does_not_exist" });
+        var compiled = await theSession.QueryAsync(new UserByUserNameShape { UserName = "does_not_exist" }, TestContext.Current.CancellationToken);
         compiled.ShouldBeNull();
     }
 
@@ -99,13 +99,13 @@ public class CorrectnessGate: IntegrationContext
     public async Task shape_2_where_orderby_skip_take_matches_reference_linq()
     {
         var query = new UsersByFirstNamePageShape { FirstNamePrefix = "Bravo", Skip = 1, Take = 2 };
-        var compiled = (await theSession.QueryAsync(query)).ToList();
+        var compiled = (await theSession.QueryAsync(query, TestContext.Current.CancellationToken)).ToList();
 
         var reference = await theSession.Query<User>()
             .Where(x => x.FirstName!.StartsWith("Bravo"))
             .OrderBy(x => x.LastName).ThenBy(x => x.FirstName)
             .Skip(1).Take(2)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         compiled.Select(x => x.UserName).ShouldBe(reference.Select(x => x.UserName));
         compiled.Count.ShouldBe(2);
@@ -120,9 +120,9 @@ public class CorrectnessGate: IntegrationContext
         // exercises the BindParameter switch dispatching the same memberName
         // ("Skip") to different runtime values across calls.
         var page1 = (await theSession.QueryAsync(new UsersByFirstNamePageShape
-            { FirstNamePrefix = "Bravo", Skip = 0, Take = 1 })).ToList();
+            { FirstNamePrefix = "Bravo", Skip = 0, Take = 1 }, TestContext.Current.CancellationToken)).ToList();
         var page2 = (await theSession.QueryAsync(new UsersByFirstNamePageShape
-            { FirstNamePrefix = "Bravo", Skip = 1, Take = 1 })).ToList();
+            { FirstNamePrefix = "Bravo", Skip = 1, Take = 1 }, TestContext.Current.CancellationToken)).ToList();
 
         page1.Single().UserName.ShouldBe("bravo_a");
         page2.Single().UserName.ShouldBe("bravo_b");
@@ -132,7 +132,7 @@ public class CorrectnessGate: IntegrationContext
     public async Task shape_3_where_plus_include_loads_assignee()
     {
         var query = new IssueWithAssigneeShape { Title = "Alpha bug" };
-        var compiled = await theSession.QueryAsync(query);
+        var compiled = await theSession.QueryAsync(query, TestContext.Current.CancellationToken);
 
         compiled.ShouldNotBeNull();
         compiled.Id.ShouldBe(_alphaIssue.Id);
@@ -151,10 +151,10 @@ public class CorrectnessGate: IntegrationContext
         // separate invocations of the SAME type with different parameters
         // produce distinct, correct includes.
         var alphaQuery = new IssueWithAssigneeShape { Title = "Alpha bug" };
-        await theSession.QueryAsync(alphaQuery);
+        await theSession.QueryAsync(alphaQuery, TestContext.Current.CancellationToken);
 
         var bravoQuery = new IssueWithAssigneeShape { Title = "Bravo bug" };
-        await theSession.QueryAsync(bravoQuery);
+        await theSession.QueryAsync(bravoQuery, TestContext.Current.CancellationToken);
 
         alphaQuery.Assignees.Single().Id.ShouldBe(_alpha_a.Id);
         bravoQuery.Assignees.Single().Id.ShouldBe(_bravo_c.Id);

--- a/src/CompiledQueryTests/PerfGate.cs
+++ b/src/CompiledQueryTests/PerfGate.cs
@@ -65,12 +65,12 @@ public class PerfGate: OneOffConfigurationsContext
         try
         {
             using var codegenStore = SeparateStore();
-            await codegenStore.Advanced.Clean.CompletelyRemoveAllAsync();
-            await codegenStore.BulkInsertDocumentsAsync(seed);
+            await codegenStore.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+            await codegenStore.BulkInsertDocumentsAsync(seed, cancellation: TestContext.Current.CancellationToken);
 
             await using var codegenSession = codegenStore.QuerySession();
             var sw = Stopwatch.StartNew();
-            var result = await codegenSession.QueryAsync(new UserByUserNameShape { UserName = "cold_b" });
+            var result = await codegenSession.QueryAsync(new UserByUserNameShape { UserName = "cold_b" }, TestContext.Current.CancellationToken);
             sw.Stop();
             codegenColdMs = sw.ElapsedMilliseconds;
             result.ShouldNotBeNull();
@@ -85,12 +85,12 @@ public class PerfGate: OneOffConfigurationsContext
         long sourceGenColdMs;
         {
             using var sourceGenStore = SeparateStore();
-            await sourceGenStore.Advanced.Clean.CompletelyRemoveAllAsync();
-            await sourceGenStore.BulkInsertDocumentsAsync(seed);
+            await sourceGenStore.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+            await sourceGenStore.BulkInsertDocumentsAsync(seed, cancellation: TestContext.Current.CancellationToken);
 
             await using var sourceGenSession = sourceGenStore.QuerySession();
             var sw = Stopwatch.StartNew();
-            var result = await sourceGenSession.QueryAsync(new UserByUserNameShape { UserName = "cold_b" });
+            var result = await sourceGenSession.QueryAsync(new UserByUserNameShape { UserName = "cold_b" }, TestContext.Current.CancellationToken);
             sw.Stop();
             sourceGenColdMs = sw.ElapsedMilliseconds;
             result.ShouldNotBeNull();
@@ -125,17 +125,17 @@ public class PerfGate: OneOffConfigurationsContext
         try
         {
             using var codegenStore = SeparateStore();
-            await codegenStore.Advanced.Clean.CompletelyRemoveAllAsync();
-            await codegenStore.BulkInsertDocumentsAsync(seed);
+            await codegenStore.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+            await codegenStore.BulkInsertDocumentsAsync(seed, cancellation: TestContext.Current.CancellationToken);
 
             await using var session = codegenStore.QuerySession();
             // Prime — codegen emits its Roslyn assembly on first call.
-            _ = await session.QueryAsync(new UserByUserNameShape { UserName = "hot_a" });
+            _ = await session.QueryAsync(new UserByUserNameShape { UserName = "hot_a" }, TestContext.Current.CancellationToken);
 
             var sw = Stopwatch.StartNew();
             for (var i = 0; i < InvocationCount; i++)
             {
-                _ = await session.QueryAsync(new UserByUserNameShape { UserName = "hot_b" });
+                _ = await session.QueryAsync(new UserByUserNameShape { UserName = "hot_b" }, TestContext.Current.CancellationToken);
             }
             sw.Stop();
             codegenSteadyMs = sw.ElapsedMilliseconds;
@@ -148,17 +148,17 @@ public class PerfGate: OneOffConfigurationsContext
         long sourceGenSteadyMs;
         {
             using var sourceGenStore = SeparateStore();
-            await sourceGenStore.Advanced.Clean.CompletelyRemoveAllAsync();
-            await sourceGenStore.BulkInsertDocumentsAsync(seed);
+            await sourceGenStore.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+            await sourceGenStore.BulkInsertDocumentsAsync(seed, cancellation: TestContext.Current.CancellationToken);
 
             await using var session = sourceGenStore.QuerySession();
             // Prime — source-gen registers the per-store source on first call.
-            _ = await session.QueryAsync(new UserByUserNameShape { UserName = "hot_a" });
+            _ = await session.QueryAsync(new UserByUserNameShape { UserName = "hot_a" }, TestContext.Current.CancellationToken);
 
             var sw = Stopwatch.StartNew();
             for (var i = 0; i < InvocationCount; i++)
             {
-                _ = await session.QueryAsync(new UserByUserNameShape { UserName = "hot_b" });
+                _ = await session.QueryAsync(new UserByUserNameShape { UserName = "hot_b" }, TestContext.Current.CancellationToken);
             }
             sw.Stop();
             sourceGenSteadyMs = sw.ElapsedMilliseconds;

--- a/src/DaemonTests.ManualOnly/Coordination/HotCold_leadership_election.cs
+++ b/src/DaemonTests.ManualOnly/Coordination/HotCold_leadership_election.cs
@@ -123,12 +123,12 @@ public class HotCold_leadership_election: DaemonContext
         await assertIsRunning(host1, 5.Seconds());
 
         var host2 = await StartAdditionalDaemonInHotColdMode();
-        await Task.Delay(500.Milliseconds());
+        await Task.Delay(500.Milliseconds(), TestContext.Current.CancellationToken);
 
         host1.Daemon().IsRunning.ShouldBeTrue();
         host2.Daemon().IsRunning.ShouldBeFalse();
 
-        await host1.StopAsync();
+        await host1.StopAsync(TestContext.Current.CancellationToken);
 
         await assertIsRunning(host2, 5.Seconds());
     }
@@ -147,7 +147,7 @@ public class HotCold_leadership_election: DaemonContext
         others[2] = await StartAdditionalDaemonInHotColdMode();
         others[3] = await StartAdditionalDaemonInHotColdMode();
 
-        await host.StopAsync();
+        await host.StopAsync(TestContext.Current.CancellationToken);
 
         var active = await findRunningDaemon(others);
 

--- a/src/DaemonTests.ManualOnly/Coordination/blue_green_projection_deployments.cs
+++ b/src/DaemonTests.ManualOnly/Coordination/blue_green_projection_deployments.cs
@@ -88,11 +88,11 @@ public class blue_green_projection_deployments
                 new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent(),
                 new EventSourcingTests.Aggregation.CEvent(), new EventSourcingTests.Aggregation.CEvent(),
                 new EventSourcingTests.Aggregation.DEvent());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             await blueDaemon.WaitForNonStaleData(5.Seconds());
 
-            (await session.LoadAsync<EventSourcingTests.Aggregation.MyAggregate>(streamId)).ShouldBeEquivalentTo(
+            (await session.LoadAsync<EventSourcingTests.Aggregation.MyAggregate>(streamId, TestContext.Current.CancellationToken)).ShouldBeEquivalentTo(
                 new EventSourcingTests.Aggregation.MyAggregate
                 {
                     ACount = 2,
@@ -107,7 +107,7 @@ public class blue_green_projection_deployments
         await greenDaemon.WaitForNonStaleData(5.Seconds());
         using (var session = greenStore.LightweightSession())
         {
-            (await session.LoadAsync<EventSourcingTests.Aggregation.MyAggregate>(streamId)).ShouldBeEquivalentTo(
+            (await session.LoadAsync<EventSourcingTests.Aggregation.MyAggregate>(streamId, TestContext.Current.CancellationToken)).ShouldBeEquivalentTo(
                 new EventSourcingTests.Aggregation.MyAggregate
                 {
                     // The "green" version doubles the counts as a cheap way
@@ -134,7 +134,7 @@ public class blue_green_projection_deployments
                     opts.Projections.Add<BlueProjection>(ProjectionLifecycle.Async);
                     opts.DatabaseSchemaName = "bluegreen";
                 }).AddAsyncDaemon(DaemonMode.HotCold);
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         var blueStore = blueHost.Services.GetRequiredService<IDocumentStore>();
 
@@ -147,7 +147,7 @@ public class blue_green_projection_deployments
                     opts.Projections.Add<GreenProjection>(ProjectionLifecycle.Async);
                     opts.DatabaseSchemaName = "bluegreen";
                 }).AddAsyncDaemon(DaemonMode.HotCold);
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         var greenStore = greenHost.Services.GetRequiredService<IDocumentStore>();
 
@@ -163,11 +163,11 @@ public class blue_green_projection_deployments
                 new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent(),
                 new EventSourcingTests.Aggregation.CEvent(), new EventSourcingTests.Aggregation.CEvent(),
                 new EventSourcingTests.Aggregation.DEvent());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             await blueDaemon.WaitForNonStaleData(5.Seconds());
 
-            (await session.LoadAsync<EventSourcingTests.Aggregation.MyAggregate>(streamId)).ShouldBeEquivalentTo(
+            (await session.LoadAsync<EventSourcingTests.Aggregation.MyAggregate>(streamId, TestContext.Current.CancellationToken)).ShouldBeEquivalentTo(
                 new EventSourcingTests.Aggregation.MyAggregate
                 {
                     ACount = 2,
@@ -182,7 +182,7 @@ public class blue_green_projection_deployments
         await greenDaemon.WaitForNonStaleData(5.Seconds());
         using (var session = greenStore.LightweightSession())
         {
-            (await session.LoadAsync<EventSourcingTests.Aggregation.MyAggregate>(streamId)).ShouldBeEquivalentTo(
+            (await session.LoadAsync<EventSourcingTests.Aggregation.MyAggregate>(streamId, TestContext.Current.CancellationToken)).ShouldBeEquivalentTo(
                 new EventSourcingTests.Aggregation.MyAggregate
                 {
                     // The "green" version doubles the counts as a cheap way

--- a/src/DaemonTests.ManualOnly/DaemonTests.ManualOnly.csproj
+++ b/src/DaemonTests.ManualOnly/DaemonTests.ManualOnly.csproj
@@ -1,6 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <!-- Swept for xUnit1051 (#5067): every call taking a CancellationToken is handed
+             TestContext.Current.CancellationToken, so a hung test is cancelled and reported
+             instead of running until CI's own timeout. Keeping the rule ON guards the sweep.
+             Must be set before Tests.props is imported. -->
+        <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/DaemonTests.ManualOnly/HealthChecks/AsyncDaemonHealthCheckExtensionsTests.cs
+++ b/src/DaemonTests.ManualOnly/HealthChecks/AsyncDaemonHealthCheckExtensionsTests.cs
@@ -83,7 +83,7 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
         });
         var healthCheck = new AsyncDaemonHealthCheck(theStore, new(100), _timeProvider, _stateTracker);
 
-        var result = await healthCheck.CheckHealthAsync(new());
+        var result = await healthCheck.CheckHealthAsync(new(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
@@ -98,11 +98,11 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
         var agent = await StartDaemon();
         using var session = theStore.LightweightSession();
         session.Events.Append(Guid.NewGuid(), new FakeIrrellevantEvent());
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         await agent.Tracker.WaitForHighWaterMark(1);
         var healthCheck = new AsyncDaemonHealthCheck(theStore, new(100), _timeProvider, _stateTracker);
 
-        var result = await healthCheck.CheckHealthAsync(new());
+        var result = await healthCheck.CheckHealthAsync(new(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
@@ -120,12 +120,12 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
         var eventCount = 100;
         for (var i = 0; i < eventCount; i++)
             session.Events.Append(stream, new FakeEvent());
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         await agent.Tracker.WaitForHighWaterMark(eventCount);
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream2:All", eventCount), 15.Seconds());
         var healthCheck = new AsyncDaemonHealthCheck(theStore, new(0), _timeProvider, _stateTracker);
 
-        var result = await healthCheck.CheckHealthAsync(new());
+        var result = await healthCheck.CheckHealthAsync(new(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Unhealthy);
     }
@@ -150,13 +150,13 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
             session.Events.Append(stream1, new FakeEvent());
             session.Events.Append(stream2, new FakeEvent());
         }
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream3:All", eventCount), 15.Seconds());
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream4:All", eventCount), 15.Seconds());
         await agent.Tracker.WaitForHighWaterMark(eventCount);
         var healthCheck = new AsyncDaemonHealthCheck(theStore, new(1), _timeProvider, _stateTracker);
 
-        var result = await healthCheck.CheckHealthAsync(new());
+        var result = await healthCheck.CheckHealthAsync(new(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
@@ -179,18 +179,18 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
             session.Events.Append(stream1, new FakeEvent());
             session.Events.Append(stream2, new FakeEvent());
         }
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream5:All", eventCount), 15.Seconds());
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream6:All", eventCount), 15.Seconds());
         await agent.Tracker.WaitForHighWaterMark(eventCount);
 
         using var treeCommand = new NpgsqlCommand($"update {theStore.Events.DatabaseSchemaName}.mt_event_progression set last_seq_id = 0 where name = 'FakeStream6:All'");
 
-        await theSession.ExecuteAsync(treeCommand);
+        await theSession.ExecuteAsync(treeCommand, TestContext.Current.CancellationToken);
 
         var healthCheck = new AsyncDaemonHealthCheck(theStore, new(1), _timeProvider, _stateTracker);
 
-        var result = await healthCheck.CheckHealthAsync(new());
+        var result = await healthCheck.CheckHealthAsync(new(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Unhealthy);
     }
@@ -213,18 +213,18 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
             session.Events.Append(stream1, new FakeEvent());
             session.Events.Append(stream2, new FakeEvent());
         }
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream5:All", eventCount), 15.Seconds());
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream6:All", eventCount), 15.Seconds());
         await agent.Tracker.WaitForHighWaterMark(eventCount);
 
         using var treeCommand = new NpgsqlCommand($"update {theStore.Events.DatabaseSchemaName}.mt_event_progression set last_seq_id = 0 where name = 'FakeStream6:All'");
 
-        await theSession.ExecuteAsync(treeCommand);
+        await theSession.ExecuteAsync(treeCommand, TestContext.Current.CancellationToken);
 
         var healthCheck = new AsyncDaemonHealthCheck(theStore, new(1, TimeSpan.FromSeconds(30)), _timeProvider, _stateTracker);
 
-        var result = await healthCheck.CheckHealthAsync(new());
+        var result = await healthCheck.CheckHealthAsync(new(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
@@ -248,23 +248,23 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
             session.Events.Append(stream1, new FakeEvent());
             session.Events.Append(stream2, new FakeEvent());
         }
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream5:All", eventCount), 15.Seconds());
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream6:All", eventCount), 15.Seconds());
         await agent.Tracker.WaitForHighWaterMark(eventCount);
 
         using var treeCommand = new NpgsqlCommand($"update {theStore.Events.DatabaseSchemaName}.mt_event_progression set last_seq_id = 0 where name = 'FakeStream6:All'");
 
-        await theSession.ExecuteAsync(treeCommand);
+        await theSession.ExecuteAsync(treeCommand, TestContext.Current.CancellationToken);
 
         var maxSameLagTime = TimeSpan.FromSeconds(30);
         var healthCheck = new AsyncDaemonHealthCheck(theStore, new(1, maxSameLagTime), _timeProvider, _stateTracker);
-        await healthCheck.CheckHealthAsync(new());
+        await healthCheck.CheckHealthAsync(new(), TestContext.Current.CancellationToken);
 
         // When
         var afterMaxSameLagTime = _now.Add(maxSameLagTime.Add(TimeSpan.FromMilliseconds(1)));
         _timeProvider.GetUtcNow().Returns(afterMaxSameLagTime);
-        var result = await healthCheck.CheckHealthAsync(new());
+        var result = await healthCheck.CheckHealthAsync(new(), TestContext.Current.CancellationToken);
 
         // Then
         result.Status.ShouldBe(HealthStatus.Unhealthy);
@@ -289,25 +289,25 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
             session.Events.Append(stream1, new FakeEvent());
             session.Events.Append(stream2, new FakeEvent());
         }
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream5:All", eventCount), 15.Seconds());
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream6:All", eventCount), 15.Seconds());
         await agent.Tracker.WaitForHighWaterMark(eventCount);
 
         await using var treeCommandSeqId0 = new NpgsqlCommand($"update {theStore.Events.DatabaseSchemaName}.mt_event_progression set last_seq_id = 0 where name = 'FakeStream6:All'");
-        await theSession.ExecuteAsync(treeCommandSeqId0);
+        await theSession.ExecuteAsync(treeCommandSeqId0, TestContext.Current.CancellationToken);
 
         var maxSameLagTime = TimeSpan.FromSeconds(30);
         var healthCheck = new AsyncDaemonHealthCheck(theStore, new(1, maxSameLagTime), _timeProvider, _stateTracker);
-        await healthCheck.CheckHealthAsync(new());
+        await healthCheck.CheckHealthAsync(new(), TestContext.Current.CancellationToken);
 
         // When
         await using var treeCommandSeqId1 = new NpgsqlCommand($"update {theStore.Events.DatabaseSchemaName}.mt_event_progression set last_seq_id = 1 where name = 'FakeStream6:All'");
-        await theSession.ExecuteAsync(treeCommandSeqId1);
+        await theSession.ExecuteAsync(treeCommandSeqId1, TestContext.Current.CancellationToken);
 
         var afterMaxSameLagTime = _now.Add(maxSameLagTime.Add(TimeSpan.FromMilliseconds(1)));
         _timeProvider.GetUtcNow().Returns(afterMaxSameLagTime);
-        var result = await healthCheck.CheckHealthAsync(new());
+        var result = await healthCheck.CheckHealthAsync(new(), TestContext.Current.CancellationToken);
 
         // Then
         result.Status.ShouldBe(HealthStatus.Healthy);

--- a/src/DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests.cs
+++ b/src/DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests.cs
@@ -130,7 +130,7 @@ public class HighWaterHealthCheckTests: DaemonContext
         await appendEventsAsync(20);
         await seedHighWaterMarkAsync(1);
 
-        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext());
+        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
@@ -146,7 +146,7 @@ public class HighWaterHealthCheckTests: DaemonContext
         await appendEventsAsync(20);
         await seedHighWaterMarkAsync(1);
 
-        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext());
+        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
@@ -162,10 +162,10 @@ public class HighWaterHealthCheckTests: DaemonContext
             x.Projections.AsyncMode = DaemonMode.Solo;
         });
         await appendEventsAsync(20);
-        var highest = await theStore.Advanced.FetchEventStoreStatistics();
+        var highest = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
         await seedHighWaterMarkAsync(highest.EventSequenceNumber);
 
-        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext());
+        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
@@ -182,7 +182,7 @@ public class HighWaterHealthCheckTests: DaemonContext
         await seedHighWaterMarkAsync(1);
 
         // first observation of the gap only starts the clock; not yet stale
-        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext());
+        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
@@ -201,12 +201,12 @@ public class HighWaterHealthCheckTests: DaemonContext
         var check = buildCheck(30.Seconds());
 
         // first check records the stalled mark at _now
-        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Healthy);
 
         // advance the clock past the threshold with the mark still stuck
         _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
 
-        var result = await check.CheckHealthAsync(new HealthCheckContext());
+        var result = await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Unhealthy);
     }
@@ -225,14 +225,14 @@ public class HighWaterHealthCheckTests: DaemonContext
         var check = buildCheck(30.Seconds());
 
         // first check: gap observed, clock starts
-        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Healthy);
 
         // the mark advances (agent alive) and time moves forward past the threshold
         await seedHighWaterMarkAsync(10);
         _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
 
         // the advance resets the clock, so it must not be reported stale
-        var result = await check.CheckHealthAsync(new HealthCheckContext());
+        var result = await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
@@ -254,7 +254,7 @@ public class HighWaterHealthCheckTests: DaemonContext
         await appendEventsAsync(20);
         await seedHighWaterHeartbeatAsync(1, _now.AddSeconds(-5)); // mark stuck at 1, but heartbeat is 5s old
 
-        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext());
+        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
@@ -271,10 +271,10 @@ public class HighWaterHealthCheckTests: DaemonContext
             x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
-        var stats = await theStore.Advanced.FetchEventStoreStatistics();
+        var stats = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
         await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90)); // caught up, heartbeat 90s old
 
-        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext());
+        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Unhealthy);
     }
@@ -291,7 +291,7 @@ public class HighWaterHealthCheckTests: DaemonContext
             x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
-        var stats = await theStore.Advanced.FetchEventStoreStatistics();
+        var stats = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
         await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90));
 
         var daemon = Substitute.For<IProjectionDaemon>();
@@ -300,11 +300,11 @@ public class HighWaterHealthCheckTests: DaemonContext
         var check = buildCheck(30.Seconds(), autoRestart: true, coordinator: coordinator);
 
         // First stale cycle: restart the loop, still report Unhealthy so an alert fires.
-        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Unhealthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Unhealthy);
         await daemon.Received(1).RestartHighWaterAgentAsync(Arg.Any<CancellationToken>());
 
         // Second cycle inside the same staleness window: still Unhealthy, but NOT restarted again (capped).
-        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Unhealthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Unhealthy);
         await daemon.Received(1).RestartHighWaterAgentAsync(Arg.Any<CancellationToken>());
     }
 
@@ -318,13 +318,13 @@ public class HighWaterHealthCheckTests: DaemonContext
             x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
-        var stats = await theStore.Advanced.FetchEventStoreStatistics();
+        var stats = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
         await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90));
 
         var daemon = Substitute.For<IProjectionDaemon>();
         var coordinator = new FakeCoordinator(daemon);
 
-        var result = await buildCheck(30.Seconds(), coordinator: coordinator).CheckHealthAsync(new HealthCheckContext());
+        var result = await buildCheck(30.Seconds(), coordinator: coordinator).CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Unhealthy);
         await daemon.DidNotReceive().RestartHighWaterAgentAsync(Arg.Any<CancellationToken>());
@@ -347,11 +347,11 @@ public class HighWaterHealthCheckTests: DaemonContext
 
         var check = buildCheck(30.Seconds(), databaseFilter: _ => false);
 
-        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Healthy);
 
         // still Healthy well past the staleness threshold, because the database is never probed
         _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
-        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Healthy);
     }
 
     [Fact]
@@ -368,10 +368,10 @@ public class HighWaterHealthCheckTests: DaemonContext
 
         var check = buildCheck(30.Seconds(), databaseFilter: _ => true);
 
-        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Healthy);
 
         _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
-        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Unhealthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Unhealthy);
     }
 
     // ---- ExternallyManaged gate (marten#4991) --------------------------------------------
@@ -388,10 +388,10 @@ public class HighWaterHealthCheckTests: DaemonContext
             x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
-        var stats = await theStore.Advanced.FetchEventStoreStatistics();
+        var stats = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
         await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90));
 
-        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext());
+        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
@@ -407,11 +407,11 @@ public class HighWaterHealthCheckTests: DaemonContext
             x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
-        var stats = await theStore.Advanced.FetchEventStoreStatistics();
+        var stats = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
         await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90));
 
         var result = await buildCheck(30.Seconds(), includeExternallyManaged: true)
-            .CheckHealthAsync(new HealthCheckContext());
+            .CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Unhealthy);
     }
@@ -431,10 +431,10 @@ public class HighWaterHealthCheckTests: DaemonContext
 
         var check = buildCheck(30.Seconds(), includeExternallyManaged: true);
 
-        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Healthy);
 
         _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
-        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Healthy);
     }
 
     // ---- per-tenant high water (marten#4991) ---------------------------------------------
@@ -454,7 +454,7 @@ public class HighWaterHealthCheckTests: DaemonContext
         await appendEventsAsync(20);
         await seedProgressionRowAsync("HighWaterMark:acme", 5, _now.AddSeconds(-90));
 
-        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext());
+        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Unhealthy);
     }
@@ -471,7 +471,7 @@ public class HighWaterHealthCheckTests: DaemonContext
         await appendEventsAsync(20);
         await seedProgressionRowAsync("HighWaterMark:acme", 5, _now.AddSeconds(-5));
 
-        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext());
+        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
@@ -492,10 +492,10 @@ public class HighWaterHealthCheckTests: DaemonContext
 
         var check = buildCheck(30.Seconds());
 
-        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Healthy);
 
         _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
-        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Healthy);
     }
 
     // Minimal IProjectionCoordinator that hands back a single daemon — avoids mocking a ValueTask-returning

--- a/src/Marten.EntityFrameworkCore.Tests/EfCoreEventProjectionTests.cs
+++ b/src/Marten.EntityFrameworkCore.Tests/EfCoreEventProjectionTests.cs
@@ -84,25 +84,25 @@ public class EfCoreEventProjectionTests: IAsyncLifetime
         await using var session = _store.LightweightSession();
         session.Events.StartStream(orderId,
             new OrderPlaced(orderId, "Alice", 99.99m, 3));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Verify Marten document
-        var order = await session.LoadAsync<Order>(orderId);
+        var order = await session.LoadAsync<Order>(orderId, TestContext.Current.CancellationToken);
         order.ShouldNotBeNull();
         order.CustomerName.ShouldBe("Alice");
         order.TotalAmount.ShouldBe(99.99m);
 
         // Verify EF Core entity
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
         await using var setSchema = conn.CreateCommand();
         setSchema.CommandText = "SET search_path TO efcore_tests";
-        await setSchema.ExecuteNonQueryAsync();
+        await setSchema.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT customer_name, status FROM ef_order_summaries WHERE id = @id";
         cmd.Parameters.AddWithValue("id", orderId);
-        await using var reader = await cmd.ExecuteReaderAsync();
-        (await reader.ReadAsync()).ShouldBeTrue();
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader.GetString(0).ShouldBe("Alice");
         reader.GetString(1).ShouldBe("Placed");
     }
@@ -115,18 +115,18 @@ public class EfCoreEventProjectionTests: IAsyncLifetime
         session.Events.StartStream(orderId,
             new OrderPlaced(orderId, "Bob", 50.00m, 1),
             new OrderShipped(orderId));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Verify EF Core entity was updated
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
         await using var setSchema = conn.CreateCommand();
         setSchema.CommandText = "SET search_path TO efcore_tests";
-        await setSchema.ExecuteNonQueryAsync();
+        await setSchema.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT status FROM ef_order_summaries WHERE id = @id";
         cmd.Parameters.AddWithValue("id", orderId);
-        var status = (string?)await cmd.ExecuteScalarAsync();
+        var status = (string?)await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken);
         status.ShouldBe("Shipped");
     }
 }

--- a/src/Marten.EntityFrameworkCore.Tests/EfCoreMultiStreamProjectionTests.cs
+++ b/src/Marten.EntityFrameworkCore.Tests/EfCoreMultiStreamProjectionTests.cs
@@ -106,7 +106,7 @@ public abstract class EfCoreMultiStreamProjectionTestsBase: IAsyncLifetime
             new CustomerOrderPlaced(Guid.NewGuid(), "Eve", 100.00m));
         session.Events.StartStream(stream2,
             new CustomerOrderPlaced(Guid.NewGuid(), "Eve", 50.00m));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await WaitForProjectionAsync();
 
@@ -115,8 +115,8 @@ public abstract class EfCoreMultiStreamProjectionTestsBase: IAsyncLifetime
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT total_orders, total_spent FROM ef_customer_order_histories WHERE id = @id";
         cmd.Parameters.AddWithValue("id", "Eve");
-        await using var reader = await cmd.ExecuteReaderAsync();
-        (await reader.ReadAsync()).ShouldBeTrue();
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader.GetInt32(0).ShouldBe(2);
         reader.GetDecimal(1).ShouldBe(150.00m);
     }
@@ -130,7 +130,7 @@ public abstract class EfCoreMultiStreamProjectionTestsBase: IAsyncLifetime
             new CustomerOrderPlaced(Guid.NewGuid(), "Alice", 80.00m));
         session.Events.StartStream(Guid.NewGuid().ToString(),
             new CustomerOrderPlaced(Guid.NewGuid(), "Bob", 120.00m));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await WaitForProjectionAsync();
 
@@ -140,8 +140,8 @@ public abstract class EfCoreMultiStreamProjectionTestsBase: IAsyncLifetime
         await using var cmd1 = conn.CreateCommand();
         cmd1.CommandText = "SELECT total_orders, total_spent FROM ef_customer_order_histories WHERE id = @id";
         cmd1.Parameters.AddWithValue("id", "Alice");
-        await using var reader1 = await cmd1.ExecuteReaderAsync();
-        (await reader1.ReadAsync()).ShouldBeTrue();
+        await using var reader1 = await cmd1.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader1.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader1.GetInt32(0).ShouldBe(1);
         reader1.GetDecimal(1).ShouldBe(80.00m);
         await reader1.CloseAsync();
@@ -150,8 +150,8 @@ public abstract class EfCoreMultiStreamProjectionTestsBase: IAsyncLifetime
         await using var cmd2 = conn.CreateCommand();
         cmd2.CommandText = "SELECT total_orders, total_spent FROM ef_customer_order_histories WHERE id = @id";
         cmd2.Parameters.AddWithValue("id", "Bob");
-        await using var reader2 = await cmd2.ExecuteReaderAsync();
-        (await reader2.ReadAsync()).ShouldBeTrue();
+        await using var reader2 = await cmd2.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader2.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader2.GetInt32(0).ShouldBe(1);
         reader2.GetDecimal(1).ShouldBe(120.00m);
     }
@@ -164,14 +164,14 @@ public abstract class EfCoreMultiStreamProjectionTestsBase: IAsyncLifetime
         var stream1 = Guid.NewGuid().ToString();
         session.Events.StartStream(stream1,
             new CustomerOrderPlaced(Guid.NewGuid(), "Charlie", 60.00m));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await WaitForProjectionAsync();
 
         var stream2 = Guid.NewGuid().ToString();
         session.Events.StartStream(stream2,
             new CustomerOrderPlaced(Guid.NewGuid(), "Charlie", 40.00m));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await WaitForProjectionAsync();
 
@@ -179,8 +179,8 @@ public abstract class EfCoreMultiStreamProjectionTestsBase: IAsyncLifetime
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT total_orders, total_spent FROM ef_customer_order_histories WHERE id = @id";
         cmd.Parameters.AddWithValue("id", "Charlie");
-        await using var reader = await cmd.ExecuteReaderAsync();
-        (await reader.ReadAsync()).ShouldBeTrue();
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader.GetInt32(0).ShouldBe(2);
         reader.GetDecimal(1).ShouldBe(100.00m);
     }
@@ -234,10 +234,10 @@ public class EfCoreMultiStreamProjectionLiveTests: IAsyncLifetime
         var stream1 = Guid.NewGuid().ToString();
         session.Events.StartStream(stream1,
             new CustomerOrderPlaced(Guid.NewGuid(), "Dana", 70.00m));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Live multi-stream projections are not persisted
-        var history = await session.LoadAsync<CustomerOrderHistory>("Dana");
+        var history = await session.LoadAsync<CustomerOrderHistory>("Dana", TestContext.Current.CancellationToken);
         history.ShouldBeNull();
     }
 
@@ -250,10 +250,10 @@ public class EfCoreMultiStreamProjectionLiveTests: IAsyncLifetime
         var streamKey = Guid.NewGuid().ToString();
         session.Events.StartStream(streamKey,
             new CustomerOrderPlaced(Guid.NewGuid(), "Eve", 100.00m));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Events are stored successfully even with a Live multi-stream projection registered
-        var events = await session.Events.FetchStreamAsync(streamKey);
+        var events = await session.Events.FetchStreamAsync(streamKey, token: TestContext.Current.CancellationToken);
         events.ShouldNotBeEmpty();
     }
 }

--- a/src/Marten.EntityFrameworkCore.Tests/EfCoreSchemaTests.cs
+++ b/src/Marten.EntityFrameworkCore.Tests/EfCoreSchemaTests.cs
@@ -197,11 +197,11 @@ public class EfCoreSchemaTests
 
         // Clean up any previous test schema
         await using var cleanupConn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await cleanupConn.OpenAsync();
+        await cleanupConn.OpenAsync(TestContext.Current.CancellationToken);
         await using (var cmd = cleanupConn.CreateCommand())
         {
             cmd.CommandText = $"DROP SCHEMA IF EXISTS {testSchema} CASCADE";
-            await cmd.ExecuteNonQueryAsync();
+            await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
         }
         await cleanupConn.CloseAsync();
 
@@ -224,7 +224,7 @@ public class EfCoreSchemaTests
 
             // Verify tables were created by querying the information schema
             await using var verifyConn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-            await verifyConn.OpenAsync();
+            await verifyConn.OpenAsync(TestContext.Current.CancellationToken);
             await using var verifyCmd = verifyConn.CreateCommand();
             verifyCmd.CommandText = @"
                 SELECT table_name FROM information_schema.tables
@@ -233,8 +233,8 @@ public class EfCoreSchemaTests
             verifyCmd.Parameters.AddWithValue("schema", SeparateSchemaDbContext.EfSchema);
 
             var tables = new System.Collections.Generic.List<string>();
-            await using var reader = await verifyCmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            await using var reader = await verifyCmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+            while (await reader.ReadAsync(TestContext.Current.CancellationToken))
             {
                 tables.Add(reader.GetString(0));
             }
@@ -246,12 +246,12 @@ public class EfCoreSchemaTests
         {
             // Clean up
             await using var finalConn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-            await finalConn.OpenAsync();
+            await finalConn.OpenAsync(TestContext.Current.CancellationToken);
             await using var finalCmd = finalConn.CreateCommand();
             finalCmd.CommandText = $"DROP SCHEMA IF EXISTS {testSchema} CASCADE";
-            await finalCmd.ExecuteNonQueryAsync();
+            await finalCmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
             finalCmd.CommandText = $"DROP SCHEMA IF EXISTS {SeparateSchemaDbContext.EfSchema} CASCADE";
-            await finalCmd.ExecuteNonQueryAsync();
+            await finalCmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
         }
     }
 

--- a/src/Marten.EntityFrameworkCore.Tests/EfCoreSingleStreamProjectionTests.cs
+++ b/src/Marten.EntityFrameworkCore.Tests/EfCoreSingleStreamProjectionTests.cs
@@ -106,7 +106,7 @@ public abstract class EfCoreSingleStreamProjectionTestsBase: IAsyncLifetime
         await using var session = Store.LightweightSession();
         session.Events.StartStream(orderId,
             new OrderPlaced(orderId, "Carol", 200.00m, 5));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await WaitForProjectionAsync();
 
@@ -115,8 +115,8 @@ public abstract class EfCoreSingleStreamProjectionTestsBase: IAsyncLifetime
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT customer_name, total_amount, item_count FROM ef_orders WHERE id = @id";
         cmd.Parameters.AddWithValue("id", orderId);
-        await using var reader = await cmd.ExecuteReaderAsync();
-        (await reader.ReadAsync()).ShouldBeTrue();
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader.GetString(0).ShouldBe("Carol");
         reader.GetDecimal(1).ShouldBe(200.00m);
         reader.GetInt32(2).ShouldBe(5);
@@ -130,7 +130,7 @@ public abstract class EfCoreSingleStreamProjectionTestsBase: IAsyncLifetime
         session.Events.StartStream(orderId,
             new OrderPlaced(orderId, "Dave", 75.00m, 2),
             new OrderShipped(orderId));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await WaitForProjectionAsync();
 
@@ -139,8 +139,8 @@ public abstract class EfCoreSingleStreamProjectionTestsBase: IAsyncLifetime
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT customer_name, is_shipped FROM ef_orders WHERE id = @id";
         cmd.Parameters.AddWithValue("id", orderId);
-        await using var reader = await cmd.ExecuteReaderAsync();
-        (await reader.ReadAsync()).ShouldBeTrue();
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader.GetString(0).ShouldBe("Dave");
         reader.GetBoolean(1).ShouldBeTrue();
     }
@@ -153,12 +153,12 @@ public abstract class EfCoreSingleStreamProjectionTestsBase: IAsyncLifetime
         await using var session = Store.LightweightSession();
         session.Events.StartStream(orderId,
             new OrderPlaced(orderId, "Eve", 120.00m, 3));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await WaitForProjectionAsync();
 
         session.Events.Append(orderId, new OrderShipped(orderId));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await WaitForProjectionAsync();
 
@@ -167,8 +167,8 @@ public abstract class EfCoreSingleStreamProjectionTestsBase: IAsyncLifetime
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT customer_name, is_shipped FROM ef_orders WHERE id = @id";
         cmd.Parameters.AddWithValue("id", orderId);
-        await using var reader = await cmd.ExecuteReaderAsync();
-        (await reader.ReadAsync()).ShouldBeTrue();
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader.GetString(0).ShouldBe("Eve");
         reader.GetBoolean(1).ShouldBeTrue();
     }
@@ -180,7 +180,7 @@ public abstract class EfCoreSingleStreamProjectionTestsBase: IAsyncLifetime
         await using var session = Store.LightweightSession();
         session.Events.StartStream(orderId,
             new OrderPlaced(orderId, "Frank", 300.00m, 10));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await WaitForProjectionAsync();
 
@@ -189,8 +189,8 @@ public abstract class EfCoreSingleStreamProjectionTestsBase: IAsyncLifetime
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT customer_name, status, total_amount FROM ef_order_summaries WHERE id = @id";
         cmd.Parameters.AddWithValue("id", orderId);
-        await using var reader = await cmd.ExecuteReaderAsync();
-        (await reader.ReadAsync()).ShouldBeTrue();
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader.GetString(0).ShouldBe("Frank");
         reader.GetString(1).ShouldBe("Placed");
         reader.GetDecimal(2).ShouldBe(300.00m);
@@ -244,9 +244,9 @@ public class EfCoreSingleStreamProjectionLiveTests: IAsyncLifetime
         session.Events.StartStream(orderId,
             new OrderPlaced(orderId, "Grace", 50.00m, 1),
             new OrderShipped(orderId));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var order = await session.Events.AggregateStreamAsync<Order>(orderId);
+        var order = await session.Events.AggregateStreamAsync<Order>(orderId, token: TestContext.Current.CancellationToken);
         order.ShouldNotBeNull();
         order.CustomerName.ShouldBe("Grace");
         order.IsShipped.ShouldBeTrue();
@@ -256,7 +256,7 @@ public class EfCoreSingleStreamProjectionLiveTests: IAsyncLifetime
     public async Task live_aggregation_returns_null_for_unknown_stream()
     {
         await using var session = _store.LightweightSession();
-        var order = await session.Events.AggregateStreamAsync<Order>(Guid.NewGuid());
+        var order = await session.Events.AggregateStreamAsync<Order>(Guid.NewGuid(), token: TestContext.Current.CancellationToken);
         order.ShouldBeNull();
     }
 
@@ -267,14 +267,14 @@ public class EfCoreSingleStreamProjectionLiveTests: IAsyncLifetime
         await using var session = _store.LightweightSession();
         session.Events.StartStream(orderId,
             new OrderPlaced(orderId, "Heidi", 90.00m, 4));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Live aggregation rebuilds on the fly
-        var order = await session.Events.AggregateStreamAsync<Order>(orderId);
+        var order = await session.Events.AggregateStreamAsync<Order>(orderId, token: TestContext.Current.CancellationToken);
         order.ShouldNotBeNull();
 
         // But the aggregate is NOT stored in the document table
-        var loaded = await session.LoadAsync<Order>(orderId);
+        var loaded = await session.LoadAsync<Order>(orderId, TestContext.Current.CancellationToken);
         loaded.ShouldBeNull();
     }
 }

--- a/src/Marten.EntityFrameworkCore.Tests/EfCoreTenantedSingleStreamProjectionTests.cs
+++ b/src/Marten.EntityFrameworkCore.Tests/EfCoreTenantedSingleStreamProjectionTests.cs
@@ -57,7 +57,7 @@ public abstract class EfCoreTenantedSingleStreamProjectionTestsBase: IAsyncLifet
         await using var session = Store.LightweightSession("alpha");
         session.Events.StartStream(orderId,
             new OrderPlaced(orderId, "Alice", 100.00m, 3));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await WaitForProjectionAsync();
 
@@ -65,8 +65,8 @@ public abstract class EfCoreTenantedSingleStreamProjectionTestsBase: IAsyncLifet
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT customer_name, tenant_id FROM ef_tenanted_orders WHERE id = @id";
         cmd.Parameters.AddWithValue("id", orderId);
-        await using var reader = await cmd.ExecuteReaderAsync();
-        (await reader.ReadAsync()).ShouldBeTrue();
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader.GetString(0).ShouldBe("Alice");
         reader.GetString(1).ShouldBe("alpha");
     }
@@ -81,14 +81,14 @@ public abstract class EfCoreTenantedSingleStreamProjectionTestsBase: IAsyncLifet
         {
             alphaSession.Events.StartStream(alphaOrderId,
                 new OrderPlaced(alphaOrderId, "AlphaCustomer", 50.00m, 1));
-            await alphaSession.SaveChangesAsync();
+            await alphaSession.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var betaSession = Store.LightweightSession("beta"))
         {
             betaSession.Events.StartStream(betaOrderId,
                 new OrderPlaced(betaOrderId, "BetaCustomer", 75.00m, 2));
-            await betaSession.SaveChangesAsync();
+            await betaSession.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await WaitForProjectionAsync();
@@ -99,8 +99,8 @@ public abstract class EfCoreTenantedSingleStreamProjectionTestsBase: IAsyncLifet
         await using var cmd1 = conn.CreateCommand();
         cmd1.CommandText = "SELECT customer_name, tenant_id FROM ef_tenanted_orders WHERE id = @id";
         cmd1.Parameters.AddWithValue("id", alphaOrderId);
-        await using var reader1 = await cmd1.ExecuteReaderAsync();
-        (await reader1.ReadAsync()).ShouldBeTrue();
+        await using var reader1 = await cmd1.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader1.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader1.GetString(0).ShouldBe("AlphaCustomer");
         reader1.GetString(1).ShouldBe("alpha");
         await reader1.CloseAsync();
@@ -109,8 +109,8 @@ public abstract class EfCoreTenantedSingleStreamProjectionTestsBase: IAsyncLifet
         await using var cmd2 = conn.CreateCommand();
         cmd2.CommandText = "SELECT customer_name, tenant_id FROM ef_tenanted_orders WHERE id = @id";
         cmd2.Parameters.AddWithValue("id", betaOrderId);
-        await using var reader2 = await cmd2.ExecuteReaderAsync();
-        (await reader2.ReadAsync()).ShouldBeTrue();
+        await using var reader2 = await cmd2.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader2.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader2.GetString(0).ShouldBe("BetaCustomer");
         reader2.GetString(1).ShouldBe("beta");
     }
@@ -123,12 +123,12 @@ public abstract class EfCoreTenantedSingleStreamProjectionTestsBase: IAsyncLifet
         await using var session = Store.LightweightSession("alpha");
         session.Events.StartStream(orderId,
             new OrderPlaced(orderId, "Carol", 200.00m, 5));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await WaitForProjectionAsync();
 
         session.Events.Append(orderId, new OrderShipped(orderId));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await WaitForProjectionAsync();
 
@@ -136,8 +136,8 @@ public abstract class EfCoreTenantedSingleStreamProjectionTestsBase: IAsyncLifet
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT customer_name, is_shipped, tenant_id FROM ef_tenanted_orders WHERE id = @id";
         cmd.Parameters.AddWithValue("id", orderId);
-        await using var reader = await cmd.ExecuteReaderAsync();
-        (await reader.ReadAsync()).ShouldBeTrue();
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
         reader.GetString(0).ShouldBe("Carol");
         reader.GetBoolean(1).ShouldBeTrue();
         reader.GetString(2).ShouldBe("alpha");

--- a/src/Marten.EntityFrameworkCore.Tests/EfCoreToJsonTests.cs
+++ b/src/Marten.EntityFrameworkCore.Tests/EfCoreToJsonTests.cs
@@ -163,13 +163,13 @@ public class EfCoreToJsonTests
 
         // Clean up any previous test schema
         await using var cleanupConn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await cleanupConn.OpenAsync();
+        await cleanupConn.OpenAsync(TestContext.Current.CancellationToken);
         await using (var cmd = cleanupConn.CreateCommand())
         {
             cmd.CommandText = $"DROP SCHEMA IF EXISTS {testSchema} CASCADE";
-            await cmd.ExecuteNonQueryAsync();
+            await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
             cmd.CommandText = $"DROP SCHEMA IF EXISTS {ToJsonDbContext.EfSchema} CASCADE";
-            await cmd.ExecuteNonQueryAsync();
+            await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
         }
 
         await cleanupConn.CloseAsync();
@@ -193,7 +193,7 @@ public class EfCoreToJsonTests
 
             // Verify the table was created with JSON columns
             await using var verifyConn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-            await verifyConn.OpenAsync();
+            await verifyConn.OpenAsync(TestContext.Current.CancellationToken);
             await using var verifyCmd = verifyConn.CreateCommand();
             verifyCmd.CommandText = @"
                 SELECT column_name, data_type
@@ -203,8 +203,8 @@ public class EfCoreToJsonTests
             verifyCmd.Parameters.AddWithValue("schema", ToJsonDbContext.EfSchema);
 
             var columnMap = new System.Collections.Generic.Dictionary<string, string>();
-            await using var reader = await verifyCmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            await using var reader = await verifyCmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+            while (await reader.ReadAsync(TestContext.Current.CancellationToken))
             {
                 columnMap[reader.GetString(0)] = reader.GetString(1);
             }
@@ -221,12 +221,12 @@ public class EfCoreToJsonTests
         {
             // Clean up
             await using var finalConn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-            await finalConn.OpenAsync();
+            await finalConn.OpenAsync(TestContext.Current.CancellationToken);
             await using var finalCmd = finalConn.CreateCommand();
             finalCmd.CommandText = $"DROP SCHEMA IF EXISTS {testSchema} CASCADE";
-            await finalCmd.ExecuteNonQueryAsync();
+            await finalCmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
             finalCmd.CommandText = $"DROP SCHEMA IF EXISTS {ToJsonDbContext.EfSchema} CASCADE";
-            await finalCmd.ExecuteNonQueryAsync();
+            await finalCmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
         }
     }
 }

--- a/src/Marten.EntityFrameworkCore.Tests/Marten.EntityFrameworkCore.Tests.csproj
+++ b/src/Marten.EntityFrameworkCore.Tests/Marten.EntityFrameworkCore.Tests.csproj
@@ -1,4 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <!-- Swept for xUnit1051 (#5067): every call taking a CancellationToken is handed
+             TestContext.Current.CancellationToken, so a hung test is cancelled and reported
+             instead of running until CI's own timeout. Keeping the rule ON guards the sweep.
+             Must be set before Tests.props is imported. -->
+        <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
+    </PropertyGroup>
     <PropertyGroup>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>

--- a/src/Marten.MemoryPack.Tests/BinaryEventIntegrationTests.cs
+++ b/src/Marten.MemoryPack.Tests/BinaryEventIntegrationTests.cs
@@ -104,11 +104,11 @@ public class BinaryEventIntegrationTests: IAsyncLifetime
                 new PassengerPickedUp(tripId, "Bob", startedAt.AddMinutes(2)),
                 new PassengerPickedUp(tripId, "Carol", startedAt.AddMinutes(5)),
                 new TripEnded(tripId, startedAt.AddMinutes(30), 42.50m));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _store.QuerySession();
-        var trip = await query.Events.AggregateStreamAsync<Trip>(tripId);
+        var trip = await query.Events.AggregateStreamAsync<Trip>(tripId, token: TestContext.Current.CancellationToken);
 
         trip.ShouldNotBeNull();
         trip.Id.ShouldBe(tripId);
@@ -134,11 +134,11 @@ public class BinaryEventIntegrationTests: IAsyncLifetime
                 new PassengerPickedUp(tripId, "Eli", DateTimeOffset.UtcNow),    // binary
                 new TripCommentAdded(tripId, "passenger on board", DateTimeOffset.UtcNow), // JSON
                 new TripEnded(tripId, DateTimeOffset.UtcNow, 19.00m));          // binary
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _store.QuerySession();
-        var trip = await query.Events.AggregateStreamAsync<Trip>(tripId);
+        var trip = await query.Events.AggregateStreamAsync<Trip>(tripId, token: TestContext.Current.CancellationToken);
 
         trip.ShouldNotBeNull();
         trip.DriverName.ShouldBe("Dana");
@@ -161,11 +161,11 @@ public class BinaryEventIntegrationTests: IAsyncLifetime
             session.Events.StartStream<Trip>(tripId,
                 new TripStarted(tripId, "Frank", DateTimeOffset.UtcNow),
                 new PassengerPickedUp(tripId, "Gina", DateTimeOffset.UtcNow));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _store.QuerySession();
-        var trip = await query.LoadAsync<Trip>(tripId);
+        var trip = await query.LoadAsync<Trip>(tripId, TestContext.Current.CancellationToken);
 
         trip.ShouldNotBeNull();
         trip.DriverName.ShouldBe("Frank");
@@ -182,7 +182,7 @@ public class BinaryEventIntegrationTests: IAsyncLifetime
         {
             session.Events.StartStream<Trip>(tripId,
                 new TripStarted(tripId, "Hana", DateTimeOffset.UtcNow));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = _store.LightweightSession())
@@ -190,11 +190,11 @@ public class BinaryEventIntegrationTests: IAsyncLifetime
             session.Events.Append(tripId,
                 new PassengerPickedUp(tripId, "Ian", DateTimeOffset.UtcNow),
                 new TripEnded(tripId, DateTimeOffset.UtcNow, 12.00m));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _store.QuerySession();
-        var trip = await query.LoadAsync<Trip>(tripId);
+        var trip = await query.LoadAsync<Trip>(tripId, TestContext.Current.CancellationToken);
 
         trip.ShouldNotBeNull();
         trip.DriverName.ShouldBe("Hana");
@@ -218,7 +218,7 @@ public class BinaryEventIntegrationTests: IAsyncLifetime
             session.Events.StartStream<Trip>(tripId,
                 new TripStarted(tripId, "Jordan", DateTimeOffset.UtcNow),
                 new PassengerPickedUp(tripId, "Kim", DateTimeOffset.UtcNow));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Read-modify-write — FetchForWriting hydrates the aggregate
@@ -226,18 +226,18 @@ public class BinaryEventIntegrationTests: IAsyncLifetime
         // append a new binary event on top.
         await using (var session = _store.LightweightSession())
         {
-            var stream = await session.Events.FetchForWriting<Trip>(tripId);
+            var stream = await session.Events.FetchForWriting<Trip>(tripId, TestContext.Current.CancellationToken);
 
             stream.Aggregate.ShouldNotBeNull();
             stream.Aggregate.DriverName.ShouldBe("Jordan");
             stream.Aggregate.Passengers.ShouldBe(new[] { "Kim" });
 
             stream.AppendOne(new TripEnded(tripId, DateTimeOffset.UtcNow, 27.75m));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _store.QuerySession();
-        var trip = await query.Events.AggregateStreamAsync<Trip>(tripId);
+        var trip = await query.Events.AggregateStreamAsync<Trip>(tripId, token: TestContext.Current.CancellationToken);
         trip.ShouldNotBeNull();
         trip.IsCompleted.ShouldBeTrue();
         trip.FareAmount.ShouldBe(27.75m);

--- a/src/Marten.MemoryPack.Tests/Marten.MemoryPack.Tests.csproj
+++ b/src/Marten.MemoryPack.Tests/Marten.MemoryPack.Tests.csproj
@@ -1,4 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <!-- Swept for xUnit1051 (#5067): every call taking a CancellationToken is handed
+             TestContext.Current.CancellationToken, so a hung test is cancelled and reported
+             instead of running until CI's own timeout. Keeping the rule ON guards the sweep.
+             Must be set before Tests.props is imported. -->
+        <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
+    </PropertyGroup>
     <PropertyGroup>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>

--- a/src/Marten.MemoryPack.Tests/MemoryPackEventTests.cs
+++ b/src/Marten.MemoryPack.Tests/MemoryPackEventTests.cs
@@ -55,11 +55,11 @@ public class MemoryPackEventTests: IAsyncLifetime
         await using (var session = _store.LightweightSession())
         {
             session.Events.StartStream(streamId, started);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _store.QuerySession();
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
 
         events.Count.ShouldBe(1);
         var loaded = events[0].Data.ShouldBeOfType<TripStarted>();
@@ -80,11 +80,11 @@ public class MemoryPackEventTests: IAsyncLifetime
                 new TripStarted(streamId, "Bob", startedAt),
                 new PassengerPickedUp(streamId, "Carol", startedAt.AddMinutes(5)),
                 new TripEnded(streamId, startedAt.AddMinutes(30), 24.50m));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _store.QuerySession();
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
 
         events.Count.ShouldBe(3);
         events[0].Data.ShouldBeOfType<TripStarted>().DriverName.ShouldBe("Bob");
@@ -107,11 +107,11 @@ public class MemoryPackEventTests: IAsyncLifetime
                 new TripCommentAdded(streamId, "looking good", DateTimeOffset.UtcNow), // JSON
                 new PassengerPickedUp(streamId, "Eli", DateTimeOffset.UtcNow), // binary
                 new TripCommentAdded(streamId, "passenger boarded", DateTimeOffset.UtcNow)); // JSON
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _store.QuerySession();
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
 
         events.Count.ShouldBe(4);
         events[0].Data.ShouldBeOfType<TripStarted>().DriverName.ShouldBe("Dana");
@@ -130,13 +130,13 @@ public class MemoryPackEventTests: IAsyncLifetime
             session.Events.StartStream(streamId,
                 new TripStarted(streamId, "Frank", DateTimeOffset.UtcNow), // binary
                 new TripCommentAdded(streamId, "hello", DateTimeOffset.UtcNow)); // JSON
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Pull the raw column values to verify the on-disk shape — the
         // discriminator is bdata IS NULL.
         await using var conn = _store.Storage.Database.CreateConnection();
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "select type, bdata is null as bdata_is_null, data::text " +
                           "from memorypack_events.mt_events where stream_id = $1 order by version";
@@ -144,9 +144,9 @@ public class MemoryPackEventTests: IAsyncLifetime
         p.Value = streamId;
         cmd.Parameters.Add(p);
 
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
         var rows = new System.Collections.Generic.List<(string type, bool bdataIsNull, string data)>();
-        while (await reader.ReadAsync())
+        while (await reader.ReadAsync(TestContext.Current.CancellationToken))
         {
             rows.Add((reader.GetString(0), reader.GetBoolean(1), reader.GetString(2)));
         }
@@ -178,13 +178,13 @@ public class MemoryPackEventTests: IAsyncLifetime
         {
             session.Events.StartStream(streamId,
                 new TripCommentAdded(streamId, "pre-upgrade comment", DateTimeOffset.UtcNow));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // The row is in mt_events with bdata = NULL. Read it back — the
         // per-row dispatch should fall through to mapping.ReadEventData.
         await using var query = _store.QuerySession();
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
 
         events.Count.ShouldBe(1);
         events[0].Data.ShouldBeOfType<TripCommentAdded>()
@@ -232,14 +232,14 @@ public class binary_serialization_upgrade_tests
         }))
         {
             // Clean slate — drop any leftover state from a prior test run.
-            await storeBeforeBinary.Advanced.Clean.CompletelyRemoveAllAsync();
+            await storeBeforeBinary.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
             await storeBeforeBinary.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 
             await using var session = storeBeforeBinary.LightweightSession();
             session.Events.StartStream(streamId,
                 new TripCommentAdded(streamId, "from json-only store v1", DateTimeOffset.UtcNow),
                 new TripCommentAdded(streamId, "from json-only store v2", DateTimeOffset.UtcNow));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // ----- Phase 2 ---------------------------------------------------
@@ -266,7 +266,7 @@ public class binary_serialization_upgrade_tests
                 session.Events.Append(streamId,
                     new TripStarted(streamId, "Alice", DateTimeOffset.UtcNow),
                     new TripEnded(streamId, DateTimeOffset.UtcNow, 42.50m));
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
 
             // Read back the whole stream — must replay all four events
@@ -274,7 +274,7 @@ public class binary_serialization_upgrade_tests
             // the per-row dispatch on bdata IS NULL.
             await using (var query = storeWithBinary.QuerySession())
             {
-                var events = await query.Events.FetchStreamAsync(streamId);
+                var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
 
                 events.Count.ShouldBe(4);
 
@@ -301,12 +301,12 @@ public class binary_serialization_upgrade_tests
             {
                 session.Events.Append(streamId,
                     new TripCommentAdded(streamId, "post-upgrade JSON", DateTimeOffset.UtcNow));
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
 
             await using (var query = storeWithBinary.QuerySession())
             {
-                var events = await query.Events.FetchStreamAsync(streamId);
+                var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
                 events.Count.ShouldBe(5);
                 events[4].Data.ShouldBeOfType<TripCommentAdded>()
                     .Comment.ShouldBe("post-upgrade JSON");
@@ -317,7 +317,7 @@ public class binary_serialization_upgrade_tests
             // the read path keys off of.
             await using (var conn = storeWithBinary.Storage.Database.CreateConnection())
             {
-                await conn.OpenAsync();
+                await conn.OpenAsync(TestContext.Current.CancellationToken);
                 await using var cmd = conn.CreateCommand();
                 cmd.CommandText = $"select type, bdata is null as bdata_is_null " +
                                   $"from {Schema}.mt_events where stream_id = $1 order by version";
@@ -326,8 +326,8 @@ public class binary_serialization_upgrade_tests
                 cmd.Parameters.Add(p);
 
                 var rows = new System.Collections.Generic.List<(string type, bool bdataIsNull)>();
-                await using var reader = await cmd.ExecuteReaderAsync();
-                while (await reader.ReadAsync())
+                await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+                while (await reader.ReadAsync(TestContext.Current.CancellationToken))
                 {
                     rows.Add((reader.GetString(0), reader.GetBoolean(1)));
                 }

--- a/src/Marten.MemoryPack.Tests/QuickModeBinaryEventTests.cs
+++ b/src/Marten.MemoryPack.Tests/QuickModeBinaryEventTests.cs
@@ -31,7 +31,7 @@ public class QuickModeBinaryEventTests
             opts.Events.UseMemoryPackSerializer();
         });
 
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
         await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 
         var streamId = Guid.NewGuid();
@@ -42,11 +42,11 @@ public class QuickModeBinaryEventTests
                 new TripStarted(streamId, "Alice", DateTimeOffset.UtcNow),     // binary
                 new TripCommentAdded(streamId, "leaving", DateTimeOffset.UtcNow), // JSON
                 new TripEnded(streamId, DateTimeOffset.UtcNow, 33.00m));       // binary
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = store.QuerySession();
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
 
         events.Count.ShouldBe(3);
         events[0].Data.ShouldBeOfType<TripStarted>().DriverName.ShouldBe("Alice");
@@ -66,7 +66,7 @@ public class QuickModeBinaryEventTests
             opts.Events.UseMemoryPackSerializer();
         });
 
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
         await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 
         var streamId = Guid.NewGuid();
@@ -77,11 +77,11 @@ public class QuickModeBinaryEventTests
                 new TripStarted(streamId, "Bob", DateTimeOffset.UtcNow),
                 new PassengerPickedUp(streamId, "Carol", DateTimeOffset.UtcNow),
                 new TripEnded(streamId, DateTimeOffset.UtcNow, 15.50m));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = store.QuerySession();
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
 
         events.Count.ShouldBe(3);
         events[0].Data.ShouldBeOfType<TripStarted>().DriverName.ShouldBe("Bob");
@@ -106,7 +106,7 @@ public class QuickModeBinaryEventTests
             opts.Events.UseMemoryPackSerializer();
         });
 
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
         await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 
         var streamId = Guid.NewGuid();
@@ -115,11 +115,11 @@ public class QuickModeBinaryEventTests
             session.Events.StartStream(streamId,
                 new TripStarted(streamId, "Dana", DateTimeOffset.UtcNow),         // binary
                 new TripCommentAdded(streamId, "hello", DateTimeOffset.UtcNow));  // JSON
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var conn = store.Storage.Database.CreateConnection();
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = $"select type, bdata is null as bdata_is_null, data::text " +
                           $"from {schema}.mt_events where stream_id = $1 order by version";
@@ -128,8 +128,8 @@ public class QuickModeBinaryEventTests
         cmd.Parameters.Add(p);
 
         var rows = new System.Collections.Generic.List<(string type, bool bdataIsNull, string data)>();
-        await using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        while (await reader.ReadAsync(TestContext.Current.CancellationToken))
         {
             rows.Add((reader.GetString(0), reader.GetBoolean(1), reader.GetString(2)));
         }

--- a/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
+++ b/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
@@ -103,10 +103,10 @@ public class noda_time_acceptance: OneOffConfigurationsContext
 
         await using var session = theStore.LightweightSession();
         session.Insert(testDoc);
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await using var query = theStore.QuerySession();
-        var docFromDb = (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.Id == testDoc.Id));
+        var docFromDb = (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.Id == testDoc.Id, TestContext.Current.CancellationToken));
 
         docFromDb.ShouldNotBeNull();
         docFromDb.Equals(testDoc).ShouldBeTrue();
@@ -129,7 +129,7 @@ public class noda_time_acceptance: OneOffConfigurationsContext
                 .Duplicate(x => x.NullableLocalDate);
         }, true);
 
-        await theStore.Advanced.Clean.CompletelyRemoveAllAsync();
+        await theStore.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
 
         var dateTime = DateTime.UtcNow;
         var localDateTime = LocalDateTime.FromDateTime(dateTime);
@@ -138,52 +138,52 @@ public class noda_time_acceptance: OneOffConfigurationsContext
 
         await using var session = theStore.LightweightSession();
         session.Insert(testDoc);
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await using var query = theStore.QuerySession();
         var results = new List<TargetWithDates>
         {
             // LocalDate
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate == localDateTime.Date)),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate < localDateTime.Date.PlusDays(1))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate <= localDateTime.Date.PlusDays(1))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate > localDateTime.Date.PlusDays(-1))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate >= localDateTime.Date.PlusDays(-1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate == localDateTime.Date, TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate < localDateTime.Date.PlusDays(1), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate <= localDateTime.Date.PlusDays(1), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate > localDateTime.Date.PlusDays(-1), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate >= localDateTime.Date.PlusDays(-1), TestContext.Current.CancellationToken)),
 
             //// Nullable LocalDate
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate == localDateTime.Date)),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate < localDateTime.Date.PlusDays(1))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate <= localDateTime.Date.PlusDays(1))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate > localDateTime.Date.PlusDays(-1))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate >= localDateTime.Date.PlusDays(-1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate == localDateTime.Date, TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate < localDateTime.Date.PlusDays(1), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate <= localDateTime.Date.PlusDays(1), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate > localDateTime.Date.PlusDays(-1), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate >= localDateTime.Date.PlusDays(-1), TestContext.Current.CancellationToken)),
 
             //// LocalDateTime
             //query.Query<TargetWithDates>().FirstOrDefault(d => d.LocalDateTime == localDateTime),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDateTime < localDateTime.PlusSeconds(1))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDateTime <= localDateTime.PlusSeconds(1))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDateTime > localDateTime.PlusSeconds(-1))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDateTime >= localDateTime.PlusSeconds(-1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDateTime < localDateTime.PlusSeconds(1), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDateTime <= localDateTime.PlusSeconds(1), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDateTime > localDateTime.PlusSeconds(-1), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDateTime >= localDateTime.PlusSeconds(-1), TestContext.Current.CancellationToken)),
 
             //// Nullable LocalDateTime
             //query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableLocalDateTime == localDateTime),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDateTime < localDateTime.PlusSeconds(1))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDateTime <= localDateTime.PlusSeconds(1))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDateTime > localDateTime.PlusSeconds(-1))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDateTime >= localDateTime.PlusSeconds(-1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDateTime < localDateTime.PlusSeconds(1), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDateTime <= localDateTime.PlusSeconds(1), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDateTime > localDateTime.PlusSeconds(-1), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDateTime >= localDateTime.PlusSeconds(-1), TestContext.Current.CancellationToken)),
 
             //// Instant UTC
             //query.Query<TargetWithDates>().FirstOrDefault(d => d.InstantUTC == instantUTC),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.InstantUTC < instantUTC.PlusTicks(1000))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.InstantUTC <= instantUTC.PlusTicks(1000))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.InstantUTC > instantUTC.PlusTicks(-1000))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.InstantUTC >= instantUTC.PlusTicks(-1000))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.InstantUTC < instantUTC.PlusTicks(1000), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.InstantUTC <= instantUTC.PlusTicks(1000), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.InstantUTC > instantUTC.PlusTicks(-1000), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.InstantUTC >= instantUTC.PlusTicks(-1000), TestContext.Current.CancellationToken)),
 
             // Nullable Instant UTC
             //query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableInstantUTC == instantUTC),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableInstantUTC < instantUTC.PlusTicks(1000))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableInstantUTC <= instantUTC.PlusTicks(1000))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableInstantUTC > instantUTC.PlusTicks(-1000))),
-            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableInstantUTC >= instantUTC.PlusTicks(-1000)))
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableInstantUTC < instantUTC.PlusTicks(1000), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableInstantUTC <= instantUTC.PlusTicks(1000), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableInstantUTC > instantUTC.PlusTicks(-1000), TestContext.Current.CancellationToken)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableInstantUTC >= instantUTC.PlusTicks(-1000), TestContext.Current.CancellationToken))
 
         };
 
@@ -216,11 +216,11 @@ public class noda_time_acceptance: OneOffConfigurationsContext
 
         await using var session = theStore.LightweightSession();
         session.Events.Append(streamId, @event);
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var streamState = await session.Events.FetchStreamStateAsync(streamId);
-        var streamState2 = await session.Events.FetchStreamStateAsync(streamId);
-        var streamState3 = await session.Events.FetchStreamAsync(streamId, timestamp: startDate);
+        var streamState = await session.Events.FetchStreamStateAsync(streamId, TestContext.Current.CancellationToken);
+        var streamState2 = await session.Events.FetchStreamStateAsync(streamId, TestContext.Current.CancellationToken);
+        var streamState3 = await session.Events.FetchStreamAsync(streamId, timestamp: startDate, token: TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -289,19 +289,19 @@ public class noda_time_acceptance: OneOffConfigurationsContext
         using (var session = theStore.LightweightSession())
         {
             session.Insert(testDoc);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var query = theStore.QuerySession())
         {
             var result = await query
                 .Query<TargetWithDates>()
-                .SingleAsync(c => c.Id == testDoc.Id);
+                .SingleAsync(c => c.Id == testDoc.Id, TestContext.Current.CancellationToken);
 
             var resultWithSelect = await query.Query<TargetWithDates>()
                 .Where(c => c.Id == testDoc.Id)
                 .Select(c => new { c.Id, c.InstantUTC, c.NullableInstantUTC, c.NullInstantUTC })
-                .SingleAsync();
+                .SingleAsync(TestContext.Current.CancellationToken);
 
             result.ShouldNotBeNull();
             result.Id.ShouldBe(testDoc.Id);
@@ -336,12 +336,12 @@ public class noda_time_acceptance: OneOffConfigurationsContext
                 .Duplicate(x => x.InstantUTC);
         }, true);
 
-        await theStore.Advanced.Clean.CompletelyRemoveAllAsync();
+        await theStore.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
 
         // This will apply schema changes, creating indexes on NodaTime fields.
         // Previously this would fail with "functions in index expression must be marked IMMUTABLE"
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
-        await theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync();
+        await theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync(TestContext.Current.CancellationToken);
     }
 
     private class CustomJsonSerializer: ISerializer

--- a/src/Marten.NodaTime.Testing/Bug_2307_JObject_in_dictionary_duplicated_field.cs
+++ b/src/Marten.NodaTime.Testing/Bug_2307_JObject_in_dictionary_duplicated_field.cs
@@ -45,7 +45,7 @@ public class Bug_2307_JObject_in_dictionary_duplicated_field: BugIntegrationCont
         await using (var session = theStore.LightweightSession())
         {
             session.Store(test1);
-            await session.SaveChangesAsync(default);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = theStore.QuerySession())
@@ -53,7 +53,7 @@ public class Bug_2307_JObject_in_dictionary_duplicated_field: BugIntegrationCont
             var instanceFilesTask = await session.Query<TestReadModel>()
                 .Where(x => x.InstanceId == e.Id)
                 .Select(x => new { x.InstanceData, x.Status, x.InstanceId, })
-                .ToListAsync(default);
+                .ToListAsync(TestContext.Current.CancellationToken);
 
             instanceFilesTask.Count.ShouldBePositive();
             instanceFilesTask[0].InstanceData["Data"].ShouldBe("Pew Pew");

--- a/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
+++ b/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
@@ -1,6 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <!-- Swept for xUnit1051 (#5067): every call taking a CancellationToken is handed
+             TestContext.Current.CancellationToken, so a hung test is cancelled and reported
+             instead of running until CI's own timeout. Keeping the rule ON guards the sweep.
+             Must be set before Tests.props is imported. -->
+        <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <RootNamespace>Marten.NodaTimePlugin.Testing</RootNamespace>
     </PropertyGroup>
 

--- a/src/Marten.PgVector.Tests/ConjoinedTenancy/conjoined_vector_tests.cs
+++ b/src/Marten.PgVector.Tests/ConjoinedTenancy/conjoined_vector_tests.cs
@@ -53,7 +53,7 @@ public class conjoined_vector_tests : IAsyncLifetime
                 Name = "Tenant A Widget",
                 Embedding = new float[] { 1, 0, 0 }
             });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Store vectors for tenant B
@@ -65,13 +65,13 @@ public class conjoined_vector_tests : IAsyncLifetime
                 Name = "Tenant B Widget",
                 Embedding = new float[] { 0, 1, 0 }
             });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Query tenant A — should only see tenant A's data
         await using (var q = _store.QuerySession("tenant_a"))
         {
-            var results = await q.Query<ProductWithVector>().ToListAsync();
+            var results = await q.Query<ProductWithVector>().ToListAsync(TestContext.Current.CancellationToken);
             results.Count.ShouldBe(1);
             results[0].Name.ShouldBe("Tenant A Widget");
         }
@@ -79,7 +79,7 @@ public class conjoined_vector_tests : IAsyncLifetime
         // Query tenant B — should only see tenant B's data
         await using (var q = _store.QuerySession("tenant_b"))
         {
-            var results = await q.Query<ProductWithVector>().ToListAsync();
+            var results = await q.Query<ProductWithVector>().ToListAsync(TestContext.Current.CancellationToken);
             results.Count.ShouldBe(1);
             results[0].Name.ShouldBe("Tenant B Widget");
         }
@@ -101,7 +101,7 @@ public class conjoined_vector_tests : IAsyncLifetime
                 Id = Guid.NewGuid(), Name = "A-Far",
                 Embedding = new float[] { 0, 0, 1 }
             });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = _store.LightweightSession("search_b"))
@@ -111,7 +111,7 @@ public class conjoined_vector_tests : IAsyncLifetime
                 Id = Guid.NewGuid(), Name = "B-Close",
                 Embedding = new float[] { 0.95f, 0.05f, 0 }
             });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Search tenant A for vectors near [1, 0, 0]

--- a/src/Marten.PgVector.Tests/Marten.PgVector.Tests.csproj
+++ b/src/Marten.PgVector.Tests/Marten.PgVector.Tests.csproj
@@ -1,4 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <!-- Swept for xUnit1051 (#5067): every call taking a CancellationToken is handed
+             TestContext.Current.CancellationToken, so a hung test is cancelled and reported
+             instead of running until CI's own timeout. Keeping the rule ON guards the sweep.
+             Must be set before Tests.props is imported. -->
+        <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
+    </PropertyGroup>
     <PropertyGroup>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>

--- a/src/Marten.PgVector.Tests/MultiDatabase/database_per_tenant_vector_tests.cs
+++ b/src/Marten.PgVector.Tests/MultiDatabase/database_per_tenant_vector_tests.cs
@@ -93,11 +93,11 @@ public class database_per_tenant_vector_tests : IAsyncLifetime
         foreach (var db in TenantDatabases)
         {
             await using var conn = new NpgsqlConnection(_tenantConnStrs[db]);
-            await conn.OpenAsync();
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
 
             await using var cmd = conn.CreateCommand();
             cmd.CommandText = "SELECT 1 FROM pg_extension WHERE extname = 'vector'";
-            var result = await cmd.ExecuteScalarAsync();
+            var result = await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken);
 
             result.ShouldNotBeNull(
                 $"pgvector extension was NOT created in database '{db}'. " +
@@ -111,9 +111,9 @@ public class database_per_tenant_vector_tests : IAsyncLifetime
         foreach (var db in TenantDatabases)
         {
             await using var conn = new NpgsqlConnection(_tenantConnStrs[db]);
-            await conn.OpenAsync();
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-            var tables = await conn.ExistingTablesAsync();
+            var tables = await conn.ExistingTablesAsync(ct: TestContext.Current.CancellationToken);
             tables.Any(t => t.Name.Contains("mt_doc_productwithvector"))
                 .ShouldBeTrue($"Document table not found in database '{db}'");
         }
@@ -130,7 +130,7 @@ public class database_per_tenant_vector_tests : IAsyncLifetime
                 Id = Guid.NewGuid(), Name = "T1 Product",
                 Embedding = new float[] { 1, 0, 0 }
             });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Store in tenant2
@@ -141,13 +141,13 @@ public class database_per_tenant_vector_tests : IAsyncLifetime
                 Id = Guid.NewGuid(), Name = "T2 Product",
                 Embedding = new float[] { 0, 1, 0 }
             });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Query tenant1
         await using (var q = _store.QuerySession(TenantDatabases[0]))
         {
-            var results = await q.Query<ProductWithVector>().ToListAsync();
+            var results = await q.Query<ProductWithVector>().ToListAsync(TestContext.Current.CancellationToken);
             results.Count.ShouldBe(1);
             results[0].Name.ShouldBe("T1 Product");
         }
@@ -155,7 +155,7 @@ public class database_per_tenant_vector_tests : IAsyncLifetime
         // Query tenant2
         await using (var q = _store.QuerySession(TenantDatabases[1]))
         {
-            var results = await q.Query<ProductWithVector>().ToListAsync();
+            var results = await q.Query<ProductWithVector>().ToListAsync(TestContext.Current.CancellationToken);
             results.Count.ShouldBe(1);
             results[0].Name.ShouldBe("T2 Product");
         }
@@ -163,7 +163,7 @@ public class database_per_tenant_vector_tests : IAsyncLifetime
         // Tenant3 should be empty
         await using (var q = _store.QuerySession(TenantDatabases[2]))
         {
-            var results = await q.Query<ProductWithVector>().ToListAsync();
+            var results = await q.Query<ProductWithVector>().ToListAsync(TestContext.Current.CancellationToken);
             results.Count.ShouldBe(0);
         }
     }
@@ -184,7 +184,7 @@ public class database_per_tenant_vector_tests : IAsyncLifetime
                 Id = Guid.NewGuid(), Name = "T1-Far",
                 Embedding = new float[] { 0, 0, 1 }
             });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = _store.LightweightSession(TenantDatabases[1]))
@@ -194,7 +194,7 @@ public class database_per_tenant_vector_tests : IAsyncLifetime
                 Id = Guid.NewGuid(), Name = "T2-Near",
                 Embedding = new float[] { 0.95f, 0.05f, 0 }
             });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var queryVector = new Vector(new float[] { 1, 0, 0 });

--- a/src/Marten.PgVector.Tests/SingleTenancy/vector_column_tests.cs
+++ b/src/Marten.PgVector.Tests/SingleTenancy/vector_column_tests.cs
@@ -47,12 +47,12 @@ public class vector_column_tests : IAsyncLifetime
         await using (var session = _store.LightweightSession())
         {
             session.Store(product);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var query = _store.QuerySession())
         {
-            var loaded = await query.LoadAsync<ProductWithVector>(product.Id);
+            var loaded = await query.LoadAsync<ProductWithVector>(product.Id, TestContext.Current.CancellationToken);
             loaded.ShouldNotBeNull();
             loaded.Name.ShouldBe("Widget");
             loaded.Embedding.ShouldNotBeNull();
@@ -73,7 +73,7 @@ public class vector_column_tests : IAsyncLifetime
         await using (var session = _store.LightweightSession())
         {
             foreach (var p in products) session.Store(p);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Search for vectors near [1, 0, 0] — should return "A" and "Near A" first
@@ -92,11 +92,11 @@ public class vector_column_tests : IAsyncLifetime
     public async Task vector_extension_is_created()
     {
         await using var conn = _store.Storage.Database.CreateConnection();
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT 1 FROM pg_extension WHERE extname = 'vector'";
-        var result = await cmd.ExecuteScalarAsync();
+        var result = await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken);
         result.ShouldNotBeNull();
     }
 }

--- a/src/Marten.PgVector.Tests/SingleTenancy/vector_projection_tests.cs
+++ b/src/Marten.PgVector.Tests/SingleTenancy/vector_projection_tests.cs
@@ -93,7 +93,7 @@ public class vector_projection_tests : IAsyncLifetime
         await using var session = _store.LightweightSession();
         session.Events.StartStream(productId,
             new ProductCreated(productId, "Widget", "A fantastic widget for all purposes"));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Query the projection table directly
         var results = await session.VectorProjectionSearchAsync(
@@ -116,7 +116,7 @@ public class vector_projection_tests : IAsyncLifetime
         {
             session.Events.StartStream(productId,
                 new ProductCreated(productId, "Widget", "Original description"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Update the product
@@ -124,7 +124,7 @@ public class vector_projection_tests : IAsyncLifetime
         {
             session.Events.Append(productId,
                 new ProductUpdated(productId, "Updated description"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Search should find the updated content
@@ -158,7 +158,7 @@ public class vector_projection_tests : IAsyncLifetime
             opts.Events.AddEventType<ProductCreated>();
         });
 
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
         await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 
         // First append — should call embedder
@@ -166,7 +166,7 @@ public class vector_projection_tests : IAsyncLifetime
         {
             session.Events.StartStream(productId,
                 new ProductCreated(productId, "Widget", "Same content"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var firstCallCount = callCount;
@@ -177,7 +177,7 @@ public class vector_projection_tests : IAsyncLifetime
         {
             session.Events.Append(productId,
                 new ProductCreated(productId, "Widget", "Same content"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         callCount.ShouldBe(firstCallCount); // No additional calls
@@ -194,7 +194,7 @@ public class vector_projection_tests : IAsyncLifetime
         {
             session.Events.StartStream(productId,
                 new ProductCreated(productId, "Widget", "To be deleted"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Delete
@@ -202,7 +202,7 @@ public class vector_projection_tests : IAsyncLifetime
         {
             session.Events.Append(productId,
                 new ProductDeleted(productId));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Search should find nothing
@@ -230,7 +230,7 @@ public class vector_projection_tests : IAsyncLifetime
             new ProductCreated(id2, "Blue Shoes", "Navy blue casual shoes"));
         session.Events.StartStream(id3,
             new ProductCreated(id3, "Garden Hose", "50ft expandable garden hose"));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Search — should return all 3 ordered by distance
         await using var querySession = _store.QuerySession();

--- a/src/Marten.PostGIS.Tests/Marten.PostGIS.Tests.csproj
+++ b/src/Marten.PostGIS.Tests/Marten.PostGIS.Tests.csproj
@@ -1,4 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <!-- Swept for xUnit1051 (#5067): every call taking a CancellationToken is handed
+             TestContext.Current.CancellationToken, so a hung test is cancelled and reported
+             instead of running until CI's own timeout. Keeping the rule ON guards the sweep.
+             Must be set before Tests.props is imported. -->
+        <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
+    </PropertyGroup>
     <PropertyGroup>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>

--- a/src/Marten.PostGIS.Tests/spatial_query_tests.cs
+++ b/src/Marten.PostGIS.Tests/spatial_query_tests.cs
@@ -39,11 +39,11 @@ public class spatial_query_tests : IAsyncLifetime
     public async Task postgis_extension_is_created()
     {
         await using var conn = _store.Storage.Database.CreateConnection();
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT 1 FROM pg_extension WHERE extname = 'postgis'";
-        var result = await cmd.ExecuteScalarAsync();
+        var result = await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken);
         result.ShouldNotBeNull();
     }
 
@@ -60,12 +60,12 @@ public class spatial_query_tests : IAsyncLifetime
         await using (var session = _store.LightweightSession())
         {
             session.Store(store);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var q = _store.QuerySession())
         {
-            var loaded = await q.LoadAsync<StoreLocation>(store.Id);
+            var loaded = await q.LoadAsync<StoreLocation>(store.Id, TestContext.Current.CancellationToken);
             loaded.ShouldNotBeNull();
             loaded.Name.ShouldBe("Downtown Store");
             // NTS Point is serialized as GeoJSON in the JSONB data column
@@ -92,12 +92,12 @@ public class spatial_query_tests : IAsyncLifetime
         await using (var session = _store.LightweightSession())
         {
             session.Store(area);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var q = _store.QuerySession())
         {
-            var loaded = await q.LoadAsync<ServiceArea>(area.Id);
+            var loaded = await q.LoadAsync<ServiceArea>(area.Id, TestContext.Current.CancellationToken);
             loaded.ShouldNotBeNull();
             loaded.Name.ShouldBe("Metro Area");
         }
@@ -120,7 +120,7 @@ public class spatial_query_tests : IAsyncLifetime
         await using (var session = _store.LightweightSession())
         {
             foreach (var s in stores) session.Store(s);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Search from downtown Seattle
@@ -149,7 +149,7 @@ public class spatial_query_tests : IAsyncLifetime
         await using (var session = _store.LightweightSession())
         {
             foreach (var s in stores) session.Store(s);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Search within ~50km of downtown Seattle using geometry (degrees)
@@ -198,7 +198,7 @@ public class spatial_query_tests : IAsyncLifetime
         await using (var session = _store.LightweightSession())
         {
             foreach (var a in areas) session.Store(a);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Find which areas contain downtown Seattle

--- a/src/Marten.SourceGenerator.Tests/CompiledQuerySourceGeneratorTests.cs
+++ b/src/Marten.SourceGenerator.Tests/CompiledQuerySourceGeneratorTests.cs
@@ -451,9 +451,9 @@ public class CompiledQuerySourceGeneratorTests
             "VerifyAssembly",
             new[]
             {
-                Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText("[assembly: JasperFx.JasperFxAssembly]"),
-                Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(src),
-                Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(generated)
+                Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText("[assembly: JasperFx.JasperFxAssembly]", cancellationToken: TestContext.Current.CancellationToken),
+                Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(src, cancellationToken: TestContext.Current.CancellationToken),
+                Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(generated, cancellationToken: TestContext.Current.CancellationToken)
             },
             AppDomain.CurrentDomain.GetAssemblies()
                 .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
@@ -462,7 +462,7 @@ public class CompiledQuerySourceGeneratorTests
                 Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary,
                 nullableContextOptions: Microsoft.CodeAnalysis.NullableContextOptions.Enable));
 
-        var diagnostics = compilation.GetDiagnostics()
+        var diagnostics = compilation.GetDiagnostics(TestContext.Current.CancellationToken)
             .Where(d => d.Severity == DiagnosticSeverity.Error)
             .ToArray();
         diagnostics.ShouldBeEmpty(string.Join("\n", diagnostics.Select(d => d.ToString())));

--- a/src/Marten.TimescaleDB.Tests/Marten.TimescaleDB.Tests.csproj
+++ b/src/Marten.TimescaleDB.Tests/Marten.TimescaleDB.Tests.csproj
@@ -1,4 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <!-- Swept for xUnit1051 (#5067): every call taking a CancellationToken is handed
+             TestContext.Current.CancellationToken, so a hung test is cancelled and reported
+             instead of running until CI's own timeout. Keeping the rule ON guards the sweep.
+             Must be set before Tests.props is imported. -->
+        <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
+    </PropertyGroup>
     <PropertyGroup>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>

--- a/src/Marten.TimescaleDB.Tests/document_hypertable_tests.cs
+++ b/src/Marten.TimescaleDB.Tests/document_hypertable_tests.cs
@@ -96,13 +96,13 @@ public class document_hypertable_tests: IAsyncLifetime
         await using (var session = _store.LightweightSession())
         {
             session.Store(new AuditEntry { Id = id, CreatedAt = createdAt, Action = "created", Severity = 1 });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Load by id (composite PK, but created_at is immutable so exactly one row per id)
         await using (var session = _store.QuerySession())
         {
-            var loaded = await session.LoadAsync<AuditEntry>(id);
+            var loaded = await session.LoadAsync<AuditEntry>(id, TestContext.Current.CancellationToken);
             loaded.ShouldNotBeNull();
             loaded.Action.ShouldBe("created");
         }
@@ -110,16 +110,16 @@ public class document_hypertable_tests: IAsyncLifetime
         // Update (created_at unchanged)
         await using (var session = _store.LightweightSession())
         {
-            var loaded = await session.LoadAsync<AuditEntry>(id);
+            var loaded = await session.LoadAsync<AuditEntry>(id, TestContext.Current.CancellationToken);
             loaded!.Action = "updated";
             loaded.Severity = 5;
             session.Store(loaded);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = _store.QuerySession())
         {
-            var loaded = await session.LoadAsync<AuditEntry>(id);
+            var loaded = await session.LoadAsync<AuditEntry>(id, TestContext.Current.CancellationToken);
             loaded!.Action.ShouldBe("updated");
             loaded.Severity.ShouldBe(5);
         }
@@ -132,12 +132,12 @@ public class document_hypertable_tests: IAsyncLifetime
         await using (var session = _store.LightweightSession())
         {
             session.Delete<AuditEntry>(id);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = _store.QuerySession())
         {
-            (await session.LoadAsync<AuditEntry>(id)).ShouldBeNull();
+            (await session.LoadAsync<AuditEntry>(id, TestContext.Current.CancellationToken)).ShouldBeNull();
         }
     }
 
@@ -157,11 +157,11 @@ public class document_hypertable_tests: IAsyncLifetime
                 });
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _store.QuerySession();
-        var high = await query.Query<AuditEntry>().CountAsync(x => x.Severity >= 5);
+        var high = await query.Query<AuditEntry>().CountAsync(x => x.Severity >= 5, TestContext.Current.CancellationToken);
         high.ShouldBe(5);
     }
 }

--- a/src/Marten.TimescaleDB.Tests/projection_hypertable_tests.cs
+++ b/src/Marten.TimescaleDB.Tests/projection_hypertable_tests.cs
@@ -119,7 +119,7 @@ public class projection_hypertable_tests: IAsyncLifetime
                     new SensorReadingRecorded(Guid.NewGuid(), baseTime.AddHours(i), 10 + i));
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var rows = await ScalarAsync<long>("select count(*) from timescale_proj.sensor_metrics");

--- a/src/ModularConfigTests/AddMartenTimingTests.cs
+++ b/src/ModularConfigTests/AddMartenTimingTests.cs
@@ -3,6 +3,7 @@ using Marten;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
+using Xunit;
 
 namespace ModularConfigTests;
 
@@ -31,7 +32,7 @@ public class AddMartenTimingTests
         builder.Services.AddSingleton<IConfigureMarten>(new SetNameLength(NameDataLengthSentinel));
 
         using var host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         try
         {
@@ -40,7 +41,7 @@ public class AddMartenTimingTests
         }
         finally
         {
-            await host.StopAsync();
+            await host.StopAsync(TestContext.Current.CancellationToken);
         }
     }
 

--- a/src/ModularConfigTests/AsyncComposeTests.cs
+++ b/src/ModularConfigTests/AsyncComposeTests.cs
@@ -4,6 +4,7 @@ using Marten;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
+using Xunit;
 
 namespace ModularConfigTests;
 
@@ -32,7 +33,7 @@ public class AsyncComposeTests
         ConfigurationFixture.AddBaselineMarten(builder.Services, schemaName);
 
         using var host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         try
         {
@@ -44,7 +45,7 @@ public class AsyncComposeTests
         }
         finally
         {
-            await host.StopAsync();
+            await host.StopAsync(TestContext.Current.CancellationToken);
         }
     }
 

--- a/src/ModularConfigTests/LastWinsTests.cs
+++ b/src/ModularConfigTests/LastWinsTests.cs
@@ -3,6 +3,7 @@ using Marten;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
+using Xunit;
 
 namespace ModularConfigTests;
 
@@ -39,7 +40,7 @@ public class LastWinsTests
         ConfigurationFixture.AddBaselineMarten(builder.Services, schemaName);
 
         using var host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         try
         {
@@ -58,7 +59,7 @@ public class LastWinsTests
         }
         finally
         {
-            await host.StopAsync();
+            await host.StopAsync(TestContext.Current.CancellationToken);
         }
     }
 

--- a/src/ModularConfigTests/ModularConfigTests.csproj
+++ b/src/ModularConfigTests/ModularConfigTests.csproj
@@ -1,6 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <!-- Swept for xUnit1051 (#5067): every call taking a CancellationToken is handed
+             TestContext.Current.CancellationToken, so a hung test is cancelled and reported
+             instead of running until CI's own timeout. Keeping the rule ON guards the sweep.
+             Must be set before Tests.props is imported. -->
+        <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <IsPackable>false</IsPackable>
         <!-- Marten#4472 modular composite configuration test harness.
              Exercises the path where projection types declared in satellite

--- a/src/ModularConfigTests/OrderingTests.cs
+++ b/src/ModularConfigTests/OrderingTests.cs
@@ -3,6 +3,7 @@ using Marten;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
+using Xunit;
 
 namespace ModularConfigTests;
 
@@ -29,7 +30,7 @@ public class OrderingTests
         ConfigurationFixture.AddBaselineMarten(builder.Services, schemaName);
 
         using var host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         try
         {
@@ -38,7 +39,7 @@ public class OrderingTests
         }
         finally
         {
-            await host.StopAsync();
+            await host.StopAsync(TestContext.Current.CancellationToken);
         }
     }
 

--- a/src/ModularConfigTests/SmokeTest.cs
+++ b/src/ModularConfigTests/SmokeTest.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using ModularConfigTests.SatelliteA;
 using ModularConfigTests.SatelliteB;
 using Shouldly;
+using Xunit;
 
 namespace ModularConfigTests;
 
@@ -46,7 +47,7 @@ public class SmokeTest
         ConfigurationFixture.AddBaselineMarten(builder.Services, schemaName);
 
         using var host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         try
         {
@@ -72,12 +73,12 @@ public class SmokeTest
             {
                 session.Events.StartStream<Order>(orderId, new OrderPlaced(orderId, 100m));
                 session.Events.Append(orderId, new OrderShipped(orderId));
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
 
             await using (var query = store.QuerySession())
             {
-                var order = await query.LoadAsync<Order>(orderId);
+                var order = await query.LoadAsync<Order>(orderId, TestContext.Current.CancellationToken);
                 order.ShouldNotBeNull();
                 order!.Amount.ShouldBe(100m);
                 order.IsShipped.ShouldBeTrue();
@@ -96,12 +97,12 @@ public class SmokeTest
                 session.Events.StartStream(streamA, new DailyOpened(day));
                 session.Events.StartStream(streamB, new DailyOpened(day));
                 session.Events.Append(streamA, new DailyClosed(day));
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
 
             await using (var query = store.QuerySession())
             {
-                var daily = await query.LoadAsync<Daily>(day);
+                var daily = await query.LoadAsync<Daily>(day, TestContext.Current.CancellationToken);
                 daily.ShouldNotBeNull();
                 daily!.OpenCount.ShouldBe(2);
                 daily.CloseCount.ShouldBe(1);
@@ -109,7 +110,7 @@ public class SmokeTest
         }
         finally
         {
-            await host.StopAsync();
+            await host.StopAsync(TestContext.Current.CancellationToken);
         }
     }
 }

--- a/src/MultiTenancyTests/DocumentStore_IMartenStorage_implementation.cs
+++ b/src/MultiTenancyTests/DocumentStore_IMartenStorage_implementation.cs
@@ -12,6 +12,7 @@ using Npgsql;
 using Shouldly;
 using Weasel.Postgresql;
 using Weasel.Postgresql.Migrations;
+using Xunit;
 
 namespace MultiTenancyTests;
 
@@ -146,7 +147,7 @@ public class DocumentStore_IMartenStorage_implementation : IAsyncLifetime
 
         foreach (var database in await theStore.Storage.AllDatabases())
         {
-            await database.AssertDatabaseMatchesConfigurationAsync();
+            await database.AssertDatabaseMatchesConfigurationAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -169,8 +170,8 @@ public class DocumentStore_IMartenStorage_implementation : IAsyncLifetime
         // Each IEventDatabase can serve the store-neutral read abstractions
         foreach (var database in databases)
         {
-            (await database.AllProjectionProgress()).ShouldNotBeNull();
-            (await database.FetchDeadLetterCountsAsync()).ShouldNotBeNull();
+            (await database.AllProjectionProgress(TestContext.Current.CancellationToken)).ShouldNotBeNull();
+            (await database.FetchDeadLetterCountsAsync(TestContext.Current.CancellationToken)).ShouldNotBeNull();
         }
     }
 }

--- a/src/MultiTenancyTests/MultiTenancyTests.csproj
+++ b/src/MultiTenancyTests/MultiTenancyTests.csproj
@@ -1,6 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <!-- Swept for xUnit1051 (#5067): every call taking a CancellationToken is handed
+             TestContext.Current.CancellationToken, so a hung test is cancelled and reported
+             instead of running until CI's own timeout. Keeping the rule ON guards the sweep.
+             Must be set before Tests.props is imported. -->
+        <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     </PropertyGroup>

--- a/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs
+++ b/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs
@@ -120,7 +120,7 @@ public class marten_managed_tenant_id_partitioning: StoreContext<MartenManagedPa
         }
 
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
-        await theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync();
+        await theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync(TestContext.Current.CancellationToken);
 
         await theStore.Advanced.RemoveMartenManagedTenantsAsync(["a2"], CancellationToken.None);
 
@@ -135,7 +135,7 @@ public class marten_managed_tenant_id_partitioning: StoreContext<MartenManagedPa
     public async Task delete_all_tenant_data_will_drop_partitions()
     {
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
-        await theStore.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await theStore.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         var statuses = await theStore
             .Advanced
@@ -149,7 +149,7 @@ public class marten_managed_tenant_id_partitioning: StoreContext<MartenManagedPa
         }
 
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
-        await theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync();
+        await theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync(TestContext.Current.CancellationToken);
 
         await theStore.Advanced.DeleteAllTenantDataAsync("a2", CancellationToken.None);
 
@@ -166,9 +166,9 @@ public class marten_managed_tenant_id_partitioning: StoreContext<MartenManagedPa
     public async Task should_not_build_storage_for_live_aggregations()
     {
         var streamId = theSession.Events.StartStream<SimpleAggregate>(new RandomEvent(), new BEvent()).Id;
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var aggregate = theSession.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+        var aggregate = theSession.Events.AggregateStreamAsync<SimpleAggregate>(streamId, token: TestContext.Current.CancellationToken);
         aggregate.ShouldNotBeNull();
 
         await theStore

--- a/src/MultiTenancyTests/rebuild_single_stream_tenant_overloads.cs
+++ b/src/MultiTenancyTests/rebuild_single_stream_tenant_overloads.cs
@@ -58,7 +58,7 @@ public class rebuild_single_stream_tenant_overloads
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
             opts.Policies.AllDocumentsAreMultiTenanted();
         });
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
 
         // tenant A: 3 AEvents → ACount = 3 after rebuild
         // tenant B: 2 BEvents → BCount = 2 after rebuild (must NOT pick up A's events)
@@ -69,22 +69,22 @@ public class rebuild_single_stream_tenant_overloads
         {
             session.Events.StartStream<Bug4668Aggregate>(streamA,
                 new AEvent_4668(), new AEvent_4668(), new AEvent_4668());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = store.LightweightSession("tenantB"))
         {
             session.Events.StartStream<Bug4668Aggregate>(streamB,
                 new BEvent_4668(), new BEvent_4668());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Rebuild tenant A's projection by Guid + tenant id.
-        await store.Advanced.RebuildSingleStreamAsync<Bug4668Aggregate>(streamA, "tenantA");
+        await store.Advanced.RebuildSingleStreamAsync<Bug4668Aggregate>(streamA, "tenantA", TestContext.Current.CancellationToken);
 
         await using (var query = store.QuerySession("tenantA"))
         {
-            var docA = await query.LoadAsync<Bug4668Aggregate>(streamA);
+            var docA = await query.LoadAsync<Bug4668Aggregate>(streamA, TestContext.Current.CancellationToken);
             docA.ShouldNotBeNull("tenant A's projection must materialize for the rebuilt stream");
             docA.ACount.ShouldBe(3, "tenant A's AEvents must roll up into ACount");
             docA.BCount.ShouldBe(0, "tenant A's stream has no BEvents");
@@ -92,11 +92,11 @@ public class rebuild_single_stream_tenant_overloads
 
         // Now rebuild tenant B; the new overload must route the AggregateStream
         // read AND the upsert to tenant B's row, leaving tenant A's doc untouched.
-        await store.Advanced.RebuildSingleStreamAsync<Bug4668Aggregate>(streamB, "tenantB");
+        await store.Advanced.RebuildSingleStreamAsync<Bug4668Aggregate>(streamB, "tenantB", TestContext.Current.CancellationToken);
 
         await using (var query = store.QuerySession("tenantB"))
         {
-            var docB = await query.LoadAsync<Bug4668Aggregate>(streamB);
+            var docB = await query.LoadAsync<Bug4668Aggregate>(streamB, TestContext.Current.CancellationToken);
             docB.ShouldNotBeNull("tenant B's projection must materialize for the rebuilt stream");
             docB.ACount.ShouldBe(0, "tenant B's stream has no AEvents");
             docB.BCount.ShouldBe(2, "tenant B's BEvents must roll up into BCount");
@@ -107,7 +107,7 @@ public class rebuild_single_stream_tenant_overloads
         // the rebuild.
         await using (var query = store.QuerySession("tenantA"))
         {
-            var crossB = await query.LoadAsync<Bug4668Aggregate>(streamB);
+            var crossB = await query.LoadAsync<Bug4668Aggregate>(streamB, TestContext.Current.CancellationToken);
             crossB.ShouldBeNull("tenant B's projection must NOT bleed into tenant A's view");
         }
     }
@@ -123,7 +123,7 @@ public class rebuild_single_stream_tenant_overloads
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
             opts.Policies.AllDocumentsAreMultiTenanted();
         });
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
 
         var keyA = "stream-A-" + Guid.NewGuid();
         var keyB = "stream-B-" + Guid.NewGuid();
@@ -132,31 +132,31 @@ public class rebuild_single_stream_tenant_overloads
         {
             session.Events.StartStream<Bug4668KeyedAggregate>(keyA,
                 new AEvent_4668(), new AEvent_4668(), new AEvent_4668(), new AEvent_4668());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = store.LightweightSession("tenantB"))
         {
             session.Events.StartStream<Bug4668KeyedAggregate>(keyB,
                 new BEvent_4668());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
-        await store.Advanced.RebuildSingleStreamAsync<Bug4668KeyedAggregate>(keyA, "tenantA");
+        await store.Advanced.RebuildSingleStreamAsync<Bug4668KeyedAggregate>(keyA, "tenantA", TestContext.Current.CancellationToken);
 
         await using (var query = store.QuerySession("tenantA"))
         {
-            var docA = await query.LoadAsync<Bug4668KeyedAggregate>(keyA);
+            var docA = await query.LoadAsync<Bug4668KeyedAggregate>(keyA, TestContext.Current.CancellationToken);
             docA.ShouldNotBeNull();
             docA.ACount.ShouldBe(4);
             docA.BCount.ShouldBe(0);
         }
 
-        await store.Advanced.RebuildSingleStreamAsync<Bug4668KeyedAggregate>(keyB, "tenantB");
+        await store.Advanced.RebuildSingleStreamAsync<Bug4668KeyedAggregate>(keyB, "tenantB", TestContext.Current.CancellationToken);
 
         await using (var query = store.QuerySession("tenantB"))
         {
-            var docB = await query.LoadAsync<Bug4668KeyedAggregate>(keyB);
+            var docB = await query.LoadAsync<Bug4668KeyedAggregate>(keyB, TestContext.Current.CancellationToken);
             docB.ShouldNotBeNull();
             docB.ACount.ShouldBe(0);
             docB.BCount.ShouldBe(1);
@@ -183,12 +183,12 @@ public class rebuild_single_stream_tenant_overloads
 
                     opts.DatabaseSchemaName = "rebuild_4668_perdb_guid";
                 }).ApplyAllDatabaseChangesOnStartup();
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         var store = host.Services.GetRequiredService<IDocumentStore>();
 
         // Each tenant gets its own DB. Reset both so prior runs don't leak.
-        await store.Advanced.ResetAllData();
+        await store.Advanced.ResetAllData(TestContext.Current.CancellationToken);
 
         var streamA = Guid.NewGuid();
         var streamB = Guid.NewGuid();
@@ -197,37 +197,37 @@ public class rebuild_single_stream_tenant_overloads
         {
             session.Events.StartStream<Bug4668Aggregate>(streamA,
                 new AEvent_4668(), new AEvent_4668());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = store.LightweightSession("rebuild4668_g_tenantB"))
         {
             session.Events.StartStream<Bug4668Aggregate>(streamB,
                 new BEvent_4668(), new BEvent_4668(), new BEvent_4668());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await store.Advanced.RebuildSingleStreamAsync<Bug4668Aggregate>(
-            streamA, "rebuild4668_g_tenantA");
+            streamA, "rebuild4668_g_tenantA", TestContext.Current.CancellationToken);
 
         await using (var query = store.QuerySession("rebuild4668_g_tenantA"))
         {
-            var doc = await query.LoadAsync<Bug4668Aggregate>(streamA);
+            var doc = await query.LoadAsync<Bug4668Aggregate>(streamA, TestContext.Current.CancellationToken);
             doc.ShouldNotBeNull("rebuild must persist into tenant A's database");
             doc.ACount.ShouldBe(2);
         }
 
         await store.Advanced.RebuildSingleStreamAsync<Bug4668Aggregate>(
-            streamB, "rebuild4668_g_tenantB");
+            streamB, "rebuild4668_g_tenantB", TestContext.Current.CancellationToken);
 
         await using (var query = store.QuerySession("rebuild4668_g_tenantB"))
         {
-            var doc = await query.LoadAsync<Bug4668Aggregate>(streamB);
+            var doc = await query.LoadAsync<Bug4668Aggregate>(streamB, TestContext.Current.CancellationToken);
             doc.ShouldNotBeNull("rebuild must persist into tenant B's database");
             doc.BCount.ShouldBe(3);
         }
 
-        await host.StopAsync();
+        await host.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -245,10 +245,10 @@ public class rebuild_single_stream_tenant_overloads
                     opts.Events.StreamIdentity = StreamIdentity.AsString;
                     opts.DatabaseSchemaName = "rebuild_4668_perdb_str";
                 }).ApplyAllDatabaseChangesOnStartup();
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         var store = host.Services.GetRequiredService<IDocumentStore>();
-        await store.Advanced.ResetAllData();
+        await store.Advanced.ResetAllData(TestContext.Current.CancellationToken);
 
         var keyA = "stream-A-" + Guid.NewGuid();
         var keyB = "stream-B-" + Guid.NewGuid();
@@ -257,37 +257,37 @@ public class rebuild_single_stream_tenant_overloads
         {
             session.Events.StartStream<Bug4668KeyedAggregate>(keyA,
                 new AEvent_4668(), new AEvent_4668(), new AEvent_4668());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = store.LightweightSession("rebuild4668_s_tenantB"))
         {
             session.Events.StartStream<Bug4668KeyedAggregate>(keyB,
                 new BEvent_4668(), new BEvent_4668());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await store.Advanced.RebuildSingleStreamAsync<Bug4668KeyedAggregate>(
-            keyA, "rebuild4668_s_tenantA");
+            keyA, "rebuild4668_s_tenantA", TestContext.Current.CancellationToken);
 
         await using (var query = store.QuerySession("rebuild4668_s_tenantA"))
         {
-            var doc = await query.LoadAsync<Bug4668KeyedAggregate>(keyA);
+            var doc = await query.LoadAsync<Bug4668KeyedAggregate>(keyA, TestContext.Current.CancellationToken);
             doc.ShouldNotBeNull("rebuild must persist into tenant A's database");
             doc.ACount.ShouldBe(3);
         }
 
         await store.Advanced.RebuildSingleStreamAsync<Bug4668KeyedAggregate>(
-            keyB, "rebuild4668_s_tenantB");
+            keyB, "rebuild4668_s_tenantB", TestContext.Current.CancellationToken);
 
         await using (var query = store.QuerySession("rebuild4668_s_tenantB"))
         {
-            var doc = await query.LoadAsync<Bug4668KeyedAggregate>(keyB);
+            var doc = await query.LoadAsync<Bug4668KeyedAggregate>(keyB, TestContext.Current.CancellationToken);
             doc.ShouldNotBeNull("rebuild must persist into tenant B's database");
             doc.BCount.ShouldBe(2);
         }
 
-        await host.StopAsync();
+        await host.StopAsync(TestContext.Current.CancellationToken);
     }
 }
 

--- a/src/MultiTenancyTests/sharded_tenancy_tests.cs
+++ b/src/MultiTenancyTests/sharded_tenancy_tests.cs
@@ -251,7 +251,7 @@ public class sharded_tenancy_tests : IAsyncLifetime
         var databases = await _store.Options.Tenancy.BuildDatabases();
         foreach (var db in databases.OfType<IMartenDatabase>())
         {
-            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+            await db.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
         }
 
         // Assign a tenant
@@ -264,9 +264,9 @@ public class sharded_tenancy_tests : IAsyncLifetime
 
         // Check that PG partitions were created
         await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-        var tables = await conn.ExistingTablesAsync();
+        var tables = await conn.ExistingTablesAsync(ct: TestContext.Current.CancellationToken);
         // Should have a partition like mt_doc_target_partition_test_tenant
         tables.Any(t => t.Name.Contains("partition_test_tenant")).ShouldBeTrue(
             $"Expected partition for 'partition_test_tenant' in {dbId}. Tables: {string.Join(", ", tables.Select(t => t.QualifiedName))}");
@@ -330,7 +330,7 @@ public class sharded_tenancy_tests : IAsyncLifetime
         var databases = await _store.Options.Tenancy.BuildDatabases();
         foreach (var db in databases.OfType<IMartenDatabase>())
         {
-            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+            await db.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
         }
 
         // Add specific tenants
@@ -342,26 +342,26 @@ public class sharded_tenancy_tests : IAsyncLifetime
         await using (var session = _store.LightweightSession("alpha"))
         {
             session.Store(new Target { Id = Guid.NewGuid(), String = "alpha_data" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = _store.LightweightSession("beta"))
         {
             session.Store(new Target { Id = Guid.NewGuid(), String = "beta_data" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Read back — isolation check
         await using (var q1 = _store.QuerySession("alpha"))
         {
-            var results = await q1.Query<Target>().ToListAsync();
+            var results = await q1.Query<Target>().ToListAsync(TestContext.Current.CancellationToken);
             results.Count.ShouldBe(1);
             results[0].String.ShouldBe("alpha_data");
         }
 
         await using (var q2 = _store.QuerySession("beta"))
         {
-            var results = await q2.Query<Target>().ToListAsync();
+            var results = await q2.Query<Target>().ToListAsync(TestContext.Current.CancellationToken);
             results.Count.ShouldBe(1);
             results[0].String.ShouldBe("beta_data");
         }
@@ -375,7 +375,7 @@ public class sharded_tenancy_tests : IAsyncLifetime
         var databases = await _store.Options.Tenancy.BuildDatabases();
         foreach (var db in databases.OfType<IMartenDatabase>())
         {
-            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+            await db.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
         }
 
         var sharded = (ShardedTenancy)_store.Options.Tenancy;
@@ -390,26 +390,26 @@ public class sharded_tenancy_tests : IAsyncLifetime
             streamA = session.Events.StartStream<ShardedTestEvent>(
                 new ShardedTestEvent { Value = "a1" },
                 new ShardedTestEvent { Value = "a2" }).Id;
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = _store.LightweightSession("ev_beta"))
         {
             streamB = session.Events.StartStream<ShardedTestEvent>(
                 new ShardedTestEvent { Value = "b1" }).Id;
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Query events per tenant
         await using (var q1 = _store.QuerySession("ev_alpha"))
         {
-            var events = await q1.Events.FetchStreamAsync(streamA);
+            var events = await q1.Events.FetchStreamAsync(streamA, token: TestContext.Current.CancellationToken);
             events.Count.ShouldBe(2);
         }
 
         await using (var q2 = _store.QuerySession("ev_beta"))
         {
-            var events = await q2.Events.FetchStreamAsync(streamB);
+            var events = await q2.Events.FetchStreamAsync(streamB, token: TestContext.Current.CancellationToken);
             events.Count.ShouldBe(1);
         }
     }
@@ -531,7 +531,7 @@ public class Bug_4366_wait_for_non_stale_under_sharded_multitenancy: IAsyncLifet
         var databases = await _store.Options.Tenancy.BuildDatabases();
         foreach (var db in databases.OfType<IMartenDatabase>())
         {
-            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+            await db.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
         }
 
         // Pre-fix: throws InvalidOperationException because Storage.Database is null

--- a/src/MultiTenancyTests/using_bucketed_database_sharding_and_document_partitioning.cs
+++ b/src/MultiTenancyTests/using_bucketed_database_sharding_and_document_partitioning.cs
@@ -22,6 +22,7 @@ using Shouldly;
 using Weasel.Core.Migrations;
 using Weasel.Postgresql;
 using Weasel.Postgresql.Migrations;
+using Xunit;
 
 namespace MultiTenancyTests;
 
@@ -122,11 +123,11 @@ public class using_bucketed_database_sharding_and_document_partitioning: IAsyncL
     public async Task creates_all_shard_databases()
     {
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         foreach (var name in _dbNames)
         {
-            (await conn.DatabaseExists(name)).ShouldBeTrue();
+            (await conn.DatabaseExists(name, TestContext.Current.CancellationToken)).ShouldBeTrue();
         }
     }
 
@@ -141,9 +142,9 @@ public class using_bucketed_database_sharding_and_document_partitioning: IAsyncL
             var database = (IMartenDatabase)db;
 
             await using var conn = database.CreateConnection();
-            await conn.OpenAsync();
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-            var tables = await conn.ExistingTablesAsync();
+            var tables = await conn.ExistingTablesAsync(ct: TestContext.Current.CancellationToken);
 
             tables.Any(x => x.QualifiedName == "public.mt_doc_user").ShouldBeTrue();
             for (var i = 1; i < NumberOfPartitions; i++)
@@ -171,23 +172,23 @@ public class using_bucketed_database_sharding_and_document_partitioning: IAsyncL
     [Fact]
     public async Task can_bulk_insert_and_query_per_tenant()
     {
-        await _store.Advanced.Clean.DeleteAllDocumentsAsync();
+        await _store.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
         var alphaTargets = Target.GenerateRandomData(40).ToArray();
         var gammaTargets = Target.GenerateRandomData(25).ToArray();
 
-        await _store.BulkInsertDocumentsAsync(TenantAlpha, alphaTargets);
-        await _store.BulkInsertDocumentsAsync(TenantGamma, gammaTargets);
+        await _store.BulkInsertDocumentsAsync(TenantAlpha, alphaTargets, cancellation: TestContext.Current.CancellationToken);
+        await _store.BulkInsertDocumentsAsync(TenantGamma, gammaTargets, cancellation: TestContext.Current.CancellationToken);
 
         await using (var queryAlpha = _store.QuerySession(TenantAlpha))
         {
-            var count = await queryAlpha.Query<Target>().CountAsync();
+            var count = await queryAlpha.Query<Target>().CountAsync(TestContext.Current.CancellationToken);
             count.ShouldBe(alphaTargets.Length);
         }
 
         await using (var queryGamma = _store.QuerySession(TenantGamma))
         {
-            var count = await queryGamma.Query<Target>().CountAsync();
+            var count = await queryGamma.Query<Target>().CountAsync(TestContext.Current.CancellationToken);
             count.ShouldBe(gammaTargets.Length);
         }
     }
@@ -198,19 +199,19 @@ public class using_bucketed_database_sharding_and_document_partitioning: IAsyncL
         var alphaTargets = Target.GenerateRandomData(10).ToArray();
         var betaTargets = Target.GenerateRandomData(10).ToArray();
 
-        await _store.BulkInsertDocumentsAsync(TenantAlpha, alphaTargets);
-        await _store.BulkInsertDocumentsAsync(TenantBeta, betaTargets);
+        await _store.BulkInsertDocumentsAsync(TenantAlpha, alphaTargets, cancellation: TestContext.Current.CancellationToken);
+        await _store.BulkInsertDocumentsAsync(TenantBeta, betaTargets, cancellation: TestContext.Current.CancellationToken);
 
-        await _store.Advanced.Clean.DeleteAllDocumentsAsync();
+        await _store.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
         await using (var q1 = _store.QuerySession(TenantAlpha))
         {
-            (await q1.Query<Target>().AnyAsync()).ShouldBeFalse();
+            (await q1.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
         }
 
         await using (var q2 = _store.QuerySession(TenantBeta))
         {
-            (await q2.Query<Target>().AnyAsync()).ShouldBeFalse();
+            (await q2.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
         }
     }
 
@@ -247,11 +248,11 @@ public class using_bucketed_database_sharding_and_document_partitioning: IAsyncL
         var tenant2 = FindTenantIdForDatabase(_dbNames[1]);
         var tenant3 = FindTenantIdForDatabase(_dbNames[2]);
 
-        await _store.Advanced.Clean.DeleteAllDocumentsAsync();
+        await _store.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
-        await _store.BulkInsertDocumentsAsync(tenant1, Target.GenerateRandomData(5).ToArray());
-        await _store.BulkInsertDocumentsAsync(tenant2, Target.GenerateRandomData(5).ToArray());
-        await _store.BulkInsertDocumentsAsync(tenant3, Target.GenerateRandomData(5).ToArray());
+        await _store.BulkInsertDocumentsAsync(tenant1, Target.GenerateRandomData(5).ToArray(), cancellation: TestContext.Current.CancellationToken);
+        await _store.BulkInsertDocumentsAsync(tenant2, Target.GenerateRandomData(5).ToArray(), cancellation: TestContext.Current.CancellationToken);
+        await _store.BulkInsertDocumentsAsync(tenant3, Target.GenerateRandomData(5).ToArray(), cancellation: TestContext.Current.CancellationToken);
 
         await using var s1 = _store.QuerySession(tenant1);
         await using var s2 = _store.QuerySession(tenant2);

--- a/src/MultiTenancyTests/using_master_table_multi_tenancy.cs
+++ b/src/MultiTenancyTests/using_master_table_multi_tenancy.cs
@@ -16,6 +16,7 @@ using Shouldly;
 using Weasel.Core.MultiTenancy;
 using Weasel.Postgresql;
 using Weasel.Postgresql.Migrations;
+using Xunit;
 
 namespace MultiTenancyTests;
 
@@ -40,9 +41,9 @@ public class master_table_multi_tenancy_independent_auto_create
     public async Task can_still_create_own_tables()
     {
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-        await conn.DropSchemaAsync("tenants");
+        await conn.DropSchemaAsync("tenants", TestContext.Current.CancellationToken);
 
         var tenant1ConnectionString = await CreateDatabaseIfNotExists(conn, "tenant1");
         var tenant2ConnectionString = await CreateDatabaseIfNotExists(conn, "tenant2");
@@ -78,7 +79,7 @@ public class master_table_multi_tenancy_independent_auto_create
                     // All detected changes will be applied to all
                     // the configured tenant databases on startup
                     .ApplyAllDatabaseChangesOnStartup();
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         await host.AddTenantDatabaseAsync("tenant4", tenant4ConnectionString);
     }
@@ -176,21 +177,21 @@ public class master_table_multi_tenancy_seeding : IAsyncLifetime
         var targets3 = Target.GenerateRandomData(100).ToArray();
         var targets4 = Target.GenerateRandomData(50).ToArray();
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
-        await theStore.BulkInsertDocumentsAsync("tenant3", targets3);
-        await theStore.BulkInsertDocumentsAsync("tenant4", targets4);
+        await theStore.BulkInsertDocumentsAsync("tenant3", targets3, cancellation: TestContext.Current.CancellationToken);
+        await theStore.BulkInsertDocumentsAsync("tenant4", targets4, cancellation: TestContext.Current.CancellationToken);
 
         await using (var query3 = theStore.QuerySession("tenant3"))
         {
-            var ids = await query3.Query<Target>().Select(x => x.Id).ToListAsync();
+            var ids = await query3.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
             ids.OrderBy(x => x).ShouldHaveTheSameElementsAs(targets3.OrderBy(x => x.Id).Select(x => x.Id).ToList());
         }
 
         await using (var query4 = theStore.QuerySession("tenant4"))
         {
-            var ids = await query4.Query<Target>().Select(x => x.Id).ToListAsync();
+            var ids = await query4.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
             ids.OrderBy(x => x).ShouldHaveTheSameElementsAs(targets4.OrderBy(x => x.Id).Select(x => x.Id).ToList());
         }
@@ -276,9 +277,9 @@ public class using_master_table_multi_tenancy : IAsyncLifetime
     public async Task run_describe()
     {
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-        await conn.DropSchemaAsync("tenants");
+        await conn.DropSchemaAsync("tenants", TestContext.Current.CancellationToken);
 
 
         tenant1ConnectionString = await CreateDatabaseIfNotExists(conn, "tenant1");
@@ -366,7 +367,7 @@ public class using_master_table_multi_tenancy : IAsyncLifetime
         await _host.AddTenantDatabaseAsync("tenant4", tenant4ConnectionString);
 
         await using var session =
-            await theStore.LightweightSerializableSessionAsync(new SessionOptions { TenantId = "tenant1" });
+            await theStore.LightweightSerializableSessionAsync(new SessionOptions { TenantId = "tenant1" }, TestContext.Current.CancellationToken);
 
         session.Connection.Database.ShouldBe("tenant1");
     }
@@ -384,21 +385,21 @@ public class using_master_table_multi_tenancy : IAsyncLifetime
         var targets3 = Target.GenerateRandomData(100).ToArray();
         var targets4 = Target.GenerateRandomData(50).ToArray();
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
-        await theStore.BulkInsertDocumentsAsync("tenant3", targets3);
-        await theStore.BulkInsertDocumentsAsync("tenant4", targets4);
+        await theStore.BulkInsertDocumentsAsync("tenant3", targets3, cancellation: TestContext.Current.CancellationToken);
+        await theStore.BulkInsertDocumentsAsync("tenant4", targets4, cancellation: TestContext.Current.CancellationToken);
 
         await using (var query3 = theStore.QuerySession("tenant3"))
         {
-            var ids = await query3.Query<Target>().Select(x => x.Id).ToListAsync();
+            var ids = await query3.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
             ids.OrderBy(x => x).ShouldHaveTheSameElementsAs(targets3.OrderBy(x => x.Id).Select(x => x.Id).ToList());
         }
 
         await using (var query4 = theStore.QuerySession("tenant4"))
         {
-            var ids = await query4.Query<Target>().Select(x => x.Id).ToListAsync();
+            var ids = await query4.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
             ids.OrderBy(x => x).ShouldHaveTheSameElementsAs(targets4.OrderBy(x => x.Id).Select(x => x.Id).ToList());
         }
@@ -417,19 +418,19 @@ public class using_master_table_multi_tenancy : IAsyncLifetime
         var targets3 = Target.GenerateRandomData(100).ToArray();
         var targets4 = Target.GenerateRandomData(50).ToArray();
 
-        await theStore.BulkInsertDocumentsAsync("tenant3", targets3);
-        await theStore.BulkInsertDocumentsAsync("tenant4", targets4);
+        await theStore.BulkInsertDocumentsAsync("tenant3", targets3, cancellation: TestContext.Current.CancellationToken);
+        await theStore.BulkInsertDocumentsAsync("tenant4", targets4, cancellation: TestContext.Current.CancellationToken);
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
         await using (var query3 = theStore.QuerySession("tenant3"))
         {
-            (await query3.Query<Target>().AnyAsync()).ShouldBeFalse();
+            (await query3.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
         }
 
         await using (var query4 = theStore.QuerySession("tenant4"))
         {
-            (await query4.Query<Target>().AnyAsync()).ShouldBeFalse();
+            (await query4.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
         }
     }
 

--- a/src/MultiTenancyTests/using_master_table_multi_tenancy_with_datasource.cs
+++ b/src/MultiTenancyTests/using_master_table_multi_tenancy_with_datasource.cs
@@ -15,6 +15,7 @@ using Weasel.Core;
 using Weasel.Core.MultiTenancy;
 using Weasel.Postgresql;
 using Weasel.Postgresql.Migrations;
+using Xunit;
 
 namespace MultiTenancyTests;
 
@@ -39,9 +40,9 @@ public class master_table_multi_tenancy_independent_auto_create_with_datasource
     public async Task can_still_create_own_tables()
     {
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-        await conn.DropSchemaAsync("tenants");
+        await conn.DropSchemaAsync("tenants", TestContext.Current.CancellationToken);
 
         var tenant1ConnectionString = await CreateDatabaseIfNotExists(conn, "tenant1");
         var tenant2ConnectionString = await CreateDatabaseIfNotExists(conn, "tenant2");
@@ -81,7 +82,7 @@ public class master_table_multi_tenancy_independent_auto_create_with_datasource
                         x.RegisterDatabase("tenant3", tenant3ConnectionString);
                     });
                 });
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         await host.AddTenantDatabaseAsync("tenant4", tenant4ConnectionString);
     }
@@ -179,21 +180,21 @@ public class master_table_multi_tenancy_seeding_with_datasource: IAsyncLifetime
         var targets3 = Target.GenerateRandomData(100).ToArray();
         var targets4 = Target.GenerateRandomData(50).ToArray();
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
-        await theStore.BulkInsertDocumentsAsync("tenant3", targets3);
-        await theStore.BulkInsertDocumentsAsync("tenant4", targets4);
+        await theStore.BulkInsertDocumentsAsync("tenant3", targets3, cancellation: TestContext.Current.CancellationToken);
+        await theStore.BulkInsertDocumentsAsync("tenant4", targets4, cancellation: TestContext.Current.CancellationToken);
 
         await using (var query3 = theStore.QuerySession("tenant3"))
         {
-            var ids = await query3.Query<Target>().Select(x => x.Id).ToListAsync();
+            var ids = await query3.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
             ids.OrderBy(x => x).ShouldHaveTheSameElementsAs(targets3.OrderBy(x => x.Id).Select(x => x.Id).ToList());
         }
 
         await using (var query4 = theStore.QuerySession("tenant4"))
         {
-            var ids = await query4.Query<Target>().Select(x => x.Id).ToListAsync();
+            var ids = await query4.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
             ids.OrderBy(x => x).ShouldHaveTheSameElementsAs(targets4.OrderBy(x => x.Id).Select(x => x.Id).ToList());
         }
@@ -290,7 +291,7 @@ public class using_master_table_multi_tenancy_with_datasource: IAsyncLifetime
         await _host.AddTenantDatabaseAsync("tenant4", tenant4ConnectionString);
 
         await using var session =
-            await theStore.LightweightSerializableSessionAsync(new SessionOptions { TenantId = "tenant1" });
+            await theStore.LightweightSerializableSessionAsync(new SessionOptions { TenantId = "tenant1" }, TestContext.Current.CancellationToken);
 
         session.Connection.Database.ShouldBe("tenant1");
     }
@@ -308,21 +309,21 @@ public class using_master_table_multi_tenancy_with_datasource: IAsyncLifetime
         var targets3 = Target.GenerateRandomData(100).ToArray();
         var targets4 = Target.GenerateRandomData(50).ToArray();
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
-        await theStore.BulkInsertDocumentsAsync("tenant3", targets3);
-        await theStore.BulkInsertDocumentsAsync("tenant4", targets4);
+        await theStore.BulkInsertDocumentsAsync("tenant3", targets3, cancellation: TestContext.Current.CancellationToken);
+        await theStore.BulkInsertDocumentsAsync("tenant4", targets4, cancellation: TestContext.Current.CancellationToken);
 
         await using (var query3 = theStore.QuerySession("tenant3"))
         {
-            var ids = await query3.Query<Target>().Select(x => x.Id).ToListAsync();
+            var ids = await query3.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
             ids.OrderBy(x => x).ShouldHaveTheSameElementsAs(targets3.OrderBy(x => x.Id).Select(x => x.Id).ToList());
         }
 
         await using (var query4 = theStore.QuerySession("tenant4"))
         {
-            var ids = await query4.Query<Target>().Select(x => x.Id).ToListAsync();
+            var ids = await query4.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
             ids.OrderBy(x => x).ShouldHaveTheSameElementsAs(targets4.OrderBy(x => x.Id).Select(x => x.Id).ToList());
         }
@@ -341,19 +342,19 @@ public class using_master_table_multi_tenancy_with_datasource: IAsyncLifetime
         var targets3 = Target.GenerateRandomData(100).ToArray();
         var targets4 = Target.GenerateRandomData(50).ToArray();
 
-        await theStore.BulkInsertDocumentsAsync("tenant3", targets3);
-        await theStore.BulkInsertDocumentsAsync("tenant4", targets4);
+        await theStore.BulkInsertDocumentsAsync("tenant3", targets3, cancellation: TestContext.Current.CancellationToken);
+        await theStore.BulkInsertDocumentsAsync("tenant4", targets4, cancellation: TestContext.Current.CancellationToken);
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
         await using (var query3 = theStore.QuerySession("tenant3"))
         {
-            (await query3.Query<Target>().AnyAsync()).ShouldBeFalse();
+            (await query3.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
         }
 
         await using (var query4 = theStore.QuerySession("tenant4"))
         {
-            (await query4.Query<Target>().AnyAsync()).ShouldBeFalse();
+            (await query4.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
         }
     }
 

--- a/src/MultiTenancyTests/using_per_database_multitenancy.cs
+++ b/src/MultiTenancyTests/using_per_database_multitenancy.cs
@@ -17,6 +17,7 @@ using Npgsql;
 using Shouldly;
 using Weasel.Core.Migrations;
 using Weasel.Postgresql;
+using Xunit;
 
 namespace MultiTenancyTests;
 
@@ -164,11 +165,11 @@ public class using_per_database_multitenancy: IAsyncLifetime
     public async Task creates_databases_from_apply()
     {
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-        (await conn.DatabaseExists("database1")).ShouldBeTrue();
-        (await conn.DatabaseExists("tenant3")).ShouldBeTrue();
-        (await conn.DatabaseExists("tenant4")).ShouldBeTrue();
+        (await conn.DatabaseExists("database1", TestContext.Current.CancellationToken)).ShouldBeTrue();
+        (await conn.DatabaseExists("tenant3", TestContext.Current.CancellationToken)).ShouldBeTrue();
+        (await conn.DatabaseExists("tenant4", TestContext.Current.CancellationToken)).ShouldBeTrue();
     }
 
     [Fact]
@@ -180,9 +181,9 @@ public class using_per_database_multitenancy: IAsyncLifetime
         foreach (IMartenDatabase database in databases)
         {
             await using var conn = database.CreateConnection();
-            await conn.OpenAsync();
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-            var tables = await conn.ExistingTablesAsync();
+            var tables = await conn.ExistingTablesAsync(ct: TestContext.Current.CancellationToken);
             tables.Any(x => x.QualifiedName == "public.mt_doc_user").ShouldBeTrue();
             tables.Any(x => x.QualifiedName == "public.mt_doc_target").ShouldBeTrue();
         }
@@ -192,7 +193,7 @@ public class using_per_database_multitenancy: IAsyncLifetime
     public async Task can_open_a_session_to_a_different_database()
     {
         await using var session =
-            await theStore.LightweightSerializableSessionAsync(new SessionOptions { TenantId = "tenant1" });
+            await theStore.LightweightSerializableSessionAsync(new SessionOptions { TenantId = "tenant1" }, TestContext.Current.CancellationToken);
 
         session.Connection.Database.ShouldBe("database1");
     }
@@ -203,21 +204,21 @@ public class using_per_database_multitenancy: IAsyncLifetime
         var targets3 = Target.GenerateRandomData(100).ToArray();
         var targets4 = Target.GenerateRandomData(50).ToArray();
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
-        await theStore.BulkInsertDocumentsAsync("tenant3", targets3);
-        await theStore.BulkInsertDocumentsAsync("tenant4", targets4);
+        await theStore.BulkInsertDocumentsAsync("tenant3", targets3, cancellation: TestContext.Current.CancellationToken);
+        await theStore.BulkInsertDocumentsAsync("tenant4", targets4, cancellation: TestContext.Current.CancellationToken);
 
         await using (var query3 = theStore.QuerySession("tenant3"))
         {
-            var ids = await query3.Query<Target>().Select(x => x.Id).ToListAsync();
+            var ids = await query3.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
             ids.OrderBy(x => x).ShouldHaveTheSameElementsAs(targets3.OrderBy(x => x.Id).Select(x => x.Id).ToList());
         }
 
         await using (var query4 = theStore.QuerySession("tenant4"))
         {
-            var ids = await query4.Query<Target>().Select(x => x.Id).ToListAsync();
+            var ids = await query4.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
             ids.OrderBy(x => x).ShouldHaveTheSameElementsAs(targets4.OrderBy(x => x.Id).Select(x => x.Id).ToList());
         }
@@ -229,19 +230,19 @@ public class using_per_database_multitenancy: IAsyncLifetime
         var targets3 = Target.GenerateRandomData(100).ToArray();
         var targets4 = Target.GenerateRandomData(50).ToArray();
 
-        await theStore.BulkInsertDocumentsAsync("tenant3", targets3);
-        await theStore.BulkInsertDocumentsAsync("tenant4", targets4);
+        await theStore.BulkInsertDocumentsAsync("tenant3", targets3, cancellation: TestContext.Current.CancellationToken);
+        await theStore.BulkInsertDocumentsAsync("tenant4", targets4, cancellation: TestContext.Current.CancellationToken);
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
         await using (var query3 = theStore.QuerySession("tenant3"))
         {
-            (await query3.Query<Target>().AnyAsync()).ShouldBeFalse();
+            (await query3.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
         }
 
         await using (var query4 = theStore.QuerySession("tenant4"))
         {
-            (await query4.Query<Target>().AnyAsync()).ShouldBeFalse();
+            (await query4.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
         }
     }
 }

--- a/src/MultiTenancyTests/using_static_database_multitenancy.cs
+++ b/src/MultiTenancyTests/using_static_database_multitenancy.cs
@@ -15,6 +15,7 @@ using Npgsql;
 using Shouldly;
 using Weasel.Postgresql;
 using Weasel.Postgresql.Migrations;
+using Xunit;
 
 namespace MultiTenancyTests;
 
@@ -125,11 +126,11 @@ public class using_static_database_multitenancy: IAsyncLifetime
     public async Task creates_databases_from_apply()
     {
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-        (await conn.DatabaseExists("database1")).ShouldBeTrue();
-        (await conn.DatabaseExists("tenant3")).ShouldBeTrue();
-        (await conn.DatabaseExists("tenant4")).ShouldBeTrue();
+        (await conn.DatabaseExists("database1", TestContext.Current.CancellationToken)).ShouldBeTrue();
+        (await conn.DatabaseExists("tenant3", TestContext.Current.CancellationToken)).ShouldBeTrue();
+        (await conn.DatabaseExists("tenant4", TestContext.Current.CancellationToken)).ShouldBeTrue();
     }
 
     [Fact]
@@ -141,9 +142,9 @@ public class using_static_database_multitenancy: IAsyncLifetime
         foreach (IMartenDatabase database in databases)
         {
             await using var conn = database.CreateConnection();
-            await conn.OpenAsync();
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-            var tables = await conn.ExistingTablesAsync();
+            var tables = await conn.ExistingTablesAsync(ct: TestContext.Current.CancellationToken);
             tables.Any(x => x.QualifiedName == "public.mt_doc_user").ShouldBeTrue();
             tables.Any(x => x.QualifiedName == "public.mt_doc_target").ShouldBeTrue();
         }
@@ -153,7 +154,7 @@ public class using_static_database_multitenancy: IAsyncLifetime
     public async Task can_open_a_session_to_a_different_database()
     {
         await using var session =
-            await theStore.LightweightSerializableSessionAsync(new SessionOptions { TenantId = "tenant1" });
+            await theStore.LightweightSerializableSessionAsync(new SessionOptions { TenantId = "tenant1" }, TestContext.Current.CancellationToken);
 
         session.Connection.Database.ShouldBe("database1");
     }
@@ -164,21 +165,21 @@ public class using_static_database_multitenancy: IAsyncLifetime
         var targets3 = Target.GenerateRandomData(100).ToArray();
         var targets4 = Target.GenerateRandomData(50).ToArray();
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
-        await theStore.BulkInsertDocumentsAsync("tenant3", targets3);
-        await theStore.BulkInsertDocumentsAsync("tenant4", targets4);
+        await theStore.BulkInsertDocumentsAsync("tenant3", targets3, cancellation: TestContext.Current.CancellationToken);
+        await theStore.BulkInsertDocumentsAsync("tenant4", targets4, cancellation: TestContext.Current.CancellationToken);
 
         await using (var query3 = theStore.QuerySession("tenant3"))
         {
-            var ids = await query3.Query<Target>().Select(x => x.Id).ToListAsync();
+            var ids = await query3.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
             ids.OrderBy(x => x).ShouldHaveTheSameElementsAs(targets3.OrderBy(x => x.Id).Select(x => x.Id).ToList());
         }
 
         await using (var query4 = theStore.QuerySession("tenant4"))
         {
-            var ids = await query4.Query<Target>().Select(x => x.Id).ToListAsync();
+            var ids = await query4.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
             ids.OrderBy(x => x).ShouldHaveTheSameElementsAs(targets4.OrderBy(x => x.Id).Select(x => x.Id).ToList());
         }
@@ -190,19 +191,19 @@ public class using_static_database_multitenancy: IAsyncLifetime
         var targets3 = Target.GenerateRandomData(100).ToArray();
         var targets4 = Target.GenerateRandomData(50).ToArray();
 
-        await theStore.BulkInsertDocumentsAsync("tenant3", targets3);
-        await theStore.BulkInsertDocumentsAsync("tenant4", targets4);
+        await theStore.BulkInsertDocumentsAsync("tenant3", targets3, cancellation: TestContext.Current.CancellationToken);
+        await theStore.BulkInsertDocumentsAsync("tenant4", targets4, cancellation: TestContext.Current.CancellationToken);
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
 
         await using (var query3 = theStore.QuerySession("tenant3"))
         {
-            (await query3.Query<Target>().AnyAsync()).ShouldBeFalse();
+            (await query3.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
         }
 
         await using (var query4 = theStore.QuerySession("tenant4"))
         {
-            (await query4.Query<Target>().AnyAsync()).ShouldBeFalse();
+            (await query4.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
         }
     }
 
@@ -210,7 +211,7 @@ public class using_static_database_multitenancy: IAsyncLifetime
     public async Task run_describe_with_single_document_store_and_static_multi_tenancy()
     {
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         var db1ConnectionString = await CreateDatabaseIfNotExists(conn, "database1");
         var tenant3ConnectionString = await CreateDatabaseIfNotExists(conn, "tenant3");

--- a/src/TenantPartitionedEventsTests/Admin/admin_api_tenant_overloads.cs
+++ b/src/TenantPartitionedEventsTests/Admin/admin_api_tenant_overloads.cs
@@ -104,7 +104,7 @@ public class admin_api_tenant_overloads
                 new EventRange(betaName, 0, 42, agent: null!)));
             session.QueueOperation(new InsertProjectionProgress(_fixture.Store.Options.EventGraph,
                 new EventRange(globalName, 0, 99, agent: null!)));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var db = (MartenDatabase)_fixture.Store.Storage.Database;
@@ -142,7 +142,7 @@ public class admin_api_tenant_overloads
         {
             session.QueueOperation(new InsertProjectionProgress(_fixture.Store.Options.EventGraph,
                 new EventRange(perTenantName, 0, 123, agent: null!)));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var es = (IEventStore)_fixture.Store;
@@ -181,7 +181,7 @@ public class admin_api_tenant_overloads
                 new EventRange(alphaName, 0, 10, agent: null!)));
             session.QueueOperation(new InsertProjectionProgress(_fixture.Store.Options.EventGraph,
                 new EventRange(betaName, 0, 20, agent: null!)));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var es = (IEventStore<IDocumentOperations, IQuerySession>)_fixture.Store;
@@ -221,7 +221,7 @@ public class admin_api_tenant_overloads
                 new EventRange(betaName, 0, 20, agent: null!)));
             session.QueueOperation(new InsertProjectionProgress(_fixture.Store.Options.EventGraph,
                 new EventRange(globalName, 0, 5, agent: null!)));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var es = (IEventStore<IDocumentOperations, IQuerySession>)_fixture.Store;

--- a/src/TenantPartitionedEventsTests/Admin/admin_extras_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Admin/admin_extras_under_partitioning.cs
@@ -127,7 +127,7 @@ public class admin_extras_under_partitioning : IAsyncLifetime
         sequencesAfterRegistration.ShouldBe(3L);
 
         // Idempotency: re-applying changes shouldn't change the count.
-        await _store.Storage.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await _store.Storage.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
 
         var sequencesAfterReapply = await CountTenantSequencesAsync(_schema);
         sequencesAfterReapply.ShouldBe(3L,

--- a/src/TenantPartitionedEventsTests/Admin/autocreate_matrix_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Admin/autocreate_matrix_under_partitioning.cs
@@ -92,11 +92,11 @@ public class autocreate_matrix_under_partitioning
         await using (var session = store.LightweightSession("alpha"))
         {
             session.Events.StartStream(streamId, new AutoCreateProbeEvent("hello"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = store.QuerySession("alpha");
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(1, $"AutoCreate.{autoCreate} must support the standard append+read flow under partitioning");
     }
 
@@ -128,11 +128,11 @@ public class autocreate_matrix_under_partitioning
         await using (var session = store.LightweightSession("alpha"))
         {
             session.Events.StartStream(streamId, new AutoCreateProbeEvent("none-virgin"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = store.QuerySession("alpha");
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(1,
             "AutoCreate.None against a virgin schema must work end-to-end after #4641 — " +
             "the admin call's bypass scope now includes the events feature");
@@ -205,7 +205,7 @@ public class autocreate_matrix_under_partitioning
             await using (var session = store.LightweightSession("alpha"))
             {
                 session.Events.StartStream(streamId, new AutoCreateProbeEvent("trigger"));
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
             (await CountQuickAppendFunctionAsync(allSchema)).ShouldBe(1L,
                 "the first SaveChangesAsync lazy-installs the events feature under permissive modes");
@@ -239,7 +239,7 @@ public class autocreate_matrix_under_partitioning
         // Primer: full DDL.
         using (var primer = BuildStore(schema, AutoCreate.All))
         {
-            await primer.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+            await primer.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
         }
 
         // Runtime: AutoCreate.None against the already-created schema.
@@ -250,11 +250,11 @@ public class autocreate_matrix_under_partitioning
         await using (var session = store.LightweightSession("alpha"))
         {
             session.Events.StartStream(streamId, new AutoCreateProbeEvent("primed"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = store.QuerySession("alpha");
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(1,
             "AutoCreate.None against a pre-existing schema must still let admin partition operations work");
     }

--- a/src/TenantPartitionedEventsTests/Admin/delete_all_tenant_data_orphan_sequence_pin.cs
+++ b/src/TenantPartitionedEventsTests/Admin/delete_all_tenant_data_orphan_sequence_pin.cs
@@ -78,7 +78,7 @@ public class delete_all_tenant_data_orphan_sequence_pin : IAsyncLifetime
         {
             session.Events.StartStream(streamId,
                 new DelEvent("a"), new DelEvent("b"), new DelEvent("c"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var seqValueBefore = await ReadSequenceLastValueAsync(_schema, $"mt_events_sequence_{tenant}");
@@ -114,7 +114,7 @@ public class delete_all_tenant_data_orphan_sequence_pin : IAsyncLifetime
         {
             session.Events.StartStream(streamId,
                 new DelEvent("x"), new DelEvent("y"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var seqValueBefore = await ReadSequenceLastValueAsync(_schema, $"mt_events_sequence_{tenant}");
@@ -150,7 +150,7 @@ public class delete_all_tenant_data_orphan_sequence_pin : IAsyncLifetime
         await using (var session = _store.LightweightSession(drop))
         {
             session.Events.StartStream(Guid.NewGuid(), new DelEvent("x"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Seed the progression rows we want the cleanup to target. Names span the two grammars:

--- a/src/TenantPartitionedEventsTests/Admin/event_store_statistics_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Admin/event_store_statistics_under_partitioning.cs
@@ -52,7 +52,7 @@ public class event_store_statistics_under_partitioning
         {
             session.Events.StartStream<TripSnapshot>(streamId,
                 new TripStarted(streamId), new TripLeg(1), new TripLeg(2), new TripLeg(3));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var statsAfter = await db.FetchEventStoreStatistics(token: CancellationToken.None);

--- a/src/TenantPartitionedEventsTests/AppendWrite/append_return_shapes_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/AppendWrite/append_return_shapes_under_partitioning.cs
@@ -41,16 +41,16 @@ public class append_return_shapes_under_partitioning
             // Both StartStream + Append using `params object[]` — the canonical
             // shape.
             s.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId), new TripLeg(1));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.Append(streamId, new TripLeg(2), new TripLeg(3));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var q = _fixture.Store.QuerySession(tenant);
-        var events = await q.Events.FetchStreamAsync(streamId);
+        var events = await q.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(4);
     }
 
@@ -70,18 +70,18 @@ public class append_return_shapes_under_partitioning
             // IEnumerable<object> overload — the shape Wolverine-style bulk
             // emitters commonly use.
             s.Events.StartStream<TripSnapshot>(streamId, seedEvents);
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         IEnumerable<object> moreEvents = new object[] { new TripLeg(3) };
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.Append(streamId, moreEvents);
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var q = _fixture.Store.QuerySession(tenant);
-        var events = await q.Events.FetchStreamAsync(streamId);
+        var events = await q.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(4);
     }
 
@@ -97,17 +97,17 @@ public class append_return_shapes_under_partitioning
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.Append(streamId, new TripLeg(42));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var q = _fixture.Store.QuerySession(tenant);
-        var events = await q.Events.FetchStreamAsync(streamId);
+        var events = await q.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(2);
         events[1].Version.ShouldBe(2L);
     }

--- a/src/TenantPartitionedEventsTests/AppendWrite/archive_stream_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/AppendWrite/archive_stream_under_partitioning.cs
@@ -48,25 +48,25 @@ public class archive_stream_under_partitioning
         await using (var s = _fixture.Store.LightweightSession(alpha))
         {
             s.Events.StartStream<TripSnapshot>(sharedId, new TripStarted(sharedId), new TripLeg(1));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<TripSnapshot>(sharedId, new TripStarted(sharedId), new TripLeg(2));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Archive only alpha's stream.
         await using (var s = _fixture.Store.LightweightSession(alpha))
         {
             s.Events.ArchiveStream(sharedId);
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Alpha's stream state shows archived; beta's same-id stream stays live.
         await using (var qa = _fixture.Store.QuerySession(alpha))
         {
-            var alphaState = await qa.Events.FetchStreamStateAsync(sharedId);
+            var alphaState = await qa.Events.FetchStreamStateAsync(sharedId, TestContext.Current.CancellationToken);
             alphaState.ShouldNotBeNull();
             alphaState!.IsArchived.ShouldBeTrue(
                 "alpha's stream was archived — its mt_streams row must have is_archived = true");
@@ -74,7 +74,7 @@ public class archive_stream_under_partitioning
 
         await using (var qb = _fixture.Store.QuerySession(beta))
         {
-            var betaState = await qb.Events.FetchStreamStateAsync(sharedId);
+            var betaState = await qb.Events.FetchStreamStateAsync(sharedId, TestContext.Current.CancellationToken);
             betaState.ShouldNotBeNull(
                 "beta's same-id stream must survive — archive is scoped by (tenant_id, stream_id)");
             betaState!.IsArchived.ShouldBeFalse(
@@ -95,13 +95,13 @@ public class archive_stream_under_partitioning
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.ArchiveStream(streamId);
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var s = _fixture.Store.LightweightSession(tenant))

--- a/src/TenantPartitionedEventsTests/AppendWrite/event_metadata_propagation_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/AppendWrite/event_metadata_propagation_under_partitioning.cs
@@ -55,11 +55,11 @@ public class event_metadata_propagation_under_partitioning
         {
             s.Events.StartStream<TripSnapshot>(streamId,
                 new TripStarted(streamId), new TripLeg(1));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var q = _fixture.Store.QuerySession(tenant);
-        var events = await q.Events.FetchStreamAsync(streamId);
+        var events = await q.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(2);
 
         foreach (var e in events)
@@ -135,11 +135,11 @@ public class event_optional_metadata_propagation_under_partitioning : IAsyncLife
 
             s.Events.StartStream<MetaAggregate>(streamId,
                 new MetaEvent("a"), new MetaEvent("b"), new MetaEvent("c"));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var q = _store.QuerySession("alpha");
-        var events = await q.Events.FetchStreamAsync(streamId);
+        var events = await q.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(3);
 
         foreach (var e in events)

--- a/src/TenantPartitionedEventsTests/AppendWrite/seq_id_gap_after_failed_batch.cs
+++ b/src/TenantPartitionedEventsTests/AppendWrite/seq_id_gap_after_failed_batch.cs
@@ -64,10 +64,10 @@ public class seq_id_gap_after_failed_batch
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.StartStream<TripSnapshot>(firstStream, new TripStarted(firstStream));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
             var seeded = await s.Events.QueryAllRawEvents()
                 .Where(e => e.StreamId == firstStream)
-                .ToListAsync();
+                .ToListAsync(TestContext.Current.CancellationToken);
             lastSeqBeforeBurn = seeded.Max(e => e.Sequence);
         }
 
@@ -75,10 +75,10 @@ public class seq_id_gap_after_failed_batch
         //    models the gap a partial / failed batch would produce.
         await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
         {
-            await conn.OpenAsync();
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
             await using var cmd = conn.CreateCommand(
                 $"select nextval('{_fixture.SchemaName}.mt_events_sequence_{tenant}')");
-            await cmd.ExecuteScalarAsync();
+            await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken);
         }
 
         // 3) Successful append — its first seq_id must SKIP the burned value.
@@ -87,10 +87,10 @@ public class seq_id_gap_after_failed_batch
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.StartStream<TripSnapshot>(nextStream, new TripStarted(nextStream));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
             var events = await s.Events.QueryAllRawEvents()
                 .Where(e => e.StreamId == nextStream)
-                .ToListAsync();
+                .ToListAsync(TestContext.Current.CancellationToken);
             nextStreamFirstSeq = events.Single().Sequence;
         }
 

--- a/src/TenantPartitionedEventsTests/AppendWrite/start_and_append_basics_guid.cs
+++ b/src/TenantPartitionedEventsTests/AppendWrite/start_and_append_basics_guid.cs
@@ -44,10 +44,10 @@ public class start_and_append_basics_guid
             new TripStarted(streamId),
             new TripLeg(1),
             new TripLeg(2));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(3);
 
         // Per-stream version is contiguous 1..N regardless of the per-tenant
@@ -77,24 +77,24 @@ public class start_and_append_basics_guid
         await using (var s = _fixture.Store.LightweightSession(alpha))
         {
             s.Events.StartStream<TripSnapshot>(alphaStream, new TripStarted(alphaStream), new TripLeg(10));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<TripSnapshot>(betaStream, new TripStarted(betaStream), new TripLeg(20));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Each tenant's sequence is freshly minted on AddMartenManagedTenantsAsync —
         // so the first append for either tenant has seq_id = 1.
         await using var query = _fixture.Store.QuerySession(alpha);
-        var alphaEvents = await query.Events.FetchStreamAsync(alphaStream);
+        var alphaEvents = await query.Events.FetchStreamAsync(alphaStream, token: TestContext.Current.CancellationToken);
         alphaEvents[0].Sequence.ShouldBe(1L);
         alphaEvents[1].Sequence.ShouldBe(2L);
 
         await using var queryB = _fixture.Store.QuerySession(beta);
-        var betaEvents = await queryB.Events.FetchStreamAsync(betaStream);
+        var betaEvents = await queryB.Events.FetchStreamAsync(betaStream, token: TestContext.Current.CancellationToken);
         betaEvents[0].Sequence.ShouldBe(1L);
         betaEvents[1].Sequence.ShouldBe(2L);
 
@@ -114,7 +114,7 @@ public class start_and_append_basics_guid
         await using (var first = _fixture.Store.LightweightSession(tenant))
         {
             first.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
-            await first.SaveChangesAsync();
+            await first.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Same id, same tenant — the second StartStream lands in the same
@@ -148,22 +148,22 @@ public class start_and_append_basics_guid
         await using (var sa = _fixture.Store.LightweightSession(alpha))
         {
             sa.Events.StartStream<TripSnapshot>(sharedStreamId, new TripStarted(sharedStreamId), new TripLeg(1));
-            await sa.SaveChangesAsync();
+            await sa.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var sb = _fixture.Store.LightweightSession(beta))
         {
             sb.Events.StartStream<TripSnapshot>(sharedStreamId, new TripStarted(sharedStreamId), new TripLeg(2), new TripLeg(3));
-            await sb.SaveChangesAsync();
+            await sb.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Each tenant queries and sees ONLY its own stream's events.
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var aEvents = await qa.Events.FetchStreamAsync(sharedStreamId);
+        var aEvents = await qa.Events.FetchStreamAsync(sharedStreamId, token: TestContext.Current.CancellationToken);
         aEvents.Count.ShouldBe(2);
 
         await using var qb = _fixture.Store.QuerySession(beta);
-        var bEvents = await qb.Events.FetchStreamAsync(sharedStreamId);
+        var bEvents = await qb.Events.FetchStreamAsync(sharedStreamId, token: TestContext.Current.CancellationToken);
         bEvents.Count.ShouldBe(3);
     }
 
@@ -177,18 +177,18 @@ public class start_and_append_basics_guid
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId), new TripLeg(5));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Plain append (no version) — events get versions 3, 4.
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.Append(streamId, new TripLeg(10), new TripLeg(20));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(4);
         events.Select(e => e.Version).ShouldBe(new long[] { 1, 2, 3, 4 });
     }
@@ -205,13 +205,13 @@ public class start_and_append_basics_guid
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.ArchiveStream(streamId);
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var s = _fixture.Store.LightweightSession(tenant))
@@ -240,12 +240,12 @@ public class start_and_append_basics_guid
             s.Events.StartStream<TripSnapshot>(streamA, new TripStarted(streamA), new TripLeg(1));
             s.Events.StartStream<TripSnapshot>(streamB, new TripStarted(streamB));
             s.Events.StartStream<TripSnapshot>(streamC, new TripStarted(streamC), new TripLeg(2), new TripLeg(3));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        (await query.Events.FetchStreamAsync(streamA)).Count.ShouldBe(2);
-        (await query.Events.FetchStreamAsync(streamB)).Count.ShouldBe(1);
-        (await query.Events.FetchStreamAsync(streamC)).Count.ShouldBe(3);
+        (await query.Events.FetchStreamAsync(streamA, token: TestContext.Current.CancellationToken)).Count.ShouldBe(2);
+        (await query.Events.FetchStreamAsync(streamB, token: TestContext.Current.CancellationToken)).Count.ShouldBe(1);
+        (await query.Events.FetchStreamAsync(streamC, token: TestContext.Current.CancellationToken)).Count.ShouldBe(3);
     }
 }

--- a/src/TenantPartitionedEventsTests/AppendWrite/start_and_append_basics_string.cs
+++ b/src/TenantPartitionedEventsTests/AppendWrite/start_and_append_basics_string.cs
@@ -52,10 +52,10 @@ public class start_and_append_basics_string
             new StringTripStarted(streamId),
             new StringTripLeg(1),
             new StringTripLeg(2));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(3);
 
         // Per-stream version is contiguous 1..N regardless of the per-tenant
@@ -85,24 +85,24 @@ public class start_and_append_basics_string
         await using (var s = _fixture.Store.LightweightSession(alpha))
         {
             s.Events.StartStream<StringTripSnapshot>(alphaStream, new StringTripStarted(alphaStream), new StringTripLeg(10));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<StringTripSnapshot>(betaStream, new StringTripStarted(betaStream), new StringTripLeg(20));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Each tenant's sequence is freshly minted on AddMartenManagedTenantsAsync —
         // so the first append for either tenant has seq_id = 1.
         await using var query = _fixture.Store.QuerySession(alpha);
-        var alphaEvents = await query.Events.FetchStreamAsync(alphaStream);
+        var alphaEvents = await query.Events.FetchStreamAsync(alphaStream, token: TestContext.Current.CancellationToken);
         alphaEvents[0].Sequence.ShouldBe(1L);
         alphaEvents[1].Sequence.ShouldBe(2L);
 
         await using var queryB = _fixture.Store.QuerySession(beta);
-        var betaEvents = await queryB.Events.FetchStreamAsync(betaStream);
+        var betaEvents = await queryB.Events.FetchStreamAsync(betaStream, token: TestContext.Current.CancellationToken);
         betaEvents[0].Sequence.ShouldBe(1L);
         betaEvents[1].Sequence.ShouldBe(2L);
 
@@ -122,7 +122,7 @@ public class start_and_append_basics_string
         await using (var first = _fixture.Store.LightweightSession(tenant))
         {
             first.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId));
-            await first.SaveChangesAsync();
+            await first.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Same key, same tenant — the second StartStream lands in the same
@@ -156,22 +156,22 @@ public class start_and_append_basics_string
         await using (var sa = _fixture.Store.LightweightSession(alpha))
         {
             sa.Events.StartStream<StringTripSnapshot>(sharedStreamId, new StringTripStarted(sharedStreamId), new StringTripLeg(1));
-            await sa.SaveChangesAsync();
+            await sa.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var sb = _fixture.Store.LightweightSession(beta))
         {
             sb.Events.StartStream<StringTripSnapshot>(sharedStreamId, new StringTripStarted(sharedStreamId), new StringTripLeg(2), new StringTripLeg(3));
-            await sb.SaveChangesAsync();
+            await sb.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Each tenant queries and sees ONLY its own stream's events.
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var aEvents = await qa.Events.FetchStreamAsync(sharedStreamId);
+        var aEvents = await qa.Events.FetchStreamAsync(sharedStreamId, token: TestContext.Current.CancellationToken);
         aEvents.Count.ShouldBe(2);
 
         await using var qb = _fixture.Store.QuerySession(beta);
-        var bEvents = await qb.Events.FetchStreamAsync(sharedStreamId);
+        var bEvents = await qb.Events.FetchStreamAsync(sharedStreamId, token: TestContext.Current.CancellationToken);
         bEvents.Count.ShouldBe(3);
     }
 
@@ -185,18 +185,18 @@ public class start_and_append_basics_string
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId), new StringTripLeg(5));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Plain append (no version) — events get versions 3, 4.
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.Append(streamId, new StringTripLeg(10), new StringTripLeg(20));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(4);
         events.Select(e => e.Version).ShouldBe(new long[] { 1, 2, 3, 4 });
     }
@@ -213,13 +213,13 @@ public class start_and_append_basics_string
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var s = _fixture.Store.LightweightSession(tenant))
         {
             s.Events.ArchiveStream(streamId);
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var s = _fixture.Store.LightweightSession(tenant))
@@ -248,12 +248,12 @@ public class start_and_append_basics_string
             s.Events.StartStream<StringTripSnapshot>(streamA, new StringTripStarted(streamA), new StringTripLeg(1));
             s.Events.StartStream<StringTripSnapshot>(streamB, new StringTripStarted(streamB));
             s.Events.StartStream<StringTripSnapshot>(streamC, new StringTripStarted(streamC), new StringTripLeg(2), new StringTripLeg(3));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        (await query.Events.FetchStreamAsync(streamA)).Count.ShouldBe(2);
-        (await query.Events.FetchStreamAsync(streamB)).Count.ShouldBe(1);
-        (await query.Events.FetchStreamAsync(streamC)).Count.ShouldBe(3);
+        (await query.Events.FetchStreamAsync(streamA, token: TestContext.Current.CancellationToken)).Count.ShouldBe(2);
+        (await query.Events.FetchStreamAsync(streamB, token: TestContext.Current.CancellationToken)).Count.ShouldBe(1);
+        (await query.Events.FetchStreamAsync(streamC, token: TestContext.Current.CancellationToken)).Count.ShouldBe(3);
     }
 }

--- a/src/TenantPartitionedEventsTests/AppendWrite/timestamp_source_per_append_mode.cs
+++ b/src/TenantPartitionedEventsTests/AppendWrite/timestamp_source_per_append_mode.cs
@@ -75,11 +75,11 @@ public class timestamp_source_per_append_mode
             // Use the IEvent envelope to set Timestamp explicitly.
             var envelope = new Event<TickEvent>(new TickEvent("alpha")) { Timestamp = bogus };
             session.Events.StartStream(streamId, envelope);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = store.QuerySession("tq");
-        var fetched = await query.Events.FetchStreamAsync(streamId);
+        var fetched = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         var serverTs = fetched.Single().Timestamp;
 
         serverTs.Year.ShouldBeGreaterThan(2000,
@@ -103,11 +103,11 @@ public class timestamp_source_per_append_mode
         {
             var envelope = new Event<TickEvent>(new TickEvent("beta")) { Timestamp = caller };
             session.Events.StartStream(streamId, envelope);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = store.QuerySession("tqst");
-        var fetched = await query.Events.FetchStreamAsync(streamId);
+        var fetched = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         var roundTripped = fetched.Single().Timestamp;
 
         // Postgres timestamp-with-time-zone has microsecond precision; the

--- a/src/TenantPartitionedEventsTests/Config/schema_groundwork_for_partitioned_events.cs
+++ b/src/TenantPartitionedEventsTests/Config/schema_groundwork_for_partitioned_events.cs
@@ -216,16 +216,16 @@ public class schema_groundwork_for_partitioned_events
         // works post-creation; this is the simpler-to-assert ordering.)
         await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "alpha", "beta");
 
-        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         // Live table inspection by fetching directly via the connection — Weasel's
         // FetchExistingAsync returns the materialized table state including its
         // current partition list.
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         var eventsTable = new Table(new PostgresqlObjectName(schema, "mt_events"));
-        var liveEvents = await eventsTable.FetchExistingAsync(conn);
+        var liveEvents = await eventsTable.FetchExistingAsync(conn, TestContext.Current.CancellationToken);
         liveEvents.ShouldNotBeNull("mt_events should exist after EnsureStorageExistsAsync");
 
         var liveEventsPartitioning = liveEvents.Partitioning.ShouldBeOfType<ListPartitioning>();
@@ -234,7 +234,7 @@ public class schema_groundwork_for_partitioned_events
             .ShouldBe(new[] { "alpha", "beta" });
 
         var streamsTable = new Table(new PostgresqlObjectName(schema, "mt_streams"));
-        var liveStreams = await streamsTable.FetchExistingAsync(conn);
+        var liveStreams = await streamsTable.FetchExistingAsync(conn, TestContext.Current.CancellationToken);
         liveStreams.ShouldNotBeNull("mt_streams should exist after EnsureStorageExistsAsync");
 
         var liveStreamsPartitioning = liveStreams.Partitioning.ShouldBeOfType<ListPartitioning>();

--- a/src/TenantPartitionedEventsTests/Daemon/daemon_in_depth_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/daemon_in_depth_under_partitioning.cs
@@ -84,7 +84,7 @@ public class daemon_in_depth_under_partitioning
         // alpha's doc lands (3 events: 1 StartStream + 2 TripLeg(1.0) = 2.0 distance).
         await using (var session = _fixture.Store.QuerySession(alpha))
         {
-            var alphaDoc = await session.LoadAsync<TripDistance>(alphaStreamId);
+            var alphaDoc = await session.LoadAsync<TripDistance>(alphaStreamId, TestContext.Current.CancellationToken);
             alphaDoc.ShouldNotBeNull(
                 "alpha's projection doc must materialize after the per-tenant rebuild");
             alphaDoc.Distance.ShouldBe(2.0,
@@ -94,7 +94,7 @@ public class daemon_in_depth_under_partitioning
         // beta's doc must NOT exist — its events were never replayed.
         await using (var session = _fixture.Store.QuerySession(beta))
         {
-            var betaDoc = await session.LoadAsync<TripDistance>(betaStreamId);
+            var betaDoc = await session.LoadAsync<TripDistance>(betaStreamId, TestContext.Current.CancellationToken);
             betaDoc.ShouldBeNull(
                 "beta's events must stay unprojected — the rebuild was scoped to alpha");
         }
@@ -121,7 +121,7 @@ public class daemon_in_depth_under_partitioning
         // somehow materialize a tombstone or empty aggregate.
         await using (var session = _fixture.Store.QuerySession(emptyTenant))
         {
-            var anyDocs = await session.Query<TripDistance>().AnyAsync();
+            var anyDocs = await session.Query<TripDistance>().AnyAsync(TestContext.Current.CancellationToken);
             anyDocs.ShouldBeFalse(
                 "a no-event rebuild must materialize zero docs — not a placeholder or tombstone");
         }

--- a/src/TenantPartitionedEventsTests/Daemon/dynamic_tenant_lifecycle_during_continuous_daemon.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/dynamic_tenant_lifecycle_during_continuous_daemon.cs
@@ -101,8 +101,8 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
         // another node) are what the coordinator has to discover.
         using var store = (DocumentStore)DocumentStore.For(Configure);
 
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
-        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         // ---- Phase 0: two initial tenants with different heights, daemon host started AFTER seeding ----
         const string tenantA = "dynlife_a";
@@ -116,7 +116,7 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
             .ConfigureServices(services =>
             {
                 services.AddMarten(Configure).AddAsyncDaemon(DaemonMode.Solo);
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
         var daemon = node.Services.GetRequiredService<IProjectionCoordinator>().DaemonForMainDatabase();
 
         try
@@ -168,7 +168,7 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
             // And the projection itself materialized for the new tenant — without any restart.
             await using (var query = store.QuerySession(tenantC))
             {
-                var doc = await query.LoadAsync<DynCounter>(streamC);
+                var doc = await query.LoadAsync<DynCounter>(streamC, TestContext.Current.CancellationToken);
                 doc.ShouldNotBeNull();
                 doc.Count.ShouldBe(2);
             }
@@ -176,7 +176,7 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
             // The original tenants were untouched by the dynamic add.
             await using (var query = store.QuerySession(tenantA))
             {
-                (await query.LoadAsync<DynCounter>(streamA))!.Count.ShouldBe(4);
+                (await query.LoadAsync<DynCounter>(streamA, TestContext.Current.CancellationToken))!.Count.ShouldBe(4);
             }
 
             // ---- Phase 2: remove a tenant while the coordinator keeps running ----
@@ -200,7 +200,7 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
             // cycles: the reaped agent no longer advances a progression row, and StopAgentAsync's
             // syncTenantPolling drops B from the vectorized polled set so no HighWaterMark:B row is
             // ever re-persisted.
-            await Task.Delay(2.Seconds());
+            await Task.Delay(2.Seconds(), TestContext.Current.CancellationToken);
             var finalRows = await ProgressionRowsAsync();
             DumpRows("after removing tenant B", finalRows);
             finalRows.Any(r => r.Name == $"{DynLifeProjection.ProjectionName}:All:{tenantB}").ShouldBeFalse(
@@ -215,7 +215,7 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
         }
         finally
         {
-            await node.StopAsync();
+            await node.StopAsync(TestContext.Current.CancellationToken);
         }
     }
 

--- a/src/TenantPartitionedEventsTests/Daemon/multi_node_hotcold_single_database_partitioned_events.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/multi_node_hotcold_single_database_partitioned_events.cs
@@ -113,8 +113,8 @@ public partial class multi_node_hotcold_single_database_partitioned_events
 
         using (var bootstrap = (DocumentStore)DocumentStore.For(Configure))
         {
-            await bootstrap.Advanced.Clean.CompletelyRemoveAllAsync();
-            await bootstrap.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+            await bootstrap.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+            await bootstrap.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
             await bootstrap.Advanced.AddMartenManagedTenantsAsync(
                 CancellationToken.None, tenants.Keys.ToArray());
 
@@ -127,7 +127,7 @@ public partial class multi_node_hotcold_single_database_partitioned_events
                     .Concat(Enumerable.Range(0, legs).Select(_ => (object)new HcLeg(1.0)))
                     .ToArray();
                 session.Events.StartStream<HcTrip>(id, events);
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
         }
 
@@ -214,18 +214,18 @@ public partial class multi_node_hotcold_single_database_partitioned_events
             foreach (var (tenant, legs) in tenants)
             {
                 await using var query = verify.QuerySession(tenant);
-                var trip = await query.LoadAsync<HcTrip>(streams[tenant]);
+                var trip = await query.LoadAsync<HcTrip>(streams[tenant], TestContext.Current.CancellationToken);
                 trip.ShouldNotBeNull($"tenant {tenant}'s HcTrip projection doc must materialize");
                 trip!.Distance.ShouldBe(legs);
-                var tally = await query.LoadAsync<HcTally>(streams[tenant]);
+                var tally = await query.LoadAsync<HcTally>(streams[tenant], TestContext.Current.CancellationToken);
                 tally.ShouldNotBeNull($"tenant {tenant}'s HcTally projection doc must materialize");
                 tally!.Count.ShouldBe(legs);
             }
         }
         finally
         {
-            await nodeA.StopAsync();
-            await nodeB.StopAsync();
+            await nodeA.StopAsync(TestContext.Current.CancellationToken);
+            await nodeB.StopAsync(TestContext.Current.CancellationToken);
         }
     }
 

--- a/src/TenantPartitionedEventsTests/Daemon/per_tenant_progression_keying.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/per_tenant_progression_keying.cs
@@ -62,7 +62,7 @@ public class per_tenant_progression_keying
                 new EventRange(alphaName, floor: 0, ceiling: 17, agent: null!)));
             session.QueueOperation(new InsertProjectionProgress(_fixture.Store.Options.EventGraph,
                 new EventRange(betaName, floor: 0, ceiling: 42, agent: null!)));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // The PK is single-column (name); the two ShardName identities are
@@ -92,7 +92,7 @@ public class per_tenant_progression_keying
         {
             session.QueueOperation(new InsertProjectionProgress(_fixture.Store.Options.EventGraph,
                 new EventRange(globalName, floor: 0, ceiling: 99, agent: null!)));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var rows = await _fixture.ReadProgressionRowsAsync(_fixture.SchemaName, projection);
@@ -118,7 +118,7 @@ public class per_tenant_progression_keying
                 new EventRange(alphaName, floor: 0, ceiling: 10, agent: null!)));
             session.QueueOperation(new InsertProjectionProgress(_fixture.Store.Options.EventGraph,
                 new EventRange(betaName, floor: 0, ceiling: 20, agent: null!)));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Bump only alpha's row from 10 → 25. Because the `name` column carries
@@ -128,7 +128,7 @@ public class per_tenant_progression_keying
         {
             session.QueueOperation(new UpdateProjectionProgress(_fixture.Store.Options.EventGraph,
                 new EventRange(alphaName, floor: 10, ceiling: 25, agent: null!)));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var rows = await _fixture.ReadProgressionRowsAsync(_fixture.SchemaName, projection);
@@ -154,7 +154,7 @@ public class per_tenant_progression_keying
                 new EventRange(alphaName, floor: 0, ceiling: 10, agent: null!)));
             session.QueueOperation(new InsertProjectionProgress(_fixture.Store.Options.EventGraph,
                 new EventRange(betaName, floor: 0, ceiling: 20, agent: null!)));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = (Marten.Internal.Sessions.DocumentSessionBase)_fixture.Store.LightweightSession(alpha))
@@ -163,7 +163,7 @@ public class per_tenant_progression_keying
             // single-arg DeleteProjectionProgress already scopes correctly
             // because the name column carries the tenant suffix.
             session.QueueOperation(new DeleteProjectionProgress(_fixture.Store.Options.EventGraph, alphaName.Identity));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var rows = await _fixture.ReadProgressionRowsAsync(_fixture.SchemaName, projection);

--- a/src/TenantPartitionedEventsTests/Daemon/per_tenant_rebuild_cancellation.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/per_tenant_rebuild_cancellation.cs
@@ -88,7 +88,7 @@ public class per_tenant_rebuild_cancellation: IAsyncLifetime
                     Enumerable.Range(0, eventCount / 4).Select(_ => (object)new TallyEvent()).ToArray());
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Arm the gate BEFORE the rebuild starts: the first ApplyAsync signals Started
@@ -103,7 +103,7 @@ public class per_tenant_rebuild_cancellation: IAsyncLifetime
             GatedPerEventProjection.ProjectionName, tenant, cts.Token);
 
         // Deterministically in-flight: the first apply has started and is parked on the gate.
-        (await Task.WhenAny(GatedPerEventProjection.Started.Task, Task.Delay(TimeSpan.FromSeconds(60))))
+        (await Task.WhenAny(GatedPerEventProjection.Started.Task, Task.Delay(TimeSpan.FromSeconds(60), TestContext.Current.CancellationToken)))
             .ShouldBe(GatedPerEventProjection.Started.Task, "rebuild never reached the projection");
 
         cts.Cancel();
@@ -138,7 +138,7 @@ public class per_tenant_rebuild_cancellation: IAsyncLifetime
 
         await using (var query = _store.QuerySession(tenant))
         {
-            (await query.Query<TallyDoc>().CountAsync()).ShouldBe(eventCount,
+            (await query.Query<TallyDoc>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(eventCount,
                 "the follow-up rebuild must fully materialize the cell");
         }
     }
@@ -152,7 +152,7 @@ public class per_tenant_rebuild_cancellation: IAsyncLifetime
         await using (var session = _store.LightweightSession(tenant))
         {
             session.Events.StartStream(Guid.NewGuid(), new TallyEvent(), new TallyEvent());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         GatedPerEventProjection.Gate = null;
@@ -177,7 +177,7 @@ public class per_tenant_rebuild_cancellation: IAsyncLifetime
             CancellationToken.None);
 
         await using var query = _store.QuerySession(tenant);
-        (await query.Query<TallyDoc>().CountAsync()).ShouldBe(2);
+        (await query.Query<TallyDoc>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(2);
     }
 
     private async Task<IReadOnlyList<long>> ReadCellProgressionsAsync(string tenantId)

--- a/src/TenantPartitionedEventsTests/Daemon/per_tenant_rebuild_isolation.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/per_tenant_rebuild_isolation.cs
@@ -63,14 +63,14 @@ public class per_tenant_rebuild_isolation
         {
             session.Events.StartStream<TripDistance>(alphaStreamId,
                 new TripStarted(alphaStreamId), new TripLeg(10), new TripLeg(20));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = _fixture.Store.LightweightSession(beta))
         {
             session.Events.StartStream<TripDistance>(betaStreamId,
                 new TripStarted(betaStreamId), new TripLeg(7), new TripLeg(13));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Drive the projection forward on both tenants. Use per-tenant
@@ -96,11 +96,11 @@ public class per_tenant_rebuild_isolation
         TripDistance betaBefore;
         await using (var session = _fixture.Store.QuerySession(alpha))
         {
-            alphaBefore = await session.LoadAsync<TripDistance>(alphaStreamId);
+            alphaBefore = await session.LoadAsync<TripDistance>(alphaStreamId, TestContext.Current.CancellationToken);
         }
         await using (var session = _fixture.Store.QuerySession(beta))
         {
-            betaBefore = await session.LoadAsync<TripDistance>(betaStreamId);
+            betaBefore = await session.LoadAsync<TripDistance>(betaStreamId, TestContext.Current.CancellationToken);
         }
         alphaBefore.ShouldNotBeNull("alpha's projection should have materialised before the per-tenant reset");
         alphaBefore.Distance.ShouldBe(30, "alpha starts at 10 + 20 = 30 miles");
@@ -127,12 +127,12 @@ public class per_tenant_rebuild_isolation
         // Alpha's doc should be GONE; beta's must be byte-identical.
         await using (var session = _fixture.Store.QuerySession(alpha))
         {
-            (await session.LoadAsync<TripDistance>(alphaStreamId))
+            (await session.LoadAsync<TripDistance>(alphaStreamId, TestContext.Current.CancellationToken))
                 .ShouldBeNull("alpha's projected doc must be wiped by the tenant-scoped teardown");
         }
         await using (var session = _fixture.Store.QuerySession(beta))
         {
-            var betaAfter = await session.LoadAsync<TripDistance>(betaStreamId);
+            var betaAfter = await session.LoadAsync<TripDistance>(betaStreamId, TestContext.Current.CancellationToken);
             betaAfter.ShouldNotBeNull("beta's doc must survive — its tenant slot was never named");
             betaAfter!.Distance.ShouldBe(betaBefore.Distance,
                 "beta's projection state must be byte-identical pre/post the per-tenant teardown");

--- a/src/TenantPartitionedEventsTests/Daemon/vectorized_high_water_detection.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/vectorized_high_water_detection.cs
@@ -177,11 +177,11 @@ public class vectorized_high_water_detection
 
         await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
         {
-            await conn.OpenAsync();
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
             // last_value → 1 (is_called=false): what the sharded/global-sequence/bulk path leaves behind.
             await using var reset = new NpgsqlCommand(
                 $"select setval('{_fixture.SchemaName}.mt_events_sequence_{tenant}', 1, false)", conn);
-            await reset.ExecuteScalarAsync();
+            await reset.ExecuteScalarAsync(TestContext.Current.CancellationToken);
         }
 
         var detector = new HighWaterDetector(

--- a/src/TenantPartitionedEventsTests/Daemon/vectorized_high_water_flag_off.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/vectorized_high_water_flag_off.cs
@@ -52,7 +52,7 @@ public class vectorized_high_water_flag_off
             o.Events.AddEventType<Probe>();
         });
 
-        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         var detector = new HighWaterDetector(
             (MartenDatabase)store.Storage.Database, store.Options.EventGraph, NullLogger.Instance);
@@ -79,7 +79,7 @@ public class vectorized_high_water_flag_off
             // Per-tenant flag off → TenantPartitions stays null
             o.Events.AddEventType<Probe>();
         });
-        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         var source = (ICrossTenantRebuildSource)store.Storage.Database;
         var tenants = await source.FindRebuildTenantsAsync("AnyProjection", CancellationToken.None);

--- a/src/TenantPartitionedEventsTests/Dcb/dcb_concurrency_replay_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Dcb/dcb_concurrency_replay_under_partitioning.cs
@@ -110,7 +110,7 @@ public class dcb_concurrency_replay_under_partitioning
             var enrolled = seedSession.Events.BuildEvent(new DcbReplayStudentEnrolled("Seed", "Math"));
             enrolled.WithTag(seedStudentId, courseId);
             seedSession.Events.Append(seedStudentId.Value, enrolled);
-            await seedSession.SaveChangesAsync();
+            await seedSession.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Synchronize the fetch → save handoff so every racer captures the

--- a/src/TenantPartitionedEventsTests/Dcb/dcb_cross_tenant_query_isolation_pin.cs
+++ b/src/TenantPartitionedEventsTests/Dcb/dcb_cross_tenant_query_isolation_pin.cs
@@ -110,7 +110,7 @@ public class dcb_cross_tenant_query_isolation_pin : IAsyncLifetime
             var evt = session.Events.BuildEvent(new DcbXtPayment("ALPHA-PAYMENT"));
             evt.WithTag(sharedCustomer);
             session.Events.Append(Guid.NewGuid(), evt);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = _store.LightweightSession("beta"))
@@ -118,13 +118,13 @@ public class dcb_cross_tenant_query_isolation_pin : IAsyncLifetime
             var evt = session.Events.BuildEvent(new DcbXtPayment("BETA-PAYMENT"));
             evt.WithTag(sharedCustomer);
             session.Events.Append(Guid.NewGuid(), evt);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var query = new EventTagQuery().Or<DcbXtCustomerId>(sharedCustomer);
 
         await using var alphaQuery = _store.LightweightSession("alpha");
-        var events = await alphaQuery.Events.QueryByTagsAsync(query);
+        var events = await alphaQuery.Events.QueryByTagsAsync(query, TestContext.Current.CancellationToken);
 
         // Exactly one row — alpha's own event. The fix to EventStore.Dcb.cs:
         // adding `AND e.tenant_id = t.tenant_id` to the JOIN means alpha's

--- a/src/TenantPartitionedEventsTests/Dcb/dcb_tag_append_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Dcb/dcb_tag_append_under_partitioning.cs
@@ -105,7 +105,7 @@ public class dcb_tag_append_under_partitioning : IAsyncLifetime
             var evt = session.Events.BuildEvent(new DcbOrderPlaced("widget"));
             evt.WithTag(orderRef);
             session.Events.Append(Guid.NewGuid(), evt);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Direct schema-level probe: the tag row exists for alpha. PK on this
@@ -113,12 +113,12 @@ public class dcb_tag_append_under_partitioning : IAsyncLifetime
         // (value, tenant_id) projection reads the recorded row independent of
         // seq_id.
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
         await using var cmd = conn.CreateCommand(
             $"select count(*) from {_schema}.mt_event_tag_dcb_order_ref where value = :v and tenant_id = :t");
         cmd.Parameters.AddWithValue("v", orderRef.Value);
         cmd.Parameters.AddWithValue("t", "alpha");
-        var count = (long)(await cmd.ExecuteScalarAsync())!;
+        var count = (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
         count.ShouldBe(1L,
             "the DCB tag row must land in mt_event_tag_* alongside the partitioned mt_events row");
     }
@@ -152,14 +152,14 @@ public class dcb_tag_append_under_partitioning : IAsyncLifetime
             var evt = session.Events.BuildEvent(new DcbOrderPlaced("alpha-widget"));
             evt.WithTag(orderRef);
             session.Events.Append(Guid.NewGuid(), evt);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var query = new EventTagQuery().Or<DcbOrderRef>(orderRef);
 
         await using (var queryA = _store.LightweightSession("alpha"))
         {
-            var events = await queryA.Events.QueryByTagsAsync(query);
+            var events = await queryA.Events.QueryByTagsAsync(query, TestContext.Current.CancellationToken);
             events.Count.ShouldBe(1,
                 "alpha must see its own tagged event via the partitioned mt_events + mt_event_tag_* JOIN");
             events[0].Data.ShouldBeOfType<DcbOrderPlaced>().Product.ShouldBe("alpha-widget");

--- a/src/TenantPartitionedEventsTests/Migration/conjoined_to_partitioned_migration.cs
+++ b/src/TenantPartitionedEventsTests/Migration/conjoined_to_partitioned_migration.cs
@@ -150,7 +150,7 @@ public class conjoined_to_partitioned_migration: IAsyncLifetime
         await using (var session = _source.LightweightSession(archivedTenant))
         {
             session.Events.ArchiveStream(streams[archivedTenant]);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var migration = new ConjoinedToPartitionedMigration(_source, _target)
@@ -159,7 +159,7 @@ public class conjoined_to_partitioned_migration: IAsyncLifetime
         };
 
         // Phase 1 — the dry-run inventory matches the seeded reality and moves nothing.
-        var plan = await migration.BuildPlanAsync();
+        var plan = await migration.BuildPlanAsync(TestContext.Current.CancellationToken);
         plan.Tenants.Count.ShouldBe(3);
         plan.TotalEvents.ShouldBe(12); // 3 tenants x (1 Started + 3 Progressed)
         foreach (var item in plan.Tenants)
@@ -177,7 +177,7 @@ public class conjoined_to_partitioned_migration: IAsyncLifetime
         }
 
         // Phase 2 — execute.
-        var result = await migration.ExecuteAsync();
+        var result = await migration.ExecuteAsync(TestContext.Current.CancellationToken);
         result.MigratedTenants.Count.ShouldBe(3);
         result.SkippedTenants.ShouldBeEmpty();
         result.EventsCopied.ShouldBe(12);
@@ -236,7 +236,7 @@ public class conjoined_to_partitioned_migration: IAsyncLifetime
                 session.Events.Append(streams[tenant], new Progressed(99));
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var after = await seqIdsAsync(_targetSchema, tenant);
             after.Count.ShouldBe(5);
@@ -246,7 +246,7 @@ public class conjoined_to_partitioned_migration: IAsyncLifetime
         // Reading the migrated stream back through the TARGET store yields the same events in order.
         await using (var query = _target.QuerySession(tenants[1]))
         {
-            var fetched = await query.Events.FetchStreamAsync(streams[tenants[1]]);
+            var fetched = await query.Events.FetchStreamAsync(streams[tenants[1]], token: TestContext.Current.CancellationToken);
             fetched.Count.ShouldBe(5); // 4 migrated + 1 live append
             fetched[0].Data.ShouldBeOfType<Started>().Id.ShouldBe(streams[tenants[1]]);
             fetched.Take(4).Select(x => x.Version).ShouldBe(new long[] { 1, 2, 3, 4 });
@@ -256,7 +256,7 @@ public class conjoined_to_partitioned_migration: IAsyncLifetime
         var secondRun = await new ConjoinedToPartitionedMigration(_source, _target)
         {
             TenantIds = tenants
-        }.ExecuteAsync();
+        }.ExecuteAsync(TestContext.Current.CancellationToken);
 
         secondRun.MigratedTenants.ShouldBeEmpty();
         secondRun.SkippedTenants.Count.ShouldBe(3);
@@ -276,7 +276,7 @@ public class conjoined_to_partitioned_migration: IAsyncLifetime
         var result = await new ConjoinedToPartitionedMigration(_source, _target)
         {
             TenantIds = new[] { wanted }
-        }.ExecuteAsync();
+        }.ExecuteAsync(TestContext.Current.CancellationToken);
 
         result.MigratedTenants.ShouldBe(new[] { wanted });
         (await seqIdsAsync(_targetSchema, wanted)).Count.ShouldBe(2);

--- a/src/TenantPartitionedEventsTests/OptimisticConcurrency/Optimistic_concurrency_under_partitioned_events.cs
+++ b/src/TenantPartitionedEventsTests/OptimisticConcurrency/Optimistic_concurrency_under_partitioned_events.cs
@@ -55,20 +55,20 @@ public class Optimistic_concurrency_under_partitioned_events_guid
         await using (var seed = _fixture.Store.LightweightSession(tenant))
         {
             seed.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId), new TripLeg(1));
-            await seed.SaveChangesAsync();
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // The canonical aggregate-handler shape: load, decide, append.
         // Pre-#4614, the SaveChangesAsync below threw NotSupportedException —
         // this assertion is the headline regression-guard.
         await using var session = _fixture.Store.LightweightSession(tenant);
-        var stream = await session.Events.FetchForWriting<TripSnapshot>(streamId);
+        var stream = await session.Events.FetchForWriting<TripSnapshot>(streamId, TestContext.Current.CancellationToken);
         stream.AppendOne(new TripLeg(2));
         stream.AppendOne(new TripLeg(3));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(4); // TripStarted + 3 TripLegs
     }
 
@@ -85,13 +85,13 @@ public class Optimistic_concurrency_under_partitioned_events_guid
 
         var streamId = Guid.NewGuid();
         await using var session = _fixture.Store.LightweightSession(tenant);
-        var stream = await session.Events.FetchForWriting<TripSnapshot>(streamId);
+        var stream = await session.Events.FetchForWriting<TripSnapshot>(streamId, TestContext.Current.CancellationToken);
         stream.AppendOne(new TripStarted(streamId));
         stream.AppendOne(new TripLeg(5));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(2);
     }
 
@@ -111,20 +111,20 @@ public class Optimistic_concurrency_under_partitioned_events_guid
         await using (var seed = _fixture.Store.LightweightSession(tenant))
         {
             seed.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
-            await seed.SaveChangesAsync();
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Session A loads — sees version 1.
         await using var sessionA = _fixture.Store.LightweightSession(tenant);
-        var streamA = await sessionA.Events.FetchForWriting<TripSnapshot>(streamId);
+        var streamA = await sessionA.Events.FetchForWriting<TripSnapshot>(streamId, TestContext.Current.CancellationToken);
 
         // Session B writes a competing event behind A's back — bumps the stream
         // to version 2.
         await using (var sessionB = _fixture.Store.LightweightSession(tenant))
         {
-            var streamB = await sessionB.Events.FetchForWriting<TripSnapshot>(streamId);
+            var streamB = await sessionB.Events.FetchForWriting<TripSnapshot>(streamId, TestContext.Current.CancellationToken);
             streamB.AppendOne(new TripLeg(10));
-            await sessionB.SaveChangesAsync();
+            await sessionB.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Now A tries to commit — its ExpectedVersionOnServer is 1, but the
@@ -145,15 +145,15 @@ public class Optimistic_concurrency_under_partitioned_events_guid
         await using (var seed = _fixture.Store.LightweightSession(tenant))
         {
             seed.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId), new TripLeg(1));
-            await seed.SaveChangesAsync();
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var session = _fixture.Store.LightweightSession(tenant);
         await session.Events.AppendOptimistic(streamId, new TripLeg(2));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        (await query.Events.FetchStreamAsync(streamId)).Count.ShouldBe(3);
+        (await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken)).Count.ShouldBe(3);
     }
 
     [Fact]
@@ -187,13 +187,13 @@ public class Optimistic_concurrency_under_partitioned_events_guid
         await using (var seed = _fixture.Store.LightweightSession(tenant))
         {
             seed.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
-            await seed.SaveChangesAsync();
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = _fixture.Store.LightweightSession(tenant))
         {
             await session.Events.AppendExclusive(streamId, new TripLeg(7));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // A follow-up plain append on the same tenant proves the prior session
@@ -201,11 +201,11 @@ public class Optimistic_concurrency_under_partitioned_events_guid
         await using (var session = _fixture.Store.LightweightSession(tenant))
         {
             session.Events.Append(streamId, new TripLeg(8));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        (await query.Events.FetchStreamAsync(streamId)).Count.ShouldBe(3);
+        (await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken)).Count.ShouldBe(3);
     }
 
     [Fact]
@@ -224,25 +224,25 @@ public class Optimistic_concurrency_under_partitioned_events_guid
         await using (var seedA = _fixture.Store.LightweightSession(tenantA))
         {
             seedA.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
-            await seedA.SaveChangesAsync();
+            await seedA.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var seedB = _fixture.Store.LightweightSession(tenantB))
         {
             seedB.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
-            await seedB.SaveChangesAsync();
+            await seedB.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Each tenant's FetchForWriting reads its own stream — both at version 1.
         // Both append concurrently — both succeed.
         await using var sessionA = _fixture.Store.LightweightSession(tenantA);
-        var streamA = await sessionA.Events.FetchForWriting<TripSnapshot>(streamId);
+        var streamA = await sessionA.Events.FetchForWriting<TripSnapshot>(streamId, TestContext.Current.CancellationToken);
         await using var sessionB = _fixture.Store.LightweightSession(tenantB);
-        var streamB = await sessionB.Events.FetchForWriting<TripSnapshot>(streamId);
+        var streamB = await sessionB.Events.FetchForWriting<TripSnapshot>(streamId, TestContext.Current.CancellationToken);
 
         streamA.AppendOne(new TripLeg(1));
         streamB.AppendOne(new TripLeg(2));
 
-        await sessionA.SaveChangesAsync();
-        await sessionB.SaveChangesAsync(); // would throw if version check leaked across tenants
+        await sessionA.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await sessionB.SaveChangesAsync(TestContext.Current.CancellationToken); // would throw if version check leaked across tenants
     }
 }

--- a/src/TenantPartitionedEventsTests/OptimisticConcurrency/Optimistic_concurrency_under_partitioned_events_string.cs
+++ b/src/TenantPartitionedEventsTests/OptimisticConcurrency/Optimistic_concurrency_under_partitioned_events_string.cs
@@ -60,20 +60,20 @@ public class Optimistic_concurrency_under_partitioned_events_string
         await using (var seed = _fixture.Store.LightweightSession(tenant))
         {
             seed.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId), new StringTripLeg(1));
-            await seed.SaveChangesAsync();
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // The canonical aggregate-handler shape: load, decide, append.
         // Pre-#4614, the SaveChangesAsync below threw NotSupportedException —
         // this assertion is the headline regression-guard.
         await using var session = _fixture.Store.LightweightSession(tenant);
-        var stream = await session.Events.FetchForWriting<StringTripSnapshot>(streamId);
+        var stream = await session.Events.FetchForWriting<StringTripSnapshot>(streamId, TestContext.Current.CancellationToken);
         stream.AppendOne(new StringTripLeg(2));
         stream.AppendOne(new StringTripLeg(3));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(4); // TripStarted + 3 TripLegs
     }
 
@@ -90,13 +90,13 @@ public class Optimistic_concurrency_under_partitioned_events_string
 
         var streamId = NewStream();
         await using var session = _fixture.Store.LightweightSession(tenant);
-        var stream = await session.Events.FetchForWriting<StringTripSnapshot>(streamId);
+        var stream = await session.Events.FetchForWriting<StringTripSnapshot>(streamId, TestContext.Current.CancellationToken);
         stream.AppendOne(new StringTripStarted(streamId));
         stream.AppendOne(new StringTripLeg(5));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var events = await query.Events.FetchStreamAsync(streamId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(2);
     }
 
@@ -116,20 +116,20 @@ public class Optimistic_concurrency_under_partitioned_events_string
         await using (var seed = _fixture.Store.LightweightSession(tenant))
         {
             seed.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId));
-            await seed.SaveChangesAsync();
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Session A loads — sees version 1.
         await using var sessionA = _fixture.Store.LightweightSession(tenant);
-        var streamA = await sessionA.Events.FetchForWriting<StringTripSnapshot>(streamId);
+        var streamA = await sessionA.Events.FetchForWriting<StringTripSnapshot>(streamId, TestContext.Current.CancellationToken);
 
         // Session B writes a competing event behind A's back — bumps the stream
         // to version 2.
         await using (var sessionB = _fixture.Store.LightweightSession(tenant))
         {
-            var streamB = await sessionB.Events.FetchForWriting<StringTripSnapshot>(streamId);
+            var streamB = await sessionB.Events.FetchForWriting<StringTripSnapshot>(streamId, TestContext.Current.CancellationToken);
             streamB.AppendOne(new StringTripLeg(10));
-            await sessionB.SaveChangesAsync();
+            await sessionB.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Now A tries to commit — its ExpectedVersionOnServer is 1, but the
@@ -150,15 +150,15 @@ public class Optimistic_concurrency_under_partitioned_events_string
         await using (var seed = _fixture.Store.LightweightSession(tenant))
         {
             seed.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId), new StringTripLeg(1));
-            await seed.SaveChangesAsync();
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var session = _fixture.Store.LightweightSession(tenant);
         await session.Events.AppendOptimistic(streamId, new StringTripLeg(2));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        (await query.Events.FetchStreamAsync(streamId)).Count.ShouldBe(3);
+        (await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken)).Count.ShouldBe(3);
     }
 
     [Fact]
@@ -192,13 +192,13 @@ public class Optimistic_concurrency_under_partitioned_events_string
         await using (var seed = _fixture.Store.LightweightSession(tenant))
         {
             seed.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId));
-            await seed.SaveChangesAsync();
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = _fixture.Store.LightweightSession(tenant))
         {
             await session.Events.AppendExclusive(streamId, new StringTripLeg(7));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // A follow-up plain append on the same tenant proves the prior session
@@ -206,11 +206,11 @@ public class Optimistic_concurrency_under_partitioned_events_string
         await using (var session = _fixture.Store.LightweightSession(tenant))
         {
             session.Events.Append(streamId, new StringTripLeg(8));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        (await query.Events.FetchStreamAsync(streamId)).Count.ShouldBe(3);
+        (await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken)).Count.ShouldBe(3);
     }
 
     [Fact]
@@ -229,25 +229,25 @@ public class Optimistic_concurrency_under_partitioned_events_string
         await using (var seedA = _fixture.Store.LightweightSession(tenantA))
         {
             seedA.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId));
-            await seedA.SaveChangesAsync();
+            await seedA.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var seedB = _fixture.Store.LightweightSession(tenantB))
         {
             seedB.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId));
-            await seedB.SaveChangesAsync();
+            await seedB.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Each tenant's FetchForWriting reads its own stream — both at version 1.
         // Both append concurrently — both succeed.
         await using var sessionA = _fixture.Store.LightweightSession(tenantA);
-        var streamA = await sessionA.Events.FetchForWriting<StringTripSnapshot>(streamId);
+        var streamA = await sessionA.Events.FetchForWriting<StringTripSnapshot>(streamId, TestContext.Current.CancellationToken);
         await using var sessionB = _fixture.Store.LightweightSession(tenantB);
-        var streamB = await sessionB.Events.FetchForWriting<StringTripSnapshot>(streamId);
+        var streamB = await sessionB.Events.FetchForWriting<StringTripSnapshot>(streamId, TestContext.Current.CancellationToken);
 
         streamA.AppendOne(new StringTripLeg(1));
         streamB.AppendOne(new StringTripLeg(2));
 
-        await sessionA.SaveChangesAsync();
-        await sessionB.SaveChangesAsync(); // would throw if version check leaked across tenants
+        await sessionA.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await sessionB.SaveChangesAsync(TestContext.Current.CancellationToken); // would throw if version check leaked across tenants
     }
 }

--- a/src/TenantPartitionedEventsTests/Projections/add_global_projection_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Projections/add_global_projection_under_partitioning.cs
@@ -102,20 +102,20 @@ public class add_global_projection_under_partitioning : IAsyncLifetime
         {
             alpha.Events.StartStream<GlobalCounter>(globalId,
                 new GlobalTickEvent("first"), new GlobalTickEvent("second"));
-            await alpha.SaveChangesAsync();
+            await alpha.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var beta = _store.LightweightSession("beta"))
         {
             beta.Events.Append(globalId, new GlobalTickEvent("third"));
-            await beta.SaveChangesAsync();
+            await beta.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // The inline global projection doc is single-tenanted, so it reads the
         // same from any tenant's session — and reflects BOTH tenants' appends
         await using (var reader = _store.QuerySession("beta"))
         {
-            var counter = await reader.LoadAsync<GlobalCounter>(globalId);
+            var counter = await reader.LoadAsync<GlobalCounter>(globalId, TestContext.Current.CancellationToken);
             counter.ShouldNotBeNull();
             counter.TickCount.ShouldBe(3);
         }
@@ -123,16 +123,16 @@ public class add_global_projection_under_partitioning : IAsyncLifetime
         // The storage-level shape: the default tenant slot is registered with the
         // reserved suffix and all three events live in its partition
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         var suffix = (string?)await conn.CreateCommand(
                 $"select partition_suffix from {_schema}.mt_tenant_partitions where partition_value = '{StorageConstants.DefaultTenantId}'")
-            .ExecuteScalarAsync();
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken);
         suffix.ShouldBe("__default__");
 
         var eventCount = (long)(await conn.CreateCommand(
                 $"select count(*) from {_schema}.mt_events___default__")
-            .ExecuteScalarAsync())!;
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
         eventCount.ShouldBe(3);
     }
 

--- a/src/TenantPartitionedEventsTests/Projections/custom_aggregate_grouper_per_tenant.cs
+++ b/src/TenantPartitionedEventsTests/Projections/custom_aggregate_grouper_per_tenant.cs
@@ -109,7 +109,7 @@ public class custom_aggregate_grouper_per_tenant : IAsyncLifetime
         {
             session.Events.StartStream(alphaCustomer, new CustomerRegistered(alphaCustomer, "Alpha Inc"));
             session.Events.Append(alphaCustomer, new CustomerLinkedToExternalAccount(alphaCustomer, sharedExternalId));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var session = _store.LightweightSession("alpha"))
         {
@@ -118,7 +118,7 @@ public class custom_aggregate_grouper_per_tenant : IAsyncLifetime
                 new ShippingLabelCreated(sharedExternalId),
                 new ShippingLabelCreated(sharedExternalId),
                 new ShippingLabelCreated(sharedExternalId));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // beta: register a DIFFERENT customer, link to the SAME external id,
@@ -127,7 +127,7 @@ public class custom_aggregate_grouper_per_tenant : IAsyncLifetime
         {
             session.Events.StartStream(betaCustomer, new CustomerRegistered(betaCustomer, "Beta LLC"));
             session.Events.Append(betaCustomer, new CustomerLinkedToExternalAccount(betaCustomer, sharedExternalId));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var session = _store.LightweightSession("beta"))
         {
@@ -138,20 +138,20 @@ public class custom_aggregate_grouper_per_tenant : IAsyncLifetime
                 new ShippingLabelCreated(sharedExternalId),
                 new ShippingLabelCreated(sharedExternalId),
                 new ShippingLabelCreated(sharedExternalId));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Read each tenant's billing doc using a tenant-scoped query. The
         // billing metric is multi-tenanted (per AllDocumentsAreMultiTenanted),
         // so each tenant sees only its own row keyed by its own customer id.
         await using var alphaQuery = _store.QuerySession("alpha");
-        var alphaBilling = await alphaQuery.LoadAsync<CustomerBillingMetrics>(alphaCustomer);
+        var alphaBilling = await alphaQuery.LoadAsync<CustomerBillingMetrics>(alphaCustomer, TestContext.Current.CancellationToken);
         alphaBilling.ShouldNotBeNull("alpha's grouper must have routed alpha's labels to alpha's customer");
         alphaBilling!.ShippingLabels.ShouldBe(3,
             "alpha appended 3 labels — beta's 5 must not bleed in via shared external id");
 
         await using var betaQuery = _store.QuerySession("beta");
-        var betaBilling = await betaQuery.LoadAsync<CustomerBillingMetrics>(betaCustomer);
+        var betaBilling = await betaQuery.LoadAsync<CustomerBillingMetrics>(betaCustomer, TestContext.Current.CancellationToken);
         betaBilling.ShouldNotBeNull("beta's grouper must have routed beta's labels to beta's customer");
         betaBilling!.ShippingLabels.ShouldBe(5,
             "beta appended 5 labels — alpha's 3 must not bleed in via shared external id");
@@ -170,26 +170,26 @@ public class custom_aggregate_grouper_per_tenant : IAsyncLifetime
         {
             session.Events.StartStream(alphaCustomer, new CustomerRegistered(alphaCustomer, "Alpha Inc"));
             session.Events.Append(alphaCustomer, new CustomerLinkedToExternalAccount(alphaCustomer, "EXT-A"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var session = _store.LightweightSession("alpha"))
         {
             var labelStream = Guid.NewGuid();
             session.Events.StartStream(labelStream, new ShippingLabelCreated("EXT-A"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Pin from alpha's own session: doc exists.
         await using (var alphaQuery = _store.QuerySession("alpha"))
         {
-            (await alphaQuery.LoadAsync<CustomerBillingMetrics>(alphaCustomer)).ShouldNotBeNull();
+            (await alphaQuery.LoadAsync<CustomerBillingMetrics>(alphaCustomer, TestContext.Current.CancellationToken)).ShouldNotBeNull();
         }
 
         // Pin from beta's session: alpha's customer id finds nothing — the
         // billing doc is in alpha's tenant slot, beta's tenant slot is empty.
         await using (var betaQuery = _store.QuerySession("beta"))
         {
-            (await betaQuery.LoadAsync<CustomerBillingMetrics>(alphaCustomer))
+            (await betaQuery.LoadAsync<CustomerBillingMetrics>(alphaCustomer, TestContext.Current.CancellationToken))
                 .ShouldBeNull("alpha's billing doc must not be visible to beta — tenant slot isolation");
         }
     }

--- a/src/TenantPartitionedEventsTests/Projections/determine_action_async_per_tenant.cs
+++ b/src/TenantPartitionedEventsTests/Projections/determine_action_async_per_tenant.cs
@@ -96,13 +96,13 @@ public class determine_action_async_per_tenant : IAsyncLifetime
         {
             session.Events.StartStream(Guid.NewGuid(),
                 new DetermineIncrementEvent(), new DetermineIncrementEvent());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var session = _store.LightweightSession("beta"))
         {
             session.Events.StartStream(Guid.NewGuid(),
                 new DetermineIncrementEvent());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Every captured tenant id is one of the writing tenants — never
@@ -136,24 +136,24 @@ public class determine_action_async_per_tenant : IAsyncLifetime
         await using (var session = _store.LightweightSession("alpha"))
         {
             session.Events.StartStream(sharedStream, new DetermineIncrementEvent());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         // beta: start + increment twice → doc with Count = 2.
         await using (var session = _store.LightweightSession("beta"))
         {
             session.Events.StartStream(sharedStream,
                 new DetermineIncrementEvent(), new DetermineIncrementEvent());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Confirm both docs exist with their counts.
         await using (var alphaQuery = _store.QuerySession("alpha"))
         {
-            (await alphaQuery.LoadAsync<DetermineCounter>(sharedStream))!.Count.ShouldBe(1);
+            (await alphaQuery.LoadAsync<DetermineCounter>(sharedStream, TestContext.Current.CancellationToken))!.Count.ShouldBe(1);
         }
         await using (var betaQuery = _store.QuerySession("beta"))
         {
-            (await betaQuery.LoadAsync<DetermineCounter>(sharedStream))!.Count.ShouldBe(2);
+            (await betaQuery.LoadAsync<DetermineCounter>(sharedStream, TestContext.Current.CancellationToken))!.Count.ShouldBe(2);
         }
 
         // alpha sends a DetermineResetEvent → projection returns Delete →
@@ -161,18 +161,18 @@ public class determine_action_async_per_tenant : IAsyncLifetime
         await using (var session = _store.LightweightSession("alpha"))
         {
             session.Events.Append(sharedStream, new DetermineResetEvent());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Pin: alpha's doc is gone, beta's is untouched (Count still 2).
         await using (var alphaQuery = _store.QuerySession("alpha"))
         {
-            (await alphaQuery.LoadAsync<DetermineCounter>(sharedStream))
+            (await alphaQuery.LoadAsync<DetermineCounter>(sharedStream, TestContext.Current.CancellationToken))
                 .ShouldBeNull("alpha's reset → Delete should have removed alpha's doc");
         }
         await using (var betaQuery = _store.QuerySession("beta"))
         {
-            var betaDoc = await betaQuery.LoadAsync<DetermineCounter>(sharedStream);
+            var betaDoc = await betaQuery.LoadAsync<DetermineCounter>(sharedStream, TestContext.Current.CancellationToken);
             betaDoc.ShouldNotBeNull("beta's doc must NOT be deleted by alpha's reset (tenant isolation)");
             betaDoc!.Count.ShouldBe(2, "beta's count must be unchanged");
         }

--- a/src/TenantPartitionedEventsTests/Projections/event_projection_per_tenant.cs
+++ b/src/TenantPartitionedEventsTests/Projections/event_projection_per_tenant.cs
@@ -86,17 +86,17 @@ public class event_projection_per_tenant : IAsyncLifetime
         {
             session.Events.StartStream(alphaStream,
                 new LegEvent(1.0), new LegEvent(2.0), new LegEvent(3.0));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var qa = _store.QuerySession(alpha);
-        var alphaLogs = await qa.Query<LegLog>().ToListAsync();
+        var alphaLogs = await qa.Query<LegLog>().ToListAsync(TestContext.Current.CancellationToken);
         alphaLogs.Count.ShouldBe(3,
             "EventProjection.Create emits one LegLog per LegEvent — alpha appended 3, so alpha's session sees 3");
         alphaLogs.Select(l => l.Distance).OrderBy(d => d).ShouldBe(new[] { 1.0, 2.0, 3.0 });
 
         await using var qb = _store.QuerySession(beta);
-        var betaLogs = await qb.Query<LegLog>().ToListAsync();
+        var betaLogs = await qb.Query<LegLog>().ToListAsync(TestContext.Current.CancellationToken);
         betaLogs.ShouldBeEmpty(
             "beta appended no events — its tenant slot must be empty (no cross-tenant doc leak)");
     }
@@ -119,22 +119,22 @@ public class event_projection_per_tenant : IAsyncLifetime
         await using (var session = _store.LightweightSession(alpha))
         {
             session.Events.StartStream(alphaStream, new LegEvent(10), new LegEvent(20));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var session = _store.LightweightSession(beta))
         {
             session.Events.StartStream(betaStream, new LegEvent(7), new LegEvent(13));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Pre-state: inline already materialized both tenants.
         await using (var qa = _store.QuerySession(alpha))
         {
-            (await qa.Query<LegLog>().ToListAsync()).Count.ShouldBe(2);
+            (await qa.Query<LegLog>().ToListAsync(TestContext.Current.CancellationToken)).Count.ShouldBe(2);
         }
         await using (var qb = _store.QuerySession(beta))
         {
-            (await qb.Query<LegLog>().ToListAsync()).Count.ShouldBe(2);
+            (await qb.Query<LegLog>().ToListAsync(TestContext.Current.CancellationToken)).Count.ShouldBe(2);
         }
 
         // Wipe alpha's docs + progression — Phase 2c teardown. Beta untouched.
@@ -145,12 +145,12 @@ public class event_projection_per_tenant : IAsyncLifetime
 
         await using (var qa = _store.QuerySession(alpha))
         {
-            (await qa.Query<LegLog>().ToListAsync())
+            (await qa.Query<LegLog>().ToListAsync(TestContext.Current.CancellationToken))
                 .ShouldBeEmpty("alpha's docs must be wiped by the tenant-scoped teardown");
         }
         await using (var qb = _store.QuerySession(beta))
         {
-            (await qb.Query<LegLog>().ToListAsync()).Count.ShouldBe(2,
+            (await qb.Query<LegLog>().ToListAsync(TestContext.Current.CancellationToken)).Count.ShouldBe(2,
                 "beta's docs must survive — the teardown is tenant-scoped to alpha");
         }
 
@@ -164,14 +164,14 @@ public class event_projection_per_tenant : IAsyncLifetime
 
         await using (var qa = _store.QuerySession(alpha))
         {
-            var alphaLogs = await qa.Query<LegLog>().ToListAsync();
+            var alphaLogs = await qa.Query<LegLog>().ToListAsync(TestContext.Current.CancellationToken);
             alphaLogs.Count.ShouldBe(2,
                 "alpha was rebuilt — its 2 LegEvents must materialize 2 LegLog docs");
             alphaLogs.Select(l => l.Distance).OrderBy(d => d).ShouldBe(new[] { 10.0, 20.0 });
         }
         await using (var qb = _store.QuerySession(beta))
         {
-            (await qb.Query<LegLog>().ToListAsync()).Count.ShouldBe(2,
+            (await qb.Query<LegLog>().ToListAsync(TestContext.Current.CancellationToken)).Count.ShouldBe(2,
                 "beta's docs must STILL be 2 — the per-tenant rebuild for alpha did not touch beta");
         }
     }

--- a/src/TenantPartitionedEventsTests/Projections/flat_table_projection_per_tenant.cs
+++ b/src/TenantPartitionedEventsTests/Projections/flat_table_projection_per_tenant.cs
@@ -93,12 +93,12 @@ public class flat_table_projection_per_tenant : IAsyncLifetime
         await _store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
         await using var cmd = conn.CreateCommand();
         cmd.CommandText =
             "select count(*) from information_schema.tables where table_schema = @s and table_name = 'ft_counters'";
         cmd.Parameters.AddWithValue("s", _schema);
-        var count = (long)(await cmd.ExecuteScalarAsync())!;
+        var count = (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
         count.ShouldBe(1L, "FlatTableProjection's ft_counters table must exist after schema apply");
     }
 
@@ -117,12 +117,12 @@ public class flat_table_projection_per_tenant : IAsyncLifetime
         {
             session.Events.StartStream(alphaCounter, new FtCounterIncremented(alphaCounter, 10));
             session.Events.Append(alphaCounter, new FtCounterIncremented(alphaCounter, 5));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var session = _store.LightweightSession("beta"))
         {
             session.Events.StartStream(betaCounter, new FtCounterIncremented(betaCounter, 100));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var alphaTotal = await ReadTotalAsync(alphaCounter);
@@ -156,7 +156,7 @@ public class flat_table_projection_per_tenant : IAsyncLifetime
         await using (var session = _store.LightweightSession("alpha"))
         {
             session.Events.StartStream(sharedCounterId, new FtCounterIncremented(sharedCounterId, 10));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         var afterAlpha = await ReadTotalAsync(sharedCounterId);
         afterAlpha.ShouldBe(10, "alpha's initial 10 lands in the row");
@@ -166,7 +166,7 @@ public class flat_table_projection_per_tenant : IAsyncLifetime
         await using (var session = _store.LightweightSession("beta"))
         {
             session.Events.StartStream(sharedCounterId, new FtCounterIncremented(sharedCounterId, 100));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         var afterBeta = await ReadTotalAsync(sharedCounterId);
 

--- a/src/TenantPartitionedEventsTests/Projections/inline_single_stream_projection_per_tenant.cs
+++ b/src/TenantPartitionedEventsTests/Projections/inline_single_stream_projection_per_tenant.cs
@@ -53,19 +53,19 @@ public class inline_single_stream_projection_per_tenant
         {
             session.Events.StartStream<TripCount>(streamId, new TripStarted(streamId),
                 new TripLeg(1), new TripLeg(2), new TripLeg(3));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Alpha sees the projected TripCount(Count=3).
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var alphaDoc = await qa.LoadAsync<TripCount>(streamId);
+        var alphaDoc = await qa.LoadAsync<TripCount>(streamId, TestContext.Current.CancellationToken);
         alphaDoc.ShouldNotBeNull();
         alphaDoc!.Count.ShouldBe(3);
 
         // Beta's session has no doc at this id (multi-tenanted policy +
         // partitioned doc table → tenant-scoped read returns null).
         await using var qb = _fixture.Store.QuerySession(beta);
-        var betaDoc = await qb.LoadAsync<TripCount>(streamId);
+        var betaDoc = await qb.LoadAsync<TripCount>(streamId, TestContext.Current.CancellationToken);
         betaDoc.ShouldBeNull();
     }
 
@@ -85,22 +85,22 @@ public class inline_single_stream_projection_per_tenant
         {
             session.Events.StartStream<TripCount>(sharedId, new TripStarted(sharedId),
                 new TripLeg(1), new TripLeg(2));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var session = _fixture.Store.LightweightSession(beta))
         {
             session.Events.StartStream<TripCount>(sharedId, new TripStarted(sharedId),
                 new TripLeg(1), new TripLeg(2), new TripLeg(3), new TripLeg(4));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var alphaDoc = await qa.LoadAsync<TripCount>(sharedId);
+        var alphaDoc = await qa.LoadAsync<TripCount>(sharedId, TestContext.Current.CancellationToken);
         alphaDoc.ShouldNotBeNull();
         alphaDoc!.Count.ShouldBe(2);
 
         await using var qb = _fixture.Store.QuerySession(beta);
-        var betaDoc = await qb.LoadAsync<TripCount>(sharedId);
+        var betaDoc = await qb.LoadAsync<TripCount>(sharedId, TestContext.Current.CancellationToken);
         betaDoc.ShouldNotBeNull();
         betaDoc!.Count.ShouldBe(4);
     }
@@ -115,21 +115,21 @@ public class inline_single_stream_projection_per_tenant
         await using (var session = _fixture.Store.LightweightSession(tenant))
         {
             session.Events.StartStream<TripCount>(streamId, new TripStarted(streamId), new TripLeg(1));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var session = _fixture.Store.LightweightSession(tenant))
         {
             session.Events.Append(streamId, new TripLeg(2), new TripLeg(3));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var session = _fixture.Store.LightweightSession(tenant))
         {
             session.Events.Append(streamId, new TripLeg(4));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var doc = await query.LoadAsync<TripCount>(streamId);
+        var doc = await query.LoadAsync<TripCount>(streamId, TestContext.Current.CancellationToken);
         doc.ShouldNotBeNull();
         // Inline materialization runs in each SaveChanges' session — Count
         // ends up at 4 (= TripLeg events appended; the initial TripStarted
@@ -148,10 +148,10 @@ public class inline_single_stream_projection_per_tenant
         // shape so a future change that auto-partitions doc tables is reviewed
         // intentionally.
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         var tripCountTable = new Table(new PostgresqlObjectName(_fixture.SchemaName, "mt_doc_p2c_trip_count"));
-        var live = await tripCountTable.FetchExistingAsync(conn);
+        var live = await tripCountTable.FetchExistingAsync(conn, TestContext.Current.CancellationToken);
         live.ShouldNotBeNull("p2c_trip_count document table must exist after fixture init");
 
         live.Partitioning.ShouldBeNull(

--- a/src/TenantPartitionedEventsTests/Projections/multi_stream_projection_rollup_by_tenant.cs
+++ b/src/TenantPartitionedEventsTests/Projections/multi_stream_projection_rollup_by_tenant.cs
@@ -106,7 +106,7 @@ public class multi_stream_projection_rollup_by_tenant : IAsyncLifetime
                 new AccountOpened(acct),
                 new TransactionPosted(acct, 100m),
                 new TransactionPosted(acct, 50m));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var session = _store.LightweightSession(beta))
         {
@@ -116,7 +116,7 @@ public class multi_stream_projection_rollup_by_tenant : IAsyncLifetime
                 new TransactionPosted(acct, 7m),
                 new TransactionPosted(acct, 3m),
                 new TransactionPosted(acct, 10m));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Per-tenant rebuild explicitly walks each tenant's events from
@@ -134,8 +134,8 @@ public class multi_stream_projection_rollup_by_tenant : IAsyncLifetime
         // DefaultTenantId as the group's TenantId) — read from a default-tenant
         // session keyed by the doc identity (= tenant id string).
         await using var query = _store.QuerySession();
-        var alphaRollup = await query.LoadAsync<TenantRollup>(alpha);
-        var betaRollup = await query.LoadAsync<TenantRollup>(beta);
+        var alphaRollup = await query.LoadAsync<TenantRollup>(alpha, TestContext.Current.CancellationToken);
+        var betaRollup = await query.LoadAsync<TenantRollup>(beta, TestContext.Current.CancellationToken);
 
         alphaRollup.ShouldNotBeNull("alpha must have a rollup doc keyed by its tenant id");
         alphaRollup!.Total.ShouldBe(150m, "alpha's 100 + 50 = 150 — no beta arithmetic leak");
@@ -164,7 +164,7 @@ public class multi_stream_projection_rollup_by_tenant : IAsyncLifetime
                 new TransactionPosted(alphaAcct, 1m),
                 new TransactionPosted(alphaAcct, 1m),
                 new TransactionPosted(alphaAcct, 1m));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var betaAcct = Guid.NewGuid();
@@ -174,7 +174,7 @@ public class multi_stream_projection_rollup_by_tenant : IAsyncLifetime
             session.Events.Append(betaAcct,
                 new TransactionPosted(betaAcct, 1m),
                 new TransactionPosted(betaAcct, 1m));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using (var daemon = await _store.BuildProjectionDaemonAsync())
@@ -184,8 +184,8 @@ public class multi_stream_projection_rollup_by_tenant : IAsyncLifetime
         }
 
         await using var query = _store.QuerySession();
-        var alphaRollup = await query.LoadAsync<TenantRollup>(alpha);
-        var betaRollup = await query.LoadAsync<TenantRollup>(beta);
+        var alphaRollup = await query.LoadAsync<TenantRollup>(alpha, TestContext.Current.CancellationToken);
+        var betaRollup = await query.LoadAsync<TenantRollup>(beta, TestContext.Current.CancellationToken);
 
         alphaRollup.ShouldNotBeNull();
         alphaRollup!.TransactionCount.ShouldBe(3,

--- a/src/TenantPartitionedEventsTests/Projections/projected_doc_tables_partitioning_invariant.cs
+++ b/src/TenantPartitionedEventsTests/Projections/projected_doc_tables_partitioning_invariant.cs
@@ -87,7 +87,7 @@ public class projected_doc_tables_partitioning_invariant
         await using (var session = store.LightweightSession("alpha"))
         {
             session.Events.StartStream(streamId, new DpiIncrementEvent());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // mt_events parent IS LIST-partitioned by tenant_id.
@@ -131,7 +131,7 @@ public class projected_doc_tables_partitioning_invariant
         await using (var session = store.LightweightSession("alpha"))
         {
             session.Events.StartStream(streamId, new DpiIncrementEvent());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // mt_events parent IS LIST-partitioned (unchanged).

--- a/src/TenantPartitionedEventsTests/Projections/raw_iprojection_per_tenant.cs
+++ b/src/TenantPartitionedEventsTests/Projections/raw_iprojection_per_tenant.cs
@@ -101,26 +101,26 @@ public class raw_iprojection_per_tenant : IAsyncLifetime
         {
             session.Events.StartStream(alphaStream,
                 new TenantTouchEvent("alpha-1"), new TenantTouchEvent("alpha-2"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var betaStream = Guid.NewGuid();
         await using (var session = _store.LightweightSession("beta"))
         {
             session.Events.StartStream(betaStream, new TenantTouchEvent("beta-1"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Each tenant's doc IS visible from its own session.
         await using (var alphaQuery = _store.QuerySession("alpha"))
         {
-            var alphaDoc = await alphaQuery.LoadAsync<TenantTouchDoc>(alphaStream);
+            var alphaDoc = await alphaQuery.LoadAsync<TenantTouchDoc>(alphaStream, TestContext.Current.CancellationToken);
             alphaDoc.ShouldNotBeNull();
             alphaDoc!.TouchCount.ShouldBe(2);
         }
         await using (var betaQuery = _store.QuerySession("beta"))
         {
-            var betaDoc = await betaQuery.LoadAsync<TenantTouchDoc>(betaStream);
+            var betaDoc = await betaQuery.LoadAsync<TenantTouchDoc>(betaStream, TestContext.Current.CancellationToken);
             betaDoc.ShouldNotBeNull();
             betaDoc!.TouchCount.ShouldBe(1);
         }
@@ -129,12 +129,12 @@ public class raw_iprojection_per_tenant : IAsyncLifetime
         // tenant's slot, not bleeding into the other.
         await using (var alphaQuery = _store.QuerySession("alpha"))
         {
-            (await alphaQuery.LoadAsync<TenantTouchDoc>(betaStream))
+            (await alphaQuery.LoadAsync<TenantTouchDoc>(betaStream, TestContext.Current.CancellationToken))
                 .ShouldBeNull("beta's doc must not be visible to alpha");
         }
         await using (var betaQuery = _store.QuerySession("beta"))
         {
-            (await betaQuery.LoadAsync<TenantTouchDoc>(alphaStream))
+            (await betaQuery.LoadAsync<TenantTouchDoc>(alphaStream, TestContext.Current.CancellationToken))
                 .ShouldBeNull("alpha's doc must not be visible to beta");
         }
     }
@@ -151,12 +151,12 @@ public class raw_iprojection_per_tenant : IAsyncLifetime
         await using (var session = _store.LightweightSession("alpha"))
         {
             session.Events.StartStream(Guid.NewGuid(), new TenantTouchEvent("alpha-call"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var session = _store.LightweightSession("beta"))
         {
             session.Events.StartStream(Guid.NewGuid(), new TenantTouchEvent("beta-call"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // The capture list records the SET of tenant ids seen within each call

--- a/src/TenantPartitionedEventsTests/Projections/same_projection_lifecycle_equivalence.cs
+++ b/src/TenantPartitionedEventsTests/Projections/same_projection_lifecycle_equivalence.cs
@@ -93,19 +93,19 @@ public class same_projection_lifecycle_equivalence : IAsyncLifetime
                 new TripLegV2(7.5),
                 new TripLegV2(2.5),
                 new TripLegV2(1.0));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _store.QuerySession(tenant);
 
         // Inline-materialized doc: read directly from the projected document
         // table (no folding at read time).
-        var inlineDoc = await query.LoadAsync<TripSummary>(streamId);
+        var inlineDoc = await query.LoadAsync<TripSummary>(streamId, TestContext.Current.CancellationToken);
         inlineDoc.ShouldNotBeNull(
             "Inline projection must have written the doc during SaveChangesAsync");
 
         // Live aggregate: read the stream and fold via Apply() at query time.
-        var liveAgg = await query.Events.AggregateStreamAsync<TripSummary>(streamId);
+        var liveAgg = await query.Events.AggregateStreamAsync<TripSummary>(streamId, token: TestContext.Current.CancellationToken);
         liveAgg.ShouldNotBeNull(
             "Live aggregation must rebuild the same aggregate from the events");
 

--- a/src/TenantPartitionedEventsTests/ReadQuery/enable_unique_index_on_event_id_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/ReadQuery/enable_unique_index_on_event_id_under_partitioning.cs
@@ -88,7 +88,7 @@ public class enable_unique_index_on_event_id_under_partitioning : IAsyncLifetime
         await using (var session = _store.LightweightSession("alpha"))
         {
             session.Events.StartStream(alphaStream, new Event<UniqEvent>(new UniqEvent("a")) { Id = sharedEventId });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Beta appends an event with the SAME id — should succeed because the
@@ -96,16 +96,16 @@ public class enable_unique_index_on_event_id_under_partitioning : IAsyncLifetime
         await using (var session = _store.LightweightSession("beta"))
         {
             session.Events.StartStream(betaStream, new Event<UniqEvent>(new UniqEvent("b")) { Id = sharedEventId });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Sanity: both events live in their respective partitions.
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
         await using var cmd = conn.CreateCommand(
             $"select count(*) from {_schema}.mt_events where id = @id");
         cmd.Parameters.AddWithValue("id", sharedEventId);
-        var count = (long)(await cmd.ExecuteScalarAsync())!;
+        var count = (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
         count.ShouldBe(2L,
             "two events share the same id across two tenant partitions — the unique " +
             "index relaxes to per-tenant scope under partitioning");

--- a/src/TenantPartitionedEventsTests/ReadQuery/read_query_aggregation_guid.cs
+++ b/src/TenantPartitionedEventsTests/ReadQuery/read_query_aggregation_guid.cs
@@ -54,22 +54,22 @@ public class read_query_aggregation_guid
         {
             s.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId),
                 new TripLeg(1), new TripLeg(2));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId),
                 new TripLeg(10), new TripLeg(20), new TripLeg(30));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var alphaEvents = await qa.Events.FetchStreamAsync(streamId);
+        var alphaEvents = await qa.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         alphaEvents.Count.ShouldBe(3); // alpha's stream
         alphaEvents.Select(e => e.Version).ShouldBe(new long[] { 1, 2, 3 });
 
         await using var qb = _fixture.Store.QuerySession(beta);
-        var betaEvents = await qb.Events.FetchStreamAsync(streamId);
+        var betaEvents = await qb.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         betaEvents.Count.ShouldBe(4); // beta's stream
         betaEvents.Select(e => e.Version).ShouldBe(new long[] { 1, 2, 3, 4 });
     }
@@ -85,13 +85,13 @@ public class read_query_aggregation_guid
         await using (var s = _fixture.Store.LightweightSession(alpha))
         {
             s.Events.StartStream<TripSnapshot>(alphaStreamId, new TripStarted(alphaStreamId), new TripLeg(1));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Beta queries for alpha's stream id — empty: the read scopes by
         // (tenant_id, stream_id) and beta has no row for that id.
         await using var qb = _fixture.Store.QuerySession(beta);
-        var betaSeesAlpha = await qb.Events.FetchStreamAsync(alphaStreamId);
+        var betaSeesAlpha = await qb.Events.FetchStreamAsync(alphaStreamId, token: TestContext.Current.CancellationToken);
         betaSeesAlpha.ShouldBeEmpty();
     }
 
@@ -106,15 +106,15 @@ public class read_query_aggregation_guid
         {
             s.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId),
                 new TripLeg(1), new TripLeg(2), new TripLeg(3), new TripLeg(4));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var twoEvents = await query.Events.FetchStreamAsync(streamId, version: 2);
+        var twoEvents = await query.Events.FetchStreamAsync(streamId, version: 2, token: TestContext.Current.CancellationToken);
         twoEvents.Count.ShouldBe(2);
         twoEvents.Last().Version.ShouldBe(2L);
 
-        var fromV3 = await query.Events.FetchStreamAsync(streamId, version: 0, fromVersion: 3);
+        var fromV3 = await query.Events.FetchStreamAsync(streamId, version: 0, fromVersion: 3, token: TestContext.Current.CancellationToken);
         fromV3.Count.ShouldBe(3); // versions 3, 4, 5
         fromV3.First().Version.ShouldBe(3L);
     }
@@ -137,23 +137,23 @@ public class read_query_aggregation_guid
         await using (var s = _fixture.Store.LightweightSession(alpha))
         {
             s.Events.StartStream<TripSnapshot>(sharedId, new TripStarted(sharedId), new TripLeg(1));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             // Beta drives the same id further along — 5 events.
             s.Events.StartStream<TripSnapshot>(sharedId, new TripStarted(sharedId),
                 new TripLeg(1), new TripLeg(2), new TripLeg(3), new TripLeg(4));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var alphaState = await qa.Events.FetchStreamStateAsync(sharedId);
+        var alphaState = await qa.Events.FetchStreamStateAsync(sharedId, TestContext.Current.CancellationToken);
         alphaState.ShouldNotBeNull();
         alphaState.Version.ShouldBe(2L); // alpha's stream has 2 events
 
         await using var qb = _fixture.Store.QuerySession(beta);
-        var betaState = await qb.Events.FetchStreamStateAsync(sharedId);
+        var betaState = await qb.Events.FetchStreamStateAsync(sharedId, TestContext.Current.CancellationToken);
         betaState.ShouldNotBeNull();
         betaState.Version.ShouldBe(5L); // beta's stream has 5 events
 
@@ -161,7 +161,7 @@ public class read_query_aggregation_guid
         var unrelated = PartitionedFixtureBase.NewTenant();
         await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, unrelated);
         await using var qu = _fixture.Store.QuerySession(unrelated);
-        var noState = await qu.Events.FetchStreamStateAsync(sharedId);
+        var noState = await qu.Events.FetchStreamStateAsync(sharedId, TestContext.Current.CancellationToken);
         noState.ShouldBeNull();
     }
 
@@ -182,28 +182,28 @@ public class read_query_aggregation_guid
         {
             s.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId),
                 new TripLeg(7), new TripLeg(11));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId), new TripLeg(99));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var alphaAgg = await qa.Events.AggregateStreamAsync<TripSnapshot>(streamId);
+        var alphaAgg = await qa.Events.AggregateStreamAsync<TripSnapshot>(streamId, token: TestContext.Current.CancellationToken);
         alphaAgg.ShouldNotBeNull();
         alphaAgg!.Distance.ShouldBe(18); // 7 + 11 — beta's 99 must NOT be folded in
         alphaAgg.LegCount.ShouldBe(2);
 
         // version bound = 2 (TripStarted + first TripLeg)
-        var alphaAtV2 = await qa.Events.AggregateStreamAsync<TripSnapshot>(streamId, version: 2);
+        var alphaAtV2 = await qa.Events.AggregateStreamAsync<TripSnapshot>(streamId, version: 2, token: TestContext.Current.CancellationToken);
         alphaAtV2.ShouldNotBeNull();
         alphaAtV2!.Distance.ShouldBe(7);
 
         // overshoot — stream has 3 events; ask for version 99 → no events at that
         // version → null aggregate.
-        var overshoot = await qa.Events.AggregateStreamAsync<TripSnapshot>(streamId, version: 99);
+        var overshoot = await qa.Events.AggregateStreamAsync<TripSnapshot>(streamId, version: 99, token: TestContext.Current.CancellationToken);
         overshoot.ShouldBeNull();
     }
 
@@ -214,7 +214,7 @@ public class read_query_aggregation_guid
         await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var none = await query.Events.AggregateStreamAsync<TripSnapshot>(Guid.NewGuid());
+        var none = await query.Events.AggregateStreamAsync<TripSnapshot>(Guid.NewGuid(), token: TestContext.Current.CancellationToken);
         none.ShouldBeNull();
     }
 
@@ -234,19 +234,19 @@ public class read_query_aggregation_guid
         {
             s.Events.StartStream<TripSnapshot>(alphaStream, new TripStarted(alphaStream),
                 new TripLeg(1), new TripLeg(2));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<TripSnapshot>(betaStream, new TripStarted(betaStream), new TripLeg(99));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var qa = _fixture.Store.QuerySession(alpha);
         var alphaAll = await qa.Events.QueryAllRawEvents()
             .Where(e => e.StreamId == alphaStream)
             .OrderBy(e => e.Sequence)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
         alphaAll.Count.ShouldBe(3); // alpha's 3 events
         alphaAll.Select(e => e.Version).ShouldBe(new long[] { 1, 2, 3 });
 
@@ -254,7 +254,7 @@ public class read_query_aggregation_guid
         // the shared store may have other tests' events floating around.
         var alphaSeesBetaStream = await qa.Events.QueryAllRawEvents()
             .Where(e => e.StreamId == betaStream)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
         alphaSeesBetaStream.ShouldBeEmpty(
             "tenant-isolation: alpha's session must not see beta's events");
     }
@@ -275,19 +275,19 @@ public class read_query_aggregation_guid
         {
             s.Events.StartStream<TripSnapshot>(alphaStream, new TripStarted(alphaStream),
                 new TripLeg(1), new TripLeg(2));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<TripSnapshot>(betaStream, new TripStarted(betaStream), new TripLeg(3));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Alpha's session queries TripLeg only — sees its own 2 legs, not beta's 1.
         await using var qa = _fixture.Store.QuerySession(alpha);
         var alphaLegs = await qa.Events.QueryRawEventDataOnly<TripLeg>()
             .Where(e => e.Distance < 100) // filter to keep this test's data scope, sibling tests don't write this exact shape
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
         alphaLegs.Count(l => l.Distance == 1 || l.Distance == 2).ShouldBe(2);
         alphaLegs.Any(l => l.Distance == 3).ShouldBeFalse(
             "tenant filter must scope by tenant_id — beta's TripLeg(3) cannot leak into alpha's session");
@@ -311,9 +311,9 @@ public class read_query_aggregation_guid
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<TripSnapshot>(betaStream, new TripStarted(betaStream), new TripLeg(42));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
             // Re-read to capture the event id assigned by the bulk path.
-            var events = await s.Events.FetchStreamAsync(betaStream);
+            var events = await s.Events.FetchStreamAsync(betaStream, token: TestContext.Current.CancellationToken);
             betaEventId = events.Last().Id;
         }
 
@@ -321,7 +321,7 @@ public class read_query_aggregation_guid
         // This is "structural cross-tenant read" — surfaced as a known
         // limitation in the #4617 spec, not yet considered a bug.
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var loaded = await qa.Events.LoadAsync(betaEventId);
+        var loaded = await qa.Events.LoadAsync(betaEventId, TestContext.Current.CancellationToken);
         loaded.ShouldNotBeNull(
             "LoadAsync currently has no tenant predicate — structural cross-tenant read. " +
             "If this changes (tenant-scoped LoadAsync), revisit the SingleEventQueryHandler comment");
@@ -341,19 +341,19 @@ public class read_query_aggregation_guid
         {
             s.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId),
                 new TripLeg(3), new TripLeg(4));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // FetchLatest lives on IEventStoreOperations (LightweightSession), not on
         // the read-only IQueryEventStore — same surface either way for an idempotent
         // read.
         await using var sa = _fixture.Store.LightweightSession(alpha);
-        var alphaLatest = await sa.Events.FetchLatest<TripSnapshot>(streamId);
+        var alphaLatest = await sa.Events.FetchLatest<TripSnapshot>(streamId, TestContext.Current.CancellationToken);
         alphaLatest.ShouldNotBeNull();
         alphaLatest!.Distance.ShouldBe(7); // 3 + 4
 
         await using var sb = _fixture.Store.LightweightSession(beta);
-        var betaLatest = await sb.Events.FetchLatest<TripSnapshot>(streamId);
+        var betaLatest = await sb.Events.FetchLatest<TripSnapshot>(streamId, TestContext.Current.CancellationToken);
         betaLatest.ShouldBeNull(
             "beta has no stream at this id — FetchLatest must return null, not leak alpha's aggregate");
     }
@@ -378,18 +378,18 @@ public class read_query_aggregation_guid
         await using (var s = _fixture.Store.LightweightSession(alpha))
         {
             s.Events.StartStream<TripSnapshot>(alphaStream, new TripStarted(alphaStream));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<TripSnapshot>(betaStream, new TripStarted(betaStream));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var alphaFirst = (await qa.Events.FetchStreamAsync(alphaStream)).Single();
+        var alphaFirst = (await qa.Events.FetchStreamAsync(alphaStream, token: TestContext.Current.CancellationToken)).Single();
         await using var qb = _fixture.Store.QuerySession(beta);
-        var betaFirst = (await qb.Events.FetchStreamAsync(betaStream)).Single();
+        var betaFirst = (await qb.Events.FetchStreamAsync(betaStream, token: TestContext.Current.CancellationToken)).Single();
 
         // Both first events have Version == 1 — per-stream version is independent.
         alphaFirst.Version.ShouldBe(1L);

--- a/src/TenantPartitionedEventsTests/ReadQuery/read_query_aggregation_string.cs
+++ b/src/TenantPartitionedEventsTests/ReadQuery/read_query_aggregation_string.cs
@@ -62,22 +62,22 @@ public class read_query_aggregation_string
         {
             s.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId),
                 new StringTripLeg(1), new StringTripLeg(2));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId),
                 new StringTripLeg(10), new StringTripLeg(20), new StringTripLeg(30));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var alphaEvents = await qa.Events.FetchStreamAsync(streamId);
+        var alphaEvents = await qa.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         alphaEvents.Count.ShouldBe(3); // alpha's stream
         alphaEvents.Select(e => e.Version).ShouldBe(new long[] { 1, 2, 3 });
 
         await using var qb = _fixture.Store.QuerySession(beta);
-        var betaEvents = await qb.Events.FetchStreamAsync(streamId);
+        var betaEvents = await qb.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
         betaEvents.Count.ShouldBe(4); // beta's stream
         betaEvents.Select(e => e.Version).ShouldBe(new long[] { 1, 2, 3, 4 });
     }
@@ -93,13 +93,13 @@ public class read_query_aggregation_string
         await using (var s = _fixture.Store.LightweightSession(alpha))
         {
             s.Events.StartStream<StringTripSnapshot>(alphaStreamId, new StringTripStarted(alphaStreamId), new StringTripLeg(1));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Beta queries for alpha's stream id — empty: the read scopes by
         // (tenant_id, stream_id) and beta has no row for that id.
         await using var qb = _fixture.Store.QuerySession(beta);
-        var betaSeesAlpha = await qb.Events.FetchStreamAsync(alphaStreamId);
+        var betaSeesAlpha = await qb.Events.FetchStreamAsync(alphaStreamId, token: TestContext.Current.CancellationToken);
         betaSeesAlpha.ShouldBeEmpty();
     }
 
@@ -114,15 +114,15 @@ public class read_query_aggregation_string
         {
             s.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId),
                 new StringTripLeg(1), new StringTripLeg(2), new StringTripLeg(3), new StringTripLeg(4));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var twoEvents = await query.Events.FetchStreamAsync(streamId, version: 2);
+        var twoEvents = await query.Events.FetchStreamAsync(streamId, version: 2, token: TestContext.Current.CancellationToken);
         twoEvents.Count.ShouldBe(2);
         twoEvents.Last().Version.ShouldBe(2L);
 
-        var fromV3 = await query.Events.FetchStreamAsync(streamId, version: 0, fromVersion: 3);
+        var fromV3 = await query.Events.FetchStreamAsync(streamId, version: 0, fromVersion: 3, token: TestContext.Current.CancellationToken);
         fromV3.Count.ShouldBe(3); // versions 3, 4, 5
         fromV3.First().Version.ShouldBe(3L);
     }
@@ -145,23 +145,23 @@ public class read_query_aggregation_string
         await using (var s = _fixture.Store.LightweightSession(alpha))
         {
             s.Events.StartStream<StringTripSnapshot>(sharedId, new StringTripStarted(sharedId), new StringTripLeg(1));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             // Beta drives the same id further along — 5 events.
             s.Events.StartStream<StringTripSnapshot>(sharedId, new StringTripStarted(sharedId),
                 new StringTripLeg(1), new StringTripLeg(2), new StringTripLeg(3), new StringTripLeg(4));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var alphaState = await qa.Events.FetchStreamStateAsync(sharedId);
+        var alphaState = await qa.Events.FetchStreamStateAsync(sharedId, TestContext.Current.CancellationToken);
         alphaState.ShouldNotBeNull();
         alphaState.Version.ShouldBe(2L); // alpha's stream has 2 events
 
         await using var qb = _fixture.Store.QuerySession(beta);
-        var betaState = await qb.Events.FetchStreamStateAsync(sharedId);
+        var betaState = await qb.Events.FetchStreamStateAsync(sharedId, TestContext.Current.CancellationToken);
         betaState.ShouldNotBeNull();
         betaState.Version.ShouldBe(5L); // beta's stream has 5 events
 
@@ -169,7 +169,7 @@ public class read_query_aggregation_string
         var unrelated = PartitionedFixtureBase.NewTenant();
         await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, unrelated);
         await using var qu = _fixture.Store.QuerySession(unrelated);
-        var noState = await qu.Events.FetchStreamStateAsync(sharedId);
+        var noState = await qu.Events.FetchStreamStateAsync(sharedId, TestContext.Current.CancellationToken);
         noState.ShouldBeNull();
     }
 
@@ -190,28 +190,28 @@ public class read_query_aggregation_string
         {
             s.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId),
                 new StringTripLeg(7), new StringTripLeg(11));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId), new StringTripLeg(99));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var alphaAgg = await qa.Events.AggregateStreamAsync<StringTripSnapshot>(streamId);
+        var alphaAgg = await qa.Events.AggregateStreamAsync<StringTripSnapshot>(streamId, token: TestContext.Current.CancellationToken);
         alphaAgg.ShouldNotBeNull();
         alphaAgg!.Distance.ShouldBe(18); // 7 + 11 — beta's 99 must NOT be folded in
         alphaAgg.LegCount.ShouldBe(2);
 
         // version bound = 2 (TripStarted + first TripLeg)
-        var alphaAtV2 = await qa.Events.AggregateStreamAsync<StringTripSnapshot>(streamId, version: 2);
+        var alphaAtV2 = await qa.Events.AggregateStreamAsync<StringTripSnapshot>(streamId, version: 2, token: TestContext.Current.CancellationToken);
         alphaAtV2.ShouldNotBeNull();
         alphaAtV2!.Distance.ShouldBe(7);
 
         // overshoot — stream has 3 events; ask for version 99 → no events at that
         // version → null aggregate.
-        var overshoot = await qa.Events.AggregateStreamAsync<StringTripSnapshot>(streamId, version: 99);
+        var overshoot = await qa.Events.AggregateStreamAsync<StringTripSnapshot>(streamId, version: 99, token: TestContext.Current.CancellationToken);
         overshoot.ShouldBeNull();
     }
 
@@ -222,7 +222,7 @@ public class read_query_aggregation_string
         await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
 
         await using var query = _fixture.Store.QuerySession(tenant);
-        var none = await query.Events.AggregateStreamAsync<StringTripSnapshot>(NewStream());
+        var none = await query.Events.AggregateStreamAsync<StringTripSnapshot>(NewStream(), token: TestContext.Current.CancellationToken);
         none.ShouldBeNull();
     }
 
@@ -242,12 +242,12 @@ public class read_query_aggregation_string
         {
             s.Events.StartStream<StringTripSnapshot>(alphaStream, new StringTripStarted(alphaStream),
                 new StringTripLeg(1), new StringTripLeg(2));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<StringTripSnapshot>(betaStream, new StringTripStarted(betaStream), new StringTripLeg(99));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Under StreamIdentity.AsString, IEvent.StreamId is unused (the actual
@@ -258,7 +258,7 @@ public class read_query_aggregation_string
         var alphaAll = await qa.Events.QueryAllRawEvents()
             .Where(e => e.StreamKey == alphaStream)
             .OrderBy(e => e.Sequence)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
         alphaAll.Count.ShouldBe(3); // alpha's 3 events
         alphaAll.Select(e => e.Version).ShouldBe(new long[] { 1, 2, 3 });
 
@@ -266,7 +266,7 @@ public class read_query_aggregation_string
         // the shared store may have other tests' events floating around.
         var alphaSeesBetaStream = await qa.Events.QueryAllRawEvents()
             .Where(e => e.StreamKey == betaStream)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
         alphaSeesBetaStream.ShouldBeEmpty(
             "tenant-isolation: alpha's session must not see beta's events");
     }
@@ -287,19 +287,19 @@ public class read_query_aggregation_string
         {
             s.Events.StartStream<StringTripSnapshot>(alphaStream, new StringTripStarted(alphaStream),
                 new StringTripLeg(1), new StringTripLeg(2));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<StringTripSnapshot>(betaStream, new StringTripStarted(betaStream), new StringTripLeg(3));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Alpha's session queries StringTripLeg only — sees its own 2 legs, not beta's 1.
         await using var qa = _fixture.Store.QuerySession(alpha);
         var alphaLegs = await qa.Events.QueryRawEventDataOnly<StringTripLeg>()
             .Where(e => e.Distance < 100) // filter to keep this test's data scope, sibling tests don't write this exact shape
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
         alphaLegs.Count(l => l.Distance == 1 || l.Distance == 2).ShouldBe(2);
         alphaLegs.Any(l => l.Distance == 3).ShouldBeFalse(
             "tenant filter must scope by tenant_id — beta's StringTripLeg(3) cannot leak into alpha's session");
@@ -325,9 +325,9 @@ public class read_query_aggregation_string
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<StringTripSnapshot>(betaStream, new StringTripStarted(betaStream), new StringTripLeg(42));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
             // Re-read to capture the event id assigned by the bulk path.
-            var events = await s.Events.FetchStreamAsync(betaStream);
+            var events = await s.Events.FetchStreamAsync(betaStream, token: TestContext.Current.CancellationToken);
             betaEventId = events.Last().Id;
         }
 
@@ -335,7 +335,7 @@ public class read_query_aggregation_string
         // This is "structural cross-tenant read" — surfaced as a known
         // limitation in the #4617 spec, not yet considered a bug.
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var loaded = await qa.Events.LoadAsync(betaEventId);
+        var loaded = await qa.Events.LoadAsync(betaEventId, TestContext.Current.CancellationToken);
         loaded.ShouldNotBeNull(
             "LoadAsync currently has no tenant predicate — structural cross-tenant read. " +
             "If this changes (tenant-scoped LoadAsync), revisit the SingleEventQueryHandler comment");
@@ -355,19 +355,19 @@ public class read_query_aggregation_string
         {
             s.Events.StartStream<StringTripSnapshot>(streamId, new StringTripStarted(streamId),
                 new StringTripLeg(3), new StringTripLeg(4));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // FetchLatest lives on IEventStoreOperations (LightweightSession), not on
         // the read-only IQueryEventStore — same surface either way for an idempotent
         // read.
         await using var sa = _fixture.Store.LightweightSession(alpha);
-        var alphaLatest = await sa.Events.FetchLatest<StringTripSnapshot>(streamId);
+        var alphaLatest = await sa.Events.FetchLatest<StringTripSnapshot>(streamId, TestContext.Current.CancellationToken);
         alphaLatest.ShouldNotBeNull();
         alphaLatest!.Distance.ShouldBe(7); // 3 + 4
 
         await using var sb = _fixture.Store.LightweightSession(beta);
-        var betaLatest = await sb.Events.FetchLatest<StringTripSnapshot>(streamId);
+        var betaLatest = await sb.Events.FetchLatest<StringTripSnapshot>(streamId, TestContext.Current.CancellationToken);
         betaLatest.ShouldBeNull(
             "beta has no stream at this id — FetchLatest must return null, not leak alpha's aggregate");
     }
@@ -392,18 +392,18 @@ public class read_query_aggregation_string
         await using (var s = _fixture.Store.LightweightSession(alpha))
         {
             s.Events.StartStream<StringTripSnapshot>(alphaStream, new StringTripStarted(alphaStream));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var s = _fixture.Store.LightweightSession(beta))
         {
             s.Events.StartStream<StringTripSnapshot>(betaStream, new StringTripStarted(betaStream));
-            await s.SaveChangesAsync();
+            await s.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var alphaFirst = (await qa.Events.FetchStreamAsync(alphaStream)).Single();
+        var alphaFirst = (await qa.Events.FetchStreamAsync(alphaStream, token: TestContext.Current.CancellationToken)).Single();
         await using var qb = _fixture.Store.QuerySession(beta);
-        var betaFirst = (await qb.Events.FetchStreamAsync(betaStream)).Single();
+        var betaFirst = (await qb.Events.FetchStreamAsync(betaStream, token: TestContext.Current.CancellationToken)).Single();
 
         // Both first events have Version == 1 — per-stream version is independent.
         alphaFirst.Version.ShouldBe(1L);

--- a/src/TenantPartitionedEventsTests/ReadQuery/read_query_deferred_items.cs
+++ b/src/TenantPartitionedEventsTests/ReadQuery/read_query_deferred_items.cs
@@ -51,24 +51,24 @@ public class read_query_deferred_items
         {
             session.Events.StartStream<TripSnapshot>(sharedStreamId,
                 new TripStarted(sharedStreamId), new TripLeg(3), new TripLeg(4));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         await using (var session = _fixture.Store.LightweightSession(beta))
         {
             session.Events.StartStream<TripSnapshot>(sharedStreamId,
                 new TripStarted(sharedStreamId), new TripLeg(10), new TripLeg(20), new TripLeg(30));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var qa = _fixture.Store.QuerySession(alpha);
-        var alphaSnap = await qa.Events.AggregateStreamToLastKnownAsync<TripSnapshot>(sharedStreamId);
+        var alphaSnap = await qa.Events.AggregateStreamToLastKnownAsync<TripSnapshot>(sharedStreamId, token: TestContext.Current.CancellationToken);
         alphaSnap.ShouldNotBeNull();
         alphaSnap!.Distance.ShouldBe(7,
             "alpha's last-known snapshot reflects ONLY alpha's events (3 + 4 = 7) — beta's must not leak");
         alphaSnap.LegCount.ShouldBe(2);
 
         await using var qb = _fixture.Store.QuerySession(beta);
-        var betaSnap = await qb.Events.AggregateStreamToLastKnownAsync<TripSnapshot>(sharedStreamId);
+        var betaSnap = await qb.Events.AggregateStreamToLastKnownAsync<TripSnapshot>(sharedStreamId, token: TestContext.Current.CancellationToken);
         betaSnap.ShouldNotBeNull();
         betaSnap!.Distance.ShouldBe(60,
             "beta's last-known snapshot reflects ONLY beta's events (10 + 20 + 30 = 60) — alpha's must not leak");
@@ -78,7 +78,7 @@ public class read_query_deferred_items
         // call internally calls FetchStreamAsync (tenant-scoped) which returns
         // empty, so the loop never produces an aggregate.
         await using var qg = _fixture.Store.QuerySession(ghost);
-        var ghostSnap = await qg.Events.AggregateStreamToLastKnownAsync<TripSnapshot>(sharedStreamId);
+        var ghostSnap = await qg.Events.AggregateStreamToLastKnownAsync<TripSnapshot>(sharedStreamId, token: TestContext.Current.CancellationToken);
         ghostSnap.ShouldBeNull(
             "ghost tenant has no events at this stream id — must return null, not leak alpha's or beta's snapshot");
     }
@@ -103,7 +103,7 @@ public class read_query_deferred_items
             {
                 session.Events.Append(alphaStream, new TripLeg(1));
             }
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         var betaStream = Guid.NewGuid();
         await using (var session = _fixture.Store.LightweightSession(beta))
@@ -113,7 +113,7 @@ public class read_query_deferred_items
             {
                 session.Events.Append(betaStream, new TripLeg(99));
             }
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Alpha's session pages 5 at a time — scope the query to alpha's

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4596_partition_race_and_MT002_rebuild.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4596_partition_race_and_MT002_rebuild.cs
@@ -150,7 +150,7 @@ public class Bug_4596_partition_race_and_MT002_rebuild : IAsyncLifetime
         // registered for the racey tenant id, regardless of which task won
         // the partition-creation race.
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         // mt_events partition for tenant id: lives at `mt_events_{suffix}`
         // where suffix == tenantId for string-keyed tenants. Probe
@@ -160,7 +160,7 @@ public class Bug_4596_partition_race_and_MT002_rebuild : IAsyncLifetime
         {
             cmd.Parameters.AddWithValue("s", _schema);
             cmd.Parameters.AddWithValue("n", $"mt_events_{raceyTenant}");
-            var partitionCount = (long)(await cmd.ExecuteScalarAsync())!;
+            var partitionCount = (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
             partitionCount.ShouldBe(1L,
                 "exactly one mt_events partition for the racey tenant must exist after the race resolves");
         }
@@ -171,7 +171,7 @@ public class Bug_4596_partition_race_and_MT002_rebuild : IAsyncLifetime
         {
             cmd.Parameters.AddWithValue("s", _schema);
             cmd.Parameters.AddWithValue("n", $"mt_events_sequence_{raceyTenant}");
-            var seqCount = (long)(await cmd.ExecuteScalarAsync())!;
+            var seqCount = (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
             seqCount.ShouldBe(1L,
                 "exactly one per-tenant sequence for the racey tenant must exist after the race resolves");
         }
@@ -184,7 +184,7 @@ public class Bug_4596_partition_race_and_MT002_rebuild : IAsyncLifetime
         {
             session.Events.StartStream<Bug4596TripStarted>(
                 Guid.NewGuid(), new Bug4596TripStarted("post-race append"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -205,7 +205,7 @@ public class Bug_4596_partition_race_and_MT002_rebuild : IAsyncLifetime
                 Guid.NewGuid(),
                 new Bug4596TripStarted("alpha-only"),
                 new Bug4596TripLeg(7.0));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Headline behavioral asymmetry pin: APPEND for an unregistered
@@ -217,7 +217,7 @@ public class Bug_4596_partition_race_and_MT002_rebuild : IAsyncLifetime
         {
             session.Events.StartStream<Bug4596TripStarted>(
                 Guid.NewGuid(), new Bug4596TripStarted("should-fail"));
-            try { await session.SaveChangesAsync(); }
+            try { await session.SaveChangesAsync(TestContext.Current.CancellationToken); }
             catch (Exception ex) { appendException = ex; }
         }
 
@@ -249,11 +249,11 @@ public class Bug_4596_partition_race_and_MT002_rebuild : IAsyncLifetime
             // (SELECT … WHERE tenant_id = 'typo_tenant'). MT002 is impossible
             // here — it's a quick-append-only RAISE.
             await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-            await conn.OpenAsync();
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
             await using var cmd = conn.CreateCommand(
                 $"select count(*) from {_schema}.mt_events where tenant_id = :t");
             cmd.Parameters.AddWithValue("t", "typo_tenant");
-            var unregisteredCount = (long)(await cmd.ExecuteScalarAsync())!;
+            var unregisteredCount = (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
             unregisteredCount.ShouldBe(0L,
                 "unregistered tenant has zero events visible to the rebuild loader — MT002 never enters the picture");
         }

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4611_mandatory_stream_type_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4611_mandatory_stream_type_under_partitioning.cs
@@ -87,32 +87,32 @@ public class Bug_4611_mandatory_stream_type_under_partitioning : IAsyncLifetime
         await using (var session = _store.LightweightSession("alpha"))
         {
             session.Events.StartStream<MandatoryAggregate>(streamId, new MandatoryEvent("first"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var query = _store.QuerySession("alpha"))
         {
-            (await query.Events.FetchStreamAsync(streamId)).Count.ShouldBe(1);
+            (await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken)).Count.ShouldBe(1);
         }
 
         await using (var session = _store.LightweightSession("alpha"))
         {
             session.Events.Append(streamId, new MandatoryEvent("second"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var query = _store.QuerySession("alpha"))
         {
-            (await query.Events.FetchStreamAsync(streamId)).Count.ShouldBe(2);
+            (await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken)).Count.ShouldBe(2);
         }
 
         // The end state pin: mt_streams row exists with type = aggregate type alias.
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
         await using var cmd = conn.CreateCommand($"select type from {_schema}.mt_streams where id = @id and tenant_id = @tid");
         cmd.Parameters.AddWithValue("id", streamId);
         cmd.Parameters.AddWithValue("tid", "alpha");
-        var typeName = (string?)await cmd.ExecuteScalarAsync();
+        var typeName = (string?)await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken);
         typeName.ShouldNotBeNull("mt_streams row must exist (not tombstoned) — the headline #4611 regression");
         typeName.ShouldBe(_store.Events.AggregateAliasFor(typeof(MandatoryAggregate)));
     }

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4665_catch_up_uses_global_high_water.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4665_catch_up_uses_global_high_water.cs
@@ -139,8 +139,8 @@ public partial class Bug_4665_catch_up_uses_global_high_water
 
             opts.Projections.Add<TripDistanceProjection>(ProjectionLifecycle.Async);
         });
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
-        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         // Five tenants. Each gets its own mt_events_sequence_{suffix}; appends
         // across tenants therefore interleave in mt_events.seq_id and produce
@@ -166,7 +166,7 @@ public partial class Bug_4665_catch_up_uses_global_high_water
                 session.Events.StartStream<TripDistance>(streamId,
                     new TripStarted(streamId),
                     new TripLeg(1.0));
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
         }
 
@@ -190,13 +190,13 @@ public partial class Bug_4665_catch_up_uses_global_high_water
         // event UNDER the global advance unprojected.
         await using (var bumpConn = new Npgsql.NpgsqlConnection(ConnectionSource.ConnectionString))
         {
-            await bumpConn.OpenAsync();
+            await bumpConn.OpenAsync(TestContext.Current.CancellationToken);
             await using var bumpCmd = bumpConn.CreateCommand();
             // Setval to 10,000 so the GLOBAL sequence reads far above the
             // actual per-tenant sequence high values (160 events across 5
             // tenants, max per-tenant ~32).
             bumpCmd.CommandText = $"select setval('{SchemaName}.mt_events_sequence', 10000);";
-            await bumpCmd.ExecuteNonQueryAsync();
+            await bumpCmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
             await bumpConn.CloseAsync();
         }
 
@@ -223,7 +223,7 @@ public partial class Bug_4665_catch_up_uses_global_high_water
         foreach (var (tenant, streamId) in lastTripPerTenant)
         {
             await using var query = store.QuerySession(tenant);
-            var doc = await query.LoadAsync<TripDistance>(streamId);
+            var doc = await query.LoadAsync<TripDistance>(streamId, TestContext.Current.CancellationToken);
             if (doc is null || doc.Distance < 1.0)
             {
                 stale.Add($"  tenant={tenant} streamId={streamId} doc={(doc is null ? "<null>" : $"Distance={doc.Distance}")}");

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4679_catch_up_per_tenant_23505.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4679_catch_up_per_tenant_23505.cs
@@ -133,8 +133,8 @@ public partial class Bug_4679_catch_up_per_tenant_23505
 
             opts.Projections.Add<TripDistanceProjection>(ProjectionLifecycle.Async);
         });
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
-        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         // Two tenants minimum — the bug needs ≥2 to fire (first tenant's loop
         // iteration inserts the store-global progression row; second tenant's
@@ -157,7 +157,7 @@ public partial class Bug_4679_catch_up_per_tenant_23505
             session.Events.StartStream<TripDistance>(streamId,
                 new TripStarted(streamId),
                 new TripLeg(1.0));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Drive the buggy path via ForceAllMartenDaemonActivityToCatchUpAsync — matches
@@ -178,7 +178,7 @@ public partial class Bug_4679_catch_up_per_tenant_23505
         }).AddAsyncDaemon(DaemonMode.Solo);
 
         using var host = hostBuilder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         try
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
@@ -193,7 +193,7 @@ public partial class Bug_4679_catch_up_per_tenant_23505
         {
             thrown = e;
         }
-        await host.StopAsync();
+        await host.StopAsync(TestContext.Current.CancellationToken);
 
         // Headline: no 23505 anywhere in the exception chain. Drill into
         // AggregateException so the per-shard exceptions surface.
@@ -215,7 +215,7 @@ public partial class Bug_4679_catch_up_per_tenant_23505
         foreach (var (tenant, streamId) in lastTripPerTenant)
         {
             await using var query = store.QuerySession(tenant);
-            var doc = await query.LoadAsync<TripDistance>(streamId);
+            var doc = await query.LoadAsync<TripDistance>(streamId, TestContext.Current.CancellationToken);
             doc.ShouldNotBeNull($"tenant {tenant} stream {streamId} should have a projected doc after catch-up");
             doc.Distance.ShouldBe(1.0);
         }

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4705_versioned_composite_per_tenant.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4705_versioned_composite_per_tenant.cs
@@ -119,8 +119,8 @@ public partial class Bug_4705_versioned_composite_per_tenant
         var schema = SchemaFor(version);
 
         using var store = (DocumentStore)DocumentStore.For(o => configure(o, version));
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
-        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         // #4705 reporter seeds a SINGLE tenant. That matters under per-tenant partitioning: each
         // tenant's events use a per-tenant sequence starting at 1, so seq_id is only globally unique
@@ -141,7 +141,7 @@ public partial class Bug_4705_versioned_composite_per_tenant
                 appended += 4;
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await store.BuildProjectionDaemonAsync();
@@ -158,7 +158,7 @@ public partial class Bug_4705_versioned_composite_per_tenant
             composite = rows.Where(r => r.Name.StartsWith("bug4705-composite")).Select(r => r.Seq).DefaultIfEmpty(0).Min();
             standalone = rows.Where(r => r.Name.StartsWith("Bug4705Standalone")).Select(r => r.Seq).DefaultIfEmpty(0).Max();
             if (highWater > 0 && composite >= highWater && standalone >= highWater) break;
-            await Task.Delay(500);
+            await Task.Delay(500, TestContext.Current.CancellationToken);
         }
 
         await daemon.StopAllAsync();

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4712_safe_harbor_high_water.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4712_safe_harbor_high_water.cs
@@ -70,8 +70,8 @@ public partial class Bug_4712_safe_harbor_high_water
             o.Projections.Add<Bug4712TripProjection>(ProjectionLifecycle.Async);
         });
 
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
-        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
         await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "t4712");
 
         long appended = 0;
@@ -85,7 +85,7 @@ public partial class Bug_4712_safe_harbor_high_water
                 appended += 4;
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var database = (MartenDatabase)store.Storage.Database;

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4717_per_tenant_progression.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4717_per_tenant_progression.cs
@@ -92,8 +92,8 @@ public partial class Bug_4717_per_tenant_progression
             });
         });
 
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
-        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         // Two tenants with DIFFERENT event heights — independent per-tenant sequences.
         var streamsPerTenant = new Dictionary<string, int> { ["t4717_a"] = 5, ["t4717_b"] = 3 };
@@ -110,7 +110,7 @@ public partial class Bug_4717_per_tenant_progression
                     new Bug4717Started(id), new Bug4717Leg(1.0), new Bug4717Leg(2.0), new Bug4717Leg(3.0));
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await store.BuildProjectionDaemonAsync();
@@ -126,7 +126,7 @@ public partial class Bug_4717_per_tenant_progression
             var allReady = projections.All(p => streamsPerTenant.Keys.All(t =>
                 rows.Any(r => isPerTenantRow(r.Name, p, t) && r.Seq >= expectedSeq[t])));
             if (allReady) break;
-            await Task.Delay(500);
+            await Task.Delay(500, TestContext.Current.CancellationToken);
         }
 
         await daemon.StopAllAsync();

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4867_per_tenant_high_water_advancement.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4867_per_tenant_high_water_advancement.cs
@@ -122,7 +122,7 @@ public class Bug_4867_per_tenant_high_water_advancement
         // Once the tenant has been observably stuck past StaleSequenceThreshold, the detector skips
         // the gap to the tenant's safe-harbor sequence — the per-tenant mirror of DetectInSafeZone.
         var threshold = _fixture.Store.Options.Projections.StaleSequenceThreshold;
-        await Task.Delay(threshold.Add(1500.Milliseconds()));
+        await Task.Delay(threshold.Add(1500.Milliseconds()), TestContext.Current.CancellationToken);
 
         var skipped = await detectAsync(detector, tenant);
         skipped.CurrentMark.ShouldBe(10,
@@ -213,8 +213,8 @@ public partial class Bug_4867_second_batch_projects_under_continuous_daemon
     {
         var schema = $"bug4867_a_p{Environment.ProcessId}";
         using var store = buildStore(schema);
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
-        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         const string tenant = "t4867_solo";
         await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
@@ -225,7 +225,7 @@ public partial class Bug_4867_second_batch_projects_under_continuous_daemon
         {
             session.Events.StartStream<Bug4867Trip>(streamId,
                 new Bug4867Started(streamId), new Bug4867Leg(1.0), new Bug4867Leg(2.0));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await store.BuildProjectionDaemonAsync();
@@ -242,7 +242,7 @@ public partial class Bug_4867_second_batch_projects_under_continuous_daemon
         await using (var session = store.LightweightSession(tenant))
         {
             session.Events.Append(streamId, new Bug4867Leg(5.0));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // THE #4867 regression: before the fix the tenant's mark stayed frozen at 3 forever and this
@@ -267,8 +267,8 @@ public partial class Bug_4867_second_batch_projects_under_continuous_daemon
     {
         var schema = $"bug4867_b_p{Environment.ProcessId}";
         using var store = buildStore(schema);
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
-        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         // Active tenant (taller per-tenant sequence) + lagging tenant (shorter). The lagging tenant's
         // own appends never move the store-global max(seq_id) — its advancement must ride the shared
@@ -284,14 +284,14 @@ public partial class Bug_4867_second_batch_projects_under_continuous_daemon
             session.Events.StartStream<Bug4867Trip>(activeStream,
                 new Bug4867Started(activeStream), new Bug4867Leg(1.0), new Bug4867Leg(1.0),
                 new Bug4867Leg(1.0), new Bug4867Leg(1.0)); // 5 events → seq 1..5, distance 4.0
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = store.LightweightSession(lagging))
         {
             session.Events.StartStream<Bug4867Trip>(laggingStream,
                 new Bug4867Started(laggingStream), new Bug4867Leg(1.0)); // 2 events → seq 1..2, distance 1.0
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await store.BuildProjectionDaemonAsync();
@@ -309,13 +309,13 @@ public partial class Bug_4867_second_batch_projects_under_continuous_daemon
         await using (var session = store.LightweightSession(lagging))
         {
             session.Events.Append(laggingStream, new Bug4867Leg(10.0));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = store.LightweightSession(active))
         {
             session.Events.Append(activeStream, new Bug4867Leg(20.0), new Bug4867Leg(20.0));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         (await waitForAsync(30.Seconds(), async () =>

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_5044_natural_key_table_migration.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_5044_natural_key_table_migration.cs
@@ -112,11 +112,11 @@ public class Bug_5044_natural_key_table_migration: IAsyncLifetime
             await using (var session = store.LightweightSession(TenantA))
             {
                 session.Events.StartStream<CaseStream>(streamId, new CaseOpened(streamId, "CASE-001"));
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
 
             await using var query = store.LightweightSession(TenantA);
-            var found = await query.Events.FetchLatest<CaseStream, CaseNumber>(new CaseNumber("CASE-001"));
+            var found = await query.Events.FetchLatest<CaseStream, CaseNumber>(new CaseNumber("CASE-001"), TestContext.Current.CancellationToken);
             found.ShouldNotBeNull();
             found.Id.ShouldBe(streamId);
         }
@@ -134,7 +134,7 @@ public class Bug_5044_natural_key_table_migration: IAsyncLifetime
         await using (var store = BuildStore())
         {
             // The cloned foreign key rows must not read back as configuration drift.
-            await store.Storage.Database.AssertDatabaseMatchesConfigurationAsync();
+            await store.Storage.Database.AssertDatabaseMatchesConfigurationAsync(TestContext.Current.CancellationToken);
         }
     }
 }

--- a/src/TenantPartitionedEventsTests/Regressions/bulk_insert_draws_from_the_tenants_own_sequence.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/bulk_insert_draws_from_the_tenants_own_sequence.cs
@@ -45,17 +45,17 @@ public class bulk_insert_draws_from_the_tenants_own_sequence
             new TripStarted(streamId), new TripLeg(1.0), new TripLeg(2.0));
         action.TenantId = tenant;
 
-        await _fixture.Store.BulkInsertEventsAsync(tenant, new[] { action });
+        await _fixture.Store.BulkInsertEventsAsync(tenant, new[] { action }, cancellation: TestContext.Current.CancellationToken);
 
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         long maxSeq;
         await using (var cmd = new NpgsqlCommand(
                          $"select max(seq_id) from {_fixture.SchemaName}.mt_events where tenant_id = @t", conn))
         {
             cmd.Parameters.AddWithValue("t", tenant);
-            maxSeq = (long)(await cmd.ExecuteScalarAsync())!;
+            maxSeq = (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
         }
 
         maxSeq.ShouldBe(3);
@@ -64,7 +64,7 @@ public class bulk_insert_draws_from_the_tenants_own_sequence
         await using (var cmd = new NpgsqlCommand(
                          $"select last_value from {_fixture.SchemaName}.mt_events_sequence_{tenant}", conn))
         {
-            ((long)(await cmd.ExecuteScalarAsync())!).ShouldBe(maxSeq,
+            ((long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!).ShouldBe(maxSeq,
                 "the bulk import must draw seq_ids from the tenant's own sequence — leaving it behind " +
                 "makes the tenant's first live append re-issue an already-used seq_id");
         }
@@ -74,14 +74,14 @@ public class bulk_insert_draws_from_the_tenants_own_sequence
         await using (var session = _fixture.Store.LightweightSession(tenant))
         {
             session.Events.Append(streamId, new TripLeg(3.0));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var cmd = new NpgsqlCommand(
                          $"select max(seq_id) from {_fixture.SchemaName}.mt_events where tenant_id = @t", conn))
         {
             cmd.Parameters.AddWithValue("t", tenant);
-            ((long)(await cmd.ExecuteScalarAsync())!).ShouldBe(maxSeq + 1);
+            ((long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!).ShouldBe(maxSeq + 1);
         }
     }
 }

--- a/src/TenantPartitionedEventsTests/Regressions/per_tenant_agent_start_routes_high_water.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/per_tenant_agent_start_routes_high_water.cs
@@ -72,8 +72,8 @@ public partial class per_tenant_agent_start_routes_high_water
             // Nested type name + tenant suffix overflows PG's 64-byte identifier limit; shorten it.
             opts.Schema.For<TenantTripDistance>().Identity(x => x.Id).DocumentAlias("pt_agent_trip");
         });
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
-        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         var tenants = new[] { $"t_{Guid.NewGuid():N}"[..12], $"t_{Guid.NewGuid():N}"[..12] };
         await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenants);
@@ -86,7 +86,7 @@ public partial class per_tenant_agent_start_routes_high_water
             streamByTenant[tenant] = streamId;
             await using var session = store.LightweightSession(tenant);
             session.Events.StartStream<TenantTripDistance>(streamId, new TripStarted(streamId), new TripLeg(1.0));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await store.BuildProjectionDaemonAsync();

--- a/src/TenantPartitionedEventsTests/Regressions/preserve_sequence_streaming_bulk_import.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/preserve_sequence_streaming_bulk_import.cs
@@ -99,7 +99,7 @@ public class preserve_sequence_streaming_bulk_import
         };
 
         await _fixture.Store.BulkInsertEventStreamAsync(tenant, headers, Stream(events),
-            BulkEventSequenceMode.PreserveSourceSequence, batchSize: 2);
+            BulkEventSequenceMode.PreserveSourceSequence, batchSize: 2, TestContext.Current.CancellationToken);
 
         // (a) The seq_ids are EXACTLY the source values — never renumbered, gaps intact.
         (await SeqIdsForTenantAsync(tenant)).ShouldBe(new long[] { 3, 7, 12, 40, 41 });
@@ -112,7 +112,7 @@ public class preserve_sequence_streaming_bulk_import
         await using (var session = _fixture.Store.LightweightSession(tenant))
         {
             session.Events.Append(streamX, new TripLeg(4.0));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var afterAppend = await SeqIdsForTenantAsync(tenant);

--- a/src/TenantPartitionedEventsTests/Regressions/schema_update_preserves_existing_per_tenant_sequences.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/schema_update_preserves_existing_per_tenant_sequences.cs
@@ -75,49 +75,49 @@ public class schema_update_preserves_existing_per_tenant_sequences : IAsyncLifet
         await using (var session = _store.LightweightSession(TenantA))
         {
             session.Events.StartStream(Guid.NewGuid(), new SeqPreserveEvent(1), new SeqPreserveEvent(2));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         var valueBefore = (long)(await conn
             .CreateCommand($"select last_value from \"{_schema}\".\"mt_events_sequence_{TenantA}\"")
-            .ExecuteScalarAsync())!;
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
         valueBefore.ShouldBeGreaterThanOrEqualTo(2);
 
         // Simulate the canary scenario: a tenant is registered on the shared partition list but its
         // sequence is missing in this database (mid-provisioning / a racing applier's stale snapshot),
         // so the next schema apply computes an Update delta for the per-tenant sequences.
         await conn.CreateCommand($"drop sequence \"{_schema}\".\"mt_events_sequence_{TenantB}\"")
-            .ExecuteNonQueryAsync();
+            .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
 
-        await _store.Storage.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await _store.Storage.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
 
         // The missing sequence is (re)created...
         var tenantBExists = await conn
             .CreateCommand(
                 "select count(*) from information_schema.sequences " +
                 $"where sequence_schema = '{_schema}' and sequence_name = 'mt_events_sequence_{TenantB}'")
-            .ExecuteScalarAsync();
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken);
         tenantBExists.ShouldBe(1L);
 
         // ...and tenant A's sequence kept its value: the update was additive-only, no drop+recreate.
         var valueAfter = (long)(await conn
             .CreateCommand($"select last_value from \"{_schema}\".\"mt_events_sequence_{TenantA}\"")
-            .ExecuteScalarAsync())!;
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
         valueAfter.ShouldBe(valueBefore);
 
         // And the next append continues from where the sequence left off instead of colliding at 1.
         await using (var session = _store.LightweightSession(TenantA))
         {
             session.Events.StartStream(Guid.NewGuid(), new SeqPreserveEvent(3));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var valueAfterAppend = (long)(await conn
             .CreateCommand($"select last_value from \"{_schema}\".\"mt_events_sequence_{TenantA}\"")
-            .ExecuteScalarAsync())!;
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
         valueAfterAppend.ShouldBeGreaterThan(valueBefore);
     }
 }

--- a/src/TenantPartitionedEventsTests/Regressions/streaming_bulk_import_on_a_partitioned_store.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/streaming_bulk_import_on_a_partitioned_store.cs
@@ -75,10 +75,10 @@ public class streaming_bulk_import_on_a_partitioned_store
             EventFor(streamX, 3, new TripLeg(3.0))
         };
 
-        await _fixture.Store.BulkInsertEventStreamAsync(tenant, headers, Stream(events), batchSize: 2);
+        await _fixture.Store.BulkInsertEventStreamAsync(tenant, headers, Stream(events), batchSize: 2, TestContext.Current.CancellationToken);
 
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         // (a) Cross-stream order preserved: reading back by seq_id yields the interleaving.
         var order = new List<Guid>();
@@ -87,8 +87,8 @@ public class streaming_bulk_import_on_a_partitioned_store
                          conn))
         {
             cmd.Parameters.AddWithValue("t", tenant);
-            await using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+            while (await reader.ReadAsync(TestContext.Current.CancellationToken))
             {
                 order.Add(reader.GetGuid(0));
             }
@@ -102,7 +102,7 @@ public class streaming_bulk_import_on_a_partitioned_store
                          $"select max(seq_id) from {_fixture.SchemaName}.mt_events where tenant_id = @t", conn))
         {
             cmd.Parameters.AddWithValue("t", tenant);
-            maxSeq = (long)(await cmd.ExecuteScalarAsync())!;
+            maxSeq = (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
         }
 
         maxSeq.ShouldBe(5);
@@ -113,21 +113,21 @@ public class streaming_bulk_import_on_a_partitioned_store
         await using (var cmd = new NpgsqlCommand(
                          $"select last_value from {_fixture.SchemaName}.mt_events_sequence_{tenant}", conn))
         {
-            ((long)(await cmd.ExecuteScalarAsync())!).ShouldBeGreaterThanOrEqualTo(maxSeq);
+            ((long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!).ShouldBeGreaterThanOrEqualTo(maxSeq);
         }
 
         // (c) A live append directly after the import continues above the imported events.
         await using (var session = _fixture.Store.LightweightSession(tenant))
         {
             session.Events.Append(streamX, new TripLeg(4.0));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var cmd = new NpgsqlCommand(
                          $"select max(seq_id) from {_fixture.SchemaName}.mt_events where tenant_id = @t", conn))
         {
             cmd.Parameters.AddWithValue("t", tenant);
-            ((long)(await cmd.ExecuteScalarAsync())!).ShouldBeGreaterThan(maxSeq);
+            ((long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!).ShouldBeGreaterThan(maxSeq);
         }
     }
 }

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4679_sharded_catch_up_23505.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4679_sharded_catch_up_23505.cs
@@ -180,7 +180,7 @@ public partial class Bug_4679_sharded_catch_up_23505: IAsyncLifetime
                 new Bug4679TripStarted(streamId),
                 new Bug4679TripLeg(1.0),
                 new Bug4679TripLeg(2.5));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Drive the buggy path directly against the shard that carries 3 tenants. This is exactly
@@ -276,7 +276,7 @@ public partial class Bug_4679_sharded_catch_up_23505: IAsyncLifetime
                 new Bug4679TripStarted(streamId),
                 new Bug4679TripLeg(1.0),
                 new Bug4679TripLeg(2.5));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await store.BuildProjectionDaemonAsync("tA");

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4706_sharded_partitioned_doc_rebuild.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4706_sharded_partitioned_doc_rebuild.cs
@@ -99,7 +99,7 @@ public class Bug_4706_sharded_partitioned_doc_rebuild: IAsyncLifetime
             var databases = await store.Options.Tenancy.BuildDatabases();
             foreach (var db in databases.OfType<IMartenDatabase>())
             {
-                await db.ApplyAllConfiguredChangesToDatabaseAsync();
+                await db.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
             }
 
             foreach (var (tenant, shard) in assignment)
@@ -111,7 +111,7 @@ public class Bug_4706_sharded_partitioned_doc_rebuild: IAsyncLifetime
             {
                 await using var session = store.LightweightSession(tenant);
                 session.Store(new Bug4706Doc { Id = Guid.NewGuid(), Name = "n-" + tenant });
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
         }
 

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4713_sharded_reapply_same_store.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4713_sharded_reapply_same_store.cs
@@ -109,7 +109,7 @@ public class Bug_4713_sharded_reapply_same_store: IAsyncLifetime
         var databases = await store.Options.Tenancy.BuildDatabases();
         foreach (var db in databases.OfType<IMartenDatabase>())
         {
-            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+            await db.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
         }
 
         // Provision tenants — the additive path that (pre-9.1.5) permanently cleared
@@ -123,7 +123,7 @@ public class Bug_4713_sharded_reapply_same_store: IAsyncLifetime
         {
             await using var session = store.LightweightSession(tenant);
             session.Store(new Bug4713Doc { Id = Guid.NewGuid(), Name = "n-" + tenant });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Capture the partition layout each shard has AFTER provisioning. #4713 is specifically about

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4751_composite_catchup_under_sharded.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4751_composite_catchup_under_sharded.cs
@@ -136,7 +136,7 @@ public class Bug_4751_composite_catchup_under_sharded: IAsyncLifetime
             {
                 session.Events.StartStream<CmpTrip>(Guid.NewGuid(), new CmpLeg(1.0), new CmpLeg(2.5));
             }
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Normal async catch-up (NOT RebuildProjectionAsync): start the daemon and wait for non-stale.
@@ -146,8 +146,8 @@ public class Bug_4751_composite_catchup_under_sharded: IAsyncLifetime
 
         // After the catch-up helper returns, BOTH composite stages must be materialized for the tenant.
         await using var query = _store.QuerySession("tenant_a");
-        var stage1 = await query.Query<CmpTrip>().CountAsync();
-        var stage2 = await query.Query<CmpTripCount>().CountAsync();
+        var stage1 = await query.Query<CmpTrip>().CountAsync(TestContext.Current.CancellationToken);
+        var stage2 = await query.Query<CmpTripCount>().CountAsync(TestContext.Current.CancellationToken);
         _output.WriteLine($"stage1 (CmpTrip) = {stage1}, stage2 (CmpTripCount) = {stage2}, expected {streams}");
 
         stage1.ShouldBe(streams, "stage-1 of the composite must be caught up by the async daemon");

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4753_sharded_partitioned_event_rebuild.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4753_sharded_partitioned_event_rebuild.cs
@@ -96,7 +96,7 @@ public class Bug_4753_sharded_partitioned_event_rebuild: IAsyncLifetime
             var databases = await store.Options.Tenancy.BuildDatabases();
             foreach (var db in databases.OfType<IMartenDatabase>())
             {
-                await db.ApplyAllConfiguredChangesToDatabaseAsync();
+                await db.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
             }
 
             foreach (var (tenant, shard) in assignment)
@@ -108,7 +108,7 @@ public class Bug_4753_sharded_partitioned_event_rebuild: IAsyncLifetime
             {
                 await using var session = store.LightweightSession(tenant);
                 session.Events.StartStream(Guid.NewGuid(), new Bug4753ShardedEvent("e-" + tenant));
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
         }
 

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4761_per_tenant_progression_same_shard.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4761_per_tenant_progression_same_shard.cs
@@ -109,7 +109,7 @@ public class Bug_4761_per_tenant_progression_same_shard: IAsyncLifetime
         {
             session.Events.StartStream<ShardedDaemonCounter>(xStream,
                 new ShardedDaemonEvent("x-1"), new ShardedDaemonEvent("x-2"), new ShardedDaemonEvent("x-3"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var yStream = Guid.NewGuid();
@@ -117,7 +117,7 @@ public class Bug_4761_per_tenant_progression_same_shard: IAsyncLifetime
         {
             session.Events.StartStream<ShardedDaemonCounter>(yStream,
                 new ShardedDaemonEvent("y-1"), new ShardedDaemonEvent("y-2"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await _store.BuildProjectionDaemonAsync("tenant_x");
@@ -129,10 +129,10 @@ public class Bug_4761_per_tenant_progression_same_shard: IAsyncLifetime
         ShardedDaemonCounter? dx = null, dy = null;
         while (sw.Elapsed < 20.Seconds())
         {
-            await using (var q = _store.QuerySession("tenant_x")) dx = await q.LoadAsync<ShardedDaemonCounter>(xStream);
-            await using (var q = _store.QuerySession("tenant_y")) dy = await q.LoadAsync<ShardedDaemonCounter>(yStream);
+            await using (var q = _store.QuerySession("tenant_x")) dx = await q.LoadAsync<ShardedDaemonCounter>(xStream, TestContext.Current.CancellationToken);
+            await using (var q = _store.QuerySession("tenant_y")) dy = await q.LoadAsync<ShardedDaemonCounter>(yStream, TestContext.Current.CancellationToken);
             if (dx is { EventCount: 3 } && dy is { EventCount: 2 }) break;
-            await Task.Delay(250);
+            await Task.Delay(250, TestContext.Current.CancellationToken);
         }
         dx.ShouldNotBeNull(); dx!.EventCount.ShouldBe(3);
         dy.ShouldNotBeNull(); dy!.EventCount.ShouldBe(2);

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4863_4855_per_database_partition_state.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4863_4855_per_database_partition_state.cs
@@ -171,7 +171,7 @@ public class Bug_4863_4855_per_database_partition_state: IAsyncLifetime
 
             await using var seed = node1.LightweightSession("t4863_one");
             seed.Store(new Doc4863A { Id = Guid.NewGuid(), Name = "seeded" });
-            await seed.SaveChangesAsync();
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Node 2 is a FRESH store instance that additionally registers Doc4863B, whose
@@ -184,7 +184,7 @@ public class Bug_4863_4855_per_database_partition_state: IAsyncLifetime
 
         // Before the fix: mt_doc_bug4863_b is created partitioned-by-tenant with ZERO
         // partitions and this fails with 23514 "no partition of relation found for row".
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // And the lazily-created table must hydrate partitions for EVERY tenant resident
         // on the shard (from the shard's own registry), not just the writing tenant.
@@ -206,7 +206,7 @@ public class Bug_4863_4855_per_database_partition_state: IAsyncLifetime
             await using var session = store.LightweightSession(tenant);
             session.Events.StartStream(Guid.NewGuid(), new Evt4863(tenant));
             session.Store(new Doc4863A { Id = Guid.NewGuid(), Name = tenant });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // First touch of shard B — before the fix the lazily-created tables on shard B
@@ -217,7 +217,7 @@ public class Bug_4863_4855_per_database_partition_state: IAsyncLifetime
         {
             sessionB.Events.StartStream(Guid.NewGuid(), new Evt4863("t4855_b1"));
             sessionB.Store(new Doc4863A { Id = Guid.NewGuid(), Name = "t4855_b1" });
-            await sessionB.SaveChangesAsync();
+            await sessionB.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var shardBStreams = await ListPartitions(PerDbPartitionStateFixture.ShardB, DocSchema, "mt_streams");
@@ -248,14 +248,14 @@ public class Bug_4863_4855_per_database_partition_state: IAsyncLifetime
         {
             sa.Events.StartStream(Guid.NewGuid(), new Evt4863("a1"));
             sa.Store(new Doc4863A { Id = Guid.NewGuid(), Name = "a1" });
-            await sa.SaveChangesAsync();
+            await sa.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var sb = store.LightweightSession("t4855_b1"))
         {
             sb.Events.StartStream(Guid.NewGuid(), new Evt4863("b1"));
             sb.Store(new Doc4863A { Id = Guid.NewGuid(), Name = "b1" });
-            await sb.SaveChangesAsync();
+            await sb.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
     }
 

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4942_auto_assign_provisioning_repair.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4942_auto_assign_provisioning_repair.cs
@@ -172,12 +172,12 @@ public class Bug_4942_auto_assign_provisioning_repair : IAsyncLifetime
         {
             session.Store(new Bug4942Doc { Id = Guid.NewGuid(), Name = "healed" });
             session.Events.StartStream(Guid.NewGuid(), new ShardedTestEvent { Value = "healed" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var query = store2.QuerySession(tenantId))
         {
-            (await query.Query<Bug4942Doc>().CountAsync()).ShouldBe(1);
+            (await query.Query<Bug4942Doc>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
         }
     }
 
@@ -231,7 +231,7 @@ public class Bug_4942_auto_assign_provisioning_repair : IAsyncLifetime
         var databases = await store.Options.Tenancy.BuildDatabases();
         foreach (var db in databases.OfType<IMartenDatabase>())
         {
-            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+            await db.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
         }
 
         var dbId = await store.Advanced.AddTenantToShardAsync(tenantId, CancellationToken.None);

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4944_database_driven_partition_sweep.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4944_database_driven_partition_sweep.cs
@@ -190,14 +190,14 @@ public class Bug_4944_database_driven_partition_sweep : IAsyncLifetime
             session.Store(new Bug4944Beta { Id = Guid.NewGuid(), Name = "b" });
             session.Store(new Bug4944Gamma { Id = Guid.NewGuid(), Name = "g" });
             session.Events.StartStream(Guid.NewGuid(), new ShardedTestEvent { Value = "e" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var query = app.QuerySession(tenantId))
         {
-            (await query.Query<Bug4944Alpha>().CountAsync()).ShouldBe(1);
-            (await query.Query<Bug4944Beta>().CountAsync()).ShouldBe(1);
-            (await query.Query<Bug4944Gamma>().CountAsync()).ShouldBe(1);
+            (await query.Query<Bug4944Alpha>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
+            (await query.Query<Bug4944Beta>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
+            (await query.Query<Bug4944Gamma>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
         }
     }
 
@@ -275,16 +275,16 @@ public class Bug_4944_database_driven_partition_sweep : IAsyncLifetime
         foreach (var connStr in _fixture.ConnectionStrings.Values)
         {
             await using var conn = new NpgsqlConnection(connStr);
-            await conn.OpenAsync();
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-            await conn.CreateCommand("create schema if not exists foreign_app").ExecuteNonQueryAsync();
+            await conn.CreateCommand("create schema if not exists foreign_app").ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
             await conn.CreateCommand(
                     "create table foreign_app.their_ledger (tenant_id varchar not null, amount int) partition by list (tenant_id)")
-                .ExecuteNonQueryAsync();
+                .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
 
             await conn.CreateCommand(
                     "create table public.other_app_ledger (category varchar not null, amount int) partition by list (category)")
-                .ExecuteNonQueryAsync();
+                .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
         }
 
         var app = BuildApplicationStore();

--- a/src/TenantPartitionedEventsTests/Sharded/composite_side_effects_rebuild_under_sharded_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/composite_side_effects_rebuild_under_sharded_partitioning.cs
@@ -173,7 +173,7 @@ public partial class composite_side_effects_rebuild_under_sharded_partitioning: 
                 session.Events.StartStream<CsTrip>(id, new TripStarted(id), new TripLeg(1.0), new TripLeg(2.5));
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await store.BuildProjectionDaemonAsync("tA");
@@ -197,8 +197,8 @@ public partial class composite_side_effects_rebuild_under_sharded_partitioning: 
         foreach (var tenant in new[] { "tA", "tB", "tC" })
         {
             await using var session = store.QuerySession(tenant);
-            (await session.Query<CsTrip>().CountAsync()).ShouldBe(streamsPerTenant);
-            (await session.Query<CsTripNotice>().CountAsync()).ShouldBe(streamsPerTenant);
+            (await session.Query<CsTrip>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(streamsPerTenant);
+            (await session.Query<CsTripNotice>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(streamsPerTenant);
         }
     }
 

--- a/src/TenantPartitionedEventsTests/Sharded/dynamic_tenant_lifecycle_on_shard_during_daemon.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/dynamic_tenant_lifecycle_on_shard_during_daemon.cs
@@ -152,14 +152,14 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
             session.Events.StartStream<ShardedDaemonCounter>(stream1,
                 new ShardedDaemonEvent("t1-1"), new ShardedDaemonEvent("t1-2"),
                 new ShardedDaemonEvent("t1-3"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var node = await new HostBuilder()
             .ConfigureServices(services =>
             {
                 services.AddMarten(Configure).AddAsyncDaemon(DaemonMode.HotCold);
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         try
         {
@@ -188,7 +188,7 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
             {
                 session.Events.StartStream<ShardedDaemonCounter>(stream2,
                     new ShardedDaemonEvent("t2-1"), new ShardedDaemonEvent("t2-2"));
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
 
             // Pin 2 — FLIPPED (was the pre-#491 negative pin + explicit StartAgentAsync): the
@@ -221,13 +221,13 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
             while (sw.Elapsed < 20.Seconds())
             {
                 await using var query = _store.QuerySession(tenant2);
-                doc2 = await query.LoadAsync<ShardedDaemonCounter>(stream2);
+                doc2 = await query.LoadAsync<ShardedDaemonCounter>(stream2, TestContext.Current.CancellationToken);
                 if (doc2 is { EventCount: 2 })
                 {
                     break;
                 }
 
-                await Task.Delay(250);
+                await Task.Delay(250, TestContext.Current.CancellationToken);
             }
 
             doc2.ShouldNotBeNull("tenant 2's projection doc must materialize on shard A");
@@ -237,7 +237,7 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
             SeqOf(rows, $"{ShardedDaemonProjection.ProjectionName}:All:{tenant1}").ShouldBe(3);
             await using (var query = _store.QuerySession(tenant1))
             {
-                (await query.LoadAsync<ShardedDaemonCounter>(stream1))!.EventCount.ShouldBe(3);
+                (await query.LoadAsync<ShardedDaemonCounter>(stream1, TestContext.Current.CancellationToken))!.EventCount.ShouldBe(3);
             }
 
             // ---- Phase 2 (#4868 / #4880): REMOVE tenant 2 while the coordinator keeps running ----
@@ -283,7 +283,7 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
             await using (var session = _store.LightweightSession(tenant1))
             {
                 session.Events.Append(stream1, new ShardedDaemonEvent("t1-4"));
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
 
             var survivorRows = await WaitForProgressionAsync(shardConnStr, r =>
@@ -311,7 +311,7 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
                 session.Events.StartStream<ShardedDaemonCounter>(reStream2,
                     new ShardedDaemonEvent("t2b-1"), new ShardedDaemonEvent("t2b-2"),
                     new ShardedDaemonEvent("t2b-3"));
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
 
             // The running coordinator re-discovers the re-added tenant on its next leadership cycle:
@@ -327,11 +327,11 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
             // projection doc is gone and only the 3 newly-appended events are projected.
             await using (var query = _store.QuerySession(tenant2))
             {
-                var reDoc = await query.LoadAsync<ShardedDaemonCounter>(reStream2);
+                var reDoc = await query.LoadAsync<ShardedDaemonCounter>(reStream2, TestContext.Current.CancellationToken);
                 reDoc.ShouldNotBeNull("the re-added tenant's projection doc must materialize on shard A");
                 reDoc!.EventCount.ShouldBe(3);
 
-                (await query.LoadAsync<ShardedDaemonCounter>(stream2))
+                (await query.LoadAsync<ShardedDaemonCounter>(stream2, TestContext.Current.CancellationToken))
                     .ShouldBeNull("the pre-removal projection doc must not survive a destructive remove + re-add");
             }
 
@@ -342,7 +342,7 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
         }
         finally
         {
-            await node.StopAsync();
+            await node.StopAsync(TestContext.Current.CancellationToken);
         }
     }
 

--- a/src/TenantPartitionedEventsTests/Sharded/multi_node_hotcold_sharded_partitioned_events.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/multi_node_hotcold_sharded_partitioned_events.cs
@@ -181,7 +181,7 @@ public partial class multi_node_hotcold_sharded_partitioned_events: IAsyncLifeti
                     .Concat(Enumerable.Range(0, legs).Select(_ => (object)new ShLeg(1.0)))
                     .ToArray();
                 session.Events.StartStream<ShTrip>(id, events);
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
         }
 
@@ -277,18 +277,18 @@ public partial class multi_node_hotcold_sharded_partitioned_events: IAsyncLifeti
             foreach (var (tenant, legs) in tenantsByShard.Values.SelectMany(x => x))
             {
                 await using var query = bootstrap.QuerySession(tenant);
-                var trip = await query.LoadAsync<ShTrip>(streams[tenant]);
+                var trip = await query.LoadAsync<ShTrip>(streams[tenant], TestContext.Current.CancellationToken);
                 trip.ShouldNotBeNull($"tenant {tenant}'s ShTrip doc must materialize on its shard");
                 trip!.Distance.ShouldBe(legs);
-                var tally = await query.LoadAsync<ShTally>(streams[tenant]);
+                var tally = await query.LoadAsync<ShTally>(streams[tenant], TestContext.Current.CancellationToken);
                 tally.ShouldNotBeNull($"tenant {tenant}'s ShTally doc must materialize on its shard");
                 tally!.Count.ShouldBe(legs);
             }
         }
         finally
         {
-            await nodeA.StopAsync();
-            await nodeB.StopAsync();
+            await nodeA.StopAsync(TestContext.Current.CancellationToken);
+            await nodeB.StopAsync(TestContext.Current.CancellationToken);
         }
     }
 

--- a/src/TenantPartitionedEventsTests/Sharded/sharded_daemon_per_shard_progression.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/sharded_daemon_per_shard_progression.cs
@@ -125,7 +125,7 @@ public class sharded_daemon_per_shard_progression : IAsyncLifetime
                 new ShardedDaemonEvent("a-1"),
                 new ShardedDaemonEvent("a-2"),
                 new ShardedDaemonEvent("a-3"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var bStream = Guid.NewGuid();
@@ -134,7 +134,7 @@ public class sharded_daemon_per_shard_progression : IAsyncLifetime
             session.Events.StartStream<ShardedDaemonCounter>(bStream,
                 new ShardedDaemonEvent("b-1"),
                 new ShardedDaemonEvent("b-2"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Drive ONE daemon per shard — under sharded tenancy each shard is its
@@ -157,13 +157,13 @@ public class sharded_daemon_per_shard_progression : IAsyncLifetime
         while (sw.Elapsed < 20.Seconds())
         {
             await using (var query = _store.QuerySession("tenant_on_a"))
-                docA = await query.LoadAsync<ShardedDaemonCounter>(aStream);
+                docA = await query.LoadAsync<ShardedDaemonCounter>(aStream, TestContext.Current.CancellationToken);
             await using (var query = _store.QuerySession("tenant_on_b"))
-                docB = await query.LoadAsync<ShardedDaemonCounter>(bStream);
+                docB = await query.LoadAsync<ShardedDaemonCounter>(bStream, TestContext.Current.CancellationToken);
 
             if (docA is { EventCount: 3 } && docB is { EventCount: 2 }) break;
 
-            await Task.Delay(250);
+            await Task.Delay(250, TestContext.Current.CancellationToken);
         }
 
         docA.ShouldNotBeNull("tenant_on_a's projection must materialize on shard A");
@@ -208,14 +208,14 @@ public class sharded_daemon_per_shard_progression : IAsyncLifetime
         {
             session.Events.StartStream<ShardedDaemonCounter>(aStream,
                 new ShardedDaemonEvent("a"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         var cStream = Guid.NewGuid();
         await using (var session = _store.LightweightSession("progress_c"))
         {
             session.Events.StartStream<ShardedDaemonCounter>(cStream,
                 new ShardedDaemonEvent("c"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemonA = await _store.BuildProjectionDaemonAsync("progress_a");
@@ -248,7 +248,7 @@ public class sharded_daemon_per_shard_progression : IAsyncLifetime
                 break;
             }
 
-            await Task.Delay(250);
+            await Task.Delay(250, TestContext.Current.CancellationToken);
         }
 
         rowsOnA.Count.ShouldBeGreaterThan(0,

--- a/src/TenantPartitionedEventsTests/Sharded/sharded_eager_apply_per_tenant_events.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/sharded_eager_apply_per_tenant_events.cs
@@ -103,7 +103,7 @@ public class sharded_eager_apply_per_tenant_events : IAsyncLifetime
         var databases = await _store.Options.Tenancy.BuildDatabases();
         foreach (var db in databases.OfType<IMartenDatabase>())
         {
-            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+            await db.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
         }
 
         // Runtime tenant provisioning hits the partition-attach path against an
@@ -118,12 +118,12 @@ public class sharded_eager_apply_per_tenant_events : IAsyncLifetime
         // partition of relation mt_events found for row).
         await using var session = _store.LightweightSession("alpha");
         session.Events.StartStream(Guid.NewGuid(), new ShardedTestEvent { Value = "eager-apply-then-tenant" });
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Sanity: the partition lives in the assigned shard.
         await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
-        await conn.OpenAsync();
-        var tables = await conn.ExistingTablesAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        var tables = await conn.ExistingTablesAsync(ct: TestContext.Current.CancellationToken);
         tables.Any(t => t.Name == "mt_events_alpha").ShouldBeTrue(
             $"mt_events_alpha partition must exist after eager-apply + runtime tenant. Tables: {string.Join(", ", tables.Select(t => t.QualifiedName))}");
     }

--- a/src/TenantPartitionedEventsTests/Sharded/sharded_one_database_per_shard.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/sharded_one_database_per_shard.cs
@@ -135,7 +135,7 @@ public class sharded_one_database_per_shard : IAsyncLifetime
         await using (var session = _store.LightweightSession("disabletest_b"))
         {
             session.Events.StartStream(streamId, new ShardedTestEvent { Value = "before-disable" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Disable tenant A. The shared MartenDatabase must NOT be disposed.
@@ -146,12 +146,12 @@ public class sharded_one_database_per_shard : IAsyncLifetime
         await using (var session = _store.LightweightSession("disabletest_b"))
         {
             session.Events.Append(streamId, new ShardedTestEvent { Value = "after-disable" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var query = _store.QuerySession("disabletest_b"))
         {
-            var events = await query.Events.FetchStreamAsync(streamId);
+            var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
             events.Count.ShouldBe(2,
                 "tenant B's appends must survive a co-located tenant A Disable — the shared " +
                 "MartenDatabase is reference-counted, not disposed on the first tenant's Disable");

--- a/src/TenantPartitionedEventsTests/Sharded/sharded_progress_reading_4797.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/sharded_progress_reading_4797.cs
@@ -126,7 +126,7 @@ public class sharded_progress_reading_4797: IAsyncLifetime
         {
             session.Events.StartStream<Progress4797Doc>(aStream,
                 new Progress4797Event("a-1"), new Progress4797Event("a-2"), new Progress4797Event("a-3"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var bStream = Guid.NewGuid();
@@ -134,7 +134,7 @@ public class sharded_progress_reading_4797: IAsyncLifetime
         {
             session.Events.StartStream<Progress4797Doc>(bStream,
                 new Progress4797Event("b-1"), new Progress4797Event("b-2"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // One daemon per shard (BuildProjectionDaemonAsync needs an explicit
@@ -161,13 +161,13 @@ public class sharded_progress_reading_4797: IAsyncLifetime
         var sw = System.Diagnostics.Stopwatch.StartNew();
         while (sw.Elapsed < 30.Seconds())
         {
-            all = await _store.Advanced.AllProjectionProgress();
+            all = await _store.Advanced.AllProjectionProgress(token: TestContext.Current.CancellationToken);
             if (SeqFor(all, "t4797_a") >= 3 && SeqFor(all, "t4797_b") >= 2)
             {
                 break;
             }
 
-            await Task.Delay(250);
+            await Task.Delay(250, TestContext.Current.CancellationToken);
         }
 
         // Per-tenant projection rows from BOTH shard databases show up in one read,
@@ -179,7 +179,7 @@ public class sharded_progress_reading_4797: IAsyncLifetime
 
         // The tenant-scoped overload keeps its documented "database containing this
         // tenant id" semantics: it reads ONLY that tenant's shard database.
-        var onlyShardA = await _store.Advanced.AllProjectionProgress("t4797_a");
+        var onlyShardA = await _store.Advanced.AllProjectionProgress("t4797_a", TestContext.Current.CancellationToken);
         SeqFor(onlyShardA, "t4797_a").ShouldBe(3);
         SeqFor(onlyShardA, "t4797_b").ShouldBe(0,
             "tenant b lives on a different shard database, so its rows must not appear");
@@ -189,20 +189,20 @@ public class sharded_progress_reading_4797: IAsyncLifetime
         // so the cross-shard read returns that tenant's exact progression.
         var tenantAShard = ShardName.Compose(
             Progress4797Projection.ProjectionName, "All", "t4797_a", 1);
-        (await _store.Advanced.ProjectionProgressFor(tenantAShard)).ShouldBe(3);
+        (await _store.Advanced.ProjectionProgressFor(tenantAShard, token: TestContext.Current.CancellationToken)).ShouldBe(3);
 
         var tenantBShard = ShardName.Compose(
             Progress4797Projection.ProjectionName, "All", "t4797_b", 1);
-        (await _store.Advanced.ProjectionProgressFor(tenantBShard)).ShouldBe(2);
+        (await _store.Advanced.ProjectionProgressFor(tenantBShard, token: TestContext.Current.CancellationToken)).ShouldBe(2);
 
         // And the issue's literal repro: the store-global HighWaterMark identity exists
         // per shard database; the null-tenant read returns the highest one instead of
         // throwing. Shard A saw 3 events on its per-tenant sequence, so the max is >= 3.
-        var highWater = await _store.Advanced.ProjectionProgressFor(new ShardName(ShardState.HighWaterMark));
+        var highWater = await _store.Advanced.ProjectionProgressFor(new ShardName(ShardState.HighWaterMark), token: TestContext.Current.CancellationToken);
         highWater.ShouldBeGreaterThanOrEqualTo(3);
 
         // A shard identity that exists nowhere reports 0, not an exception.
-        (await _store.Advanced.ProjectionProgressFor(new ShardName("NoSuchProjection"))).ShouldBe(0);
+        (await _store.Advanced.ProjectionProgressFor(new ShardName("NoSuchProjection"), token: TestContext.Current.CancellationToken)).ShouldBe(0);
     }
 }
 

--- a/src/TenantPartitionedEventsTests/Sharded/sharded_tenancy_per_tenant_events.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/sharded_tenancy_per_tenant_events.cs
@@ -119,7 +119,7 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
         // never created. With the fix, it succeeds.
         await using var session = _store.LightweightSession("alpha");
         session.Events.StartStream(Guid.NewGuid(), new ShardedTestEvent { Value = "first" });
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
     }
 
     // #4611 — With UseTenantPartitionedEvents, StartStream actions are routed through the bulk
@@ -143,12 +143,12 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
         await using (var session = _store.LightweightSession("india"))
         {
             session.Events.StartStream<ShardedAggregate>(streamId, new ShardedTestEvent { Value = "first" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var query = _store.QuerySession("india"))
         {
-            (await query.Events.FetchStreamAsync(streamId)).Count.ShouldBe(1);
+            (await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken)).Count.ShouldBe(1);
         }
 
         // End-state assertion that #4611 specifically broke: the mt_streams row must
@@ -166,12 +166,12 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
         await using (var session = _store.LightweightSession("india"))
         {
             session.Events.Append(streamId, new ShardedTestEvent { Value = "second" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var query = _store.QuerySession("india"))
         {
-            (await query.Events.FetchStreamAsync(streamId)).Count.ShouldBe(2);
+            (await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken)).Count.ShouldBe(2);
         }
     }
 
@@ -264,16 +264,16 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
         await using (var session = _store.LightweightSession("charlie"))
         {
             session.Events.StartStream(Guid.NewGuid(), new ShardedTestEvent { Value = "for-partition-check" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // The original report observed that AddTenantToShardAsync created the document
         // LIST partitions but not the event partition. This pins both ends — event
         // partition + sequence — for the runtime-provisioning path.
         await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-        var tables = await conn.ExistingTablesAsync();
+        var tables = await conn.ExistingTablesAsync(ct: TestContext.Current.CancellationToken);
         tables.Any(t => t.Name == "mt_events_charlie").ShouldBeTrue(
             $"mt_events_charlie partition must exist in shard '{dbId}'. Tables: {string.Join(", ", tables.Select(t => t.QualifiedName))}");
     }
@@ -311,7 +311,7 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
         // And the append actually works — the full surface this enables.
         await using var session = _store.LightweightSession("echo");
         session.Events.StartStream(Guid.NewGuid(), new ShardedTestEvent { Value = "via-dynamic-source" });
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/src/TenantPartitionedEventsTests/TenantPartitionedEventsTests.csproj
+++ b/src/TenantPartitionedEventsTests/TenantPartitionedEventsTests.csproj
@@ -1,6 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <!-- Swept for xUnit1051 (#5067): every call taking a CancellationToken is handed
+             TestContext.Current.CancellationToken, so a hung test is cancelled and reported
+             instead of running until CI's own timeout. Keeping the rule ON guards the sweep.
+             Must be set before Tests.props is imported. -->
+        <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     </PropertyGroup>


### PR DESCRIPTION
Second increment of #5067. **Stacked on #5083** — please merge that one first; this PR's base is its branch, so the diff shown here is only the second increment.

983 more sites, across the twelve projects where **none** of the flagged sites sit inside a `#region sample_*` block. That is the selection criterion: those suites cannot leak a test-only cancellation token into the docs, so the rule can be turned on outright with no pragma bracketing.

| project | sites |
|---|---:|
| TenantPartitionedEventsTests | 518 |
| MultiTenancyTests | 148 |
| Marten.EntityFrameworkCore.Tests | 75 |
| DaemonTests.ManualOnly | 64 |
| Marten.MemoryPack.Tests | 45 |
| Marten.NodaTime.Testing | 41 |
| Marten.PgVector.Tests | 31 |
| CompiledQueryTests | 24 |
| ModularConfigTests | 14 |
| Marten.TimescaleDB.Tests | 10 |
| Marten.PostGIS.Tests | 9 |
| Marten.SourceGenerator.Tests | 4 |

`Marten.SourceGenerator.Tests` does not import `Tests.props`, so its four sites were never suppressed — they have been warning on master all along.

## Three shapes that needed more than an appended argument

- **Parameters not named `token`.** `BulkInsertDocumentsAsync` and `BulkInsertEventsAsync` take `cancellation`; Weasel's `ApplyAllConfiguredChangesToDatabaseAsync` and `ExistingTablesAsync` take `ct`; Roslyn's `ParseText` takes `cancellationToken`.
- **Calls already using an out-of-position named argument** (`timestamp:`, `fromVersion:`), which force the token to be named as well.
- **Two chained shapes where the token belonged to a different call in the chain** — `compilation.GetDiagnostics().Where(…).ToArray()` and `new ConjoinedToPartitionedMigration(…) { … }.ExecuteAsync()`. In the second, an object initializer rather than a `.` follows the constructor's argument list.

## Verification

- All twelve projects compile on **net9.0 and net10.0** with the rule enforced: **0 errors, 0 xUnit1051**.
- **mdsnippets gate passes.** Regenerated the docs on this branch and on clean master and diffed the two trees: **zero rendered content changes, zero occurrences of the token under `docs/`**. The one file that moves, `configuration/multitenancy.md`, changes only snippet source-link line ranges, because `using Xunit;` had to be added to some MultiTenancyTests files. Regenerated and committed. markdownlint and cspell clean.

Note for anyone else gating on mdsnippets: master already carries pre-existing drift in 22 doc files, so it cannot be gated on a clean working tree — it has to be gated on "no content change versus the master baseline", which is how this was checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)