### PR TITLE
Fix #5065: make the recording message outbox thread safe

### DIFF
--- a/src/DaemonTests/Aggregations/side_effects_in_aggregations.cs
+++ b/src/DaemonTests/Aggregations/side_effects_in_aggregations.cs
@@ -464,12 +464,30 @@ public class SideEffects2: IRevisioned
 
 public class RecordingMessageOutbox: IMessageOutbox
 {
-    public readonly List<RecordingMessageBatch> Batches = new();
+    private readonly List<RecordingMessageBatch> _batches = new();
+
+    // The daemon raises side effects for the slices in a batch concurrently, so both of the
+    // collections in this harness have to be synchronized -- an unguarded List.Add silently drops
+    // batches and messages, which is what made blue_green_side_effect_gate look flaky (#5065).
+    // The sibling copy in Composites/composite_rebuild_suppresses_side_effects.cs already locks.
+    public IReadOnlyList<RecordingMessageBatch> Batches
+    {
+        get
+        {
+            lock (_batches)
+            {
+                return _batches.ToList();
+            }
+        }
+    }
 
     public ValueTask<IMessageBatch> CreateBatch(DocumentSessionBase session)
     {
         var batch = new RecordingMessageBatch();
-        Batches.Add(batch);
+        lock (_batches)
+        {
+            _batches.Add(batch);
+        }
 
         return new ValueTask<IMessageBatch>(batch);
     }
@@ -479,7 +497,18 @@ public record TenantMessage(string tenantId, object message);
 
 public class RecordingMessageBatch: IMessageBatch
 {
-    public readonly List<TenantMessage> Messages = new();
+    private readonly List<TenantMessage> _messages = new();
+
+    public IReadOnlyList<TenantMessage> Messages
+    {
+        get
+        {
+            lock (_messages)
+            {
+                return _messages.ToList();
+            }
+        }
+    }
 
     public Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
     {
@@ -498,7 +527,11 @@ public class RecordingMessageBatch: IMessageBatch
     public bool BeforeCommitWasCalled { get; set; }
     public ValueTask PublishAsync<T>(T message, string tenantId)
     {
-        Messages.Add(new TenantMessage(tenantId, message));
+        lock (_messages)
+        {
+            _messages.Add(new TenantMessage(tenantId, message));
+        }
+
         return new ValueTask();
     }
 }

--- a/src/Marten/Events/Aggregation/IMessageBatch.cs
+++ b/src/Marten/Events/Aggregation/IMessageBatch.cs
@@ -3,6 +3,23 @@ using JasperFx.Events.Projections;
 
 namespace Marten.Events.Aggregation;
 
+/// <summary>
+///     A batch of messages published by projection side effects within a single projection update.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Implementations must be thread safe.</b> The async daemon raises side effects for the event
+///         slices in one batch concurrently, so <see cref="IMessageSink.PublishAsync{T}" /> is called from
+///         several threads against the same <see cref="IMessageBatch" /> instance -- measured at up to 8
+///         simultaneous callers across 10 threads for a single-stream projection catching up over 20
+///         streams. An implementation that appends to an unsynchronized collection silently loses
+///         messages under load; see #5065, where exactly that made a daemon test look flaky.
+///     </para>
+///     <para>
+///         The same applies to any collection an <see cref="IMessageOutbox" /> uses to track the batches
+///         it hands out, since <see cref="IMessageOutbox.CreateBatch" /> is reached from those threads too.
+///     </para>
+/// </remarks>
 public interface IMessageBatch: IMessageSink, IChangeListener
 {
 


### PR DESCRIPTION
Closes #5065. **The issue's premise turns out to be wrong, and so was my first diagnosis on it** — this is not a drain-timing flake, and not the gate bug I initially reported. It is a thread-safety defect in the test harness.

## Why the "asserts before the daemon drained" reading is wrong

It fails **4 out of 4 runs on clean master in about a second**. A drain race does not do that.

## What the state actually shows

Instrumenting the **blue** leg — which has no opt-in and no gate at all, so a gate boundary cannot be involved:

```
fired=19 distinct=19 progress=20 trackerSeq=20 batches=1 perBatch=[19] docs=20
fired=18 distinct=18 progress=20 trackerSeq=20 batches=1 perBatch=[18] docs=20
fired=19 distinct=19 progress=20 trackerSeq=20 batches=1 perBatch=[19] docs=20
```

Self-contradictory for any "events were missed" theory:

- `progress=20` / `trackerSeq=20` — the projection committed all 20
- `docs=20` — all 20 aggregates were built, so every slice ran and `RaiseSideEffects` fired for each
- `batches=1 perBatch=[19]`, `distinct == fired` — the one batch holds 19 messages, no duplicates

Every slice ran, yet a message is missing from the list: a lost `List<T>.Add`. That also explains the wandering shortfall — 19/20, 18/20, 7/8, 4/8 — which is what made it read as timing.

## The contention is measured, not inferred

Instrumenting `PublishAsync` with thread ids and an in-flight counter:

```
threads=10  maxConcurrent=5
threads=10  maxConcurrent=8
threads=10  maxConcurrent=4
```

**Up to 8 concurrent publishers across 10 threads into a single batch**, for one single-stream projection catching up over 20 streams. So the lock in this PR is not papering over a timing bug — the contended access is directly observed. `ProjectionUpdateBatch.CurrentMessageBatch` is properly double-check-locked, so batch *creation* was never the problem.

## The fix

`RecordingMessageOutbox` / `RecordingMessageBatch` in `Aggregations/side_effects_in_aggregations.cs` appended to unsynchronized `List<T>` for both `Batches` and `Messages`. The sibling copy in `Composites/composite_rebuild_suppresses_side_effects.cs` already locks both — a known hazard that this copy never picked up.

Also documents the requirement on `IMessageBatch`. That is the part worth keeping beyond the test: it is the interface Marten users implement, nothing said `PublishAsync` is called concurrently, and in a real outbox the symptom is silently dropped messages rather than a visibly flaky test.

## Verification

- **10 consecutive runs** of the class, 2/2 green every time — against 4/4 red immediately before.
- **Full DaemonTests on net9.0 is now 257/257.** It was 256/257, with this as the only failure — so DaemonTests has no known red left.
- Builds clean on net9.0 and net10.0. `mdsnippets` gate clean: 22 drifted doc files, exactly the pre-existing master baseline, none of it from this change (neither file contributes snippets).

## No upstream issue needed

I had reported this as a JasperFx hand-off; that was wrong and I have corrected the issue thread. Nothing here is in JasperFx — the harness is Marten's, `IMessageBatch` is Marten's, and `CurrentMessageBatch` is Marten's and already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)