### PR TITLE
#5067: record that xUnit1051 stays suppressed outside the swept suites

### DIFF
--- a/docs/events/projections/read-aggregates.md
+++ b/docs/events/projections/read-aggregates.md
@@ -33,7 +33,7 @@ var summaries = await _compositeSession
     .QueryForNonStaleData<BoardSummary>(10.Seconds())
     .ToListAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Composites/multi_stage_projections.cs#L322-L332' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_querying_for_non_stale_projection_data' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Composites/multi_stage_projections.cs#L319-L329' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_querying_for_non_stale_projection_data' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To be clear though, if you need the latest version of a single stream projection, we recommend always

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -282,3 +282,14 @@ dotnet_diagnostic.MA0095.severity = none
 dotnet_diagnostic.MA0096.severity = none
 dotnet_diagnostic.MA0097.severity = none
 dotnet_diagnostic.MA0098.severity = none
+
+# xUnit1051 ("pass TestContext.Current.CancellationToken") is enforced in the swept test
+# projects -- see the ThreadTestCancellationToken switch in Tests.props and #5067. This one
+# file is exempted because it hosts sample_querying_for_non_stale_projection_data, which
+# mdsnippets renders into docs/events/projections/read-aggregates.md: threading a test-only
+# cancellation token there would publish it to users as if it were guidance. Exempting the
+# file here rather than bracketing the region with a #pragma pair keeps the suppression out
+# of the source next to the sample. The trade-off is that the rest of this file is no longer
+# covered by the rule.
+[DaemonTests/Composites/multi_stage_projections.cs]
+dotnet_diagnostic.xUnit1051.severity = none

--- a/src/DaemonTests/Composites/multi_stage_projections.cs
+++ b/src/DaemonTests/Composites/multi_stage_projections.cs
@@ -313,12 +313,9 @@ public class multi_stage_projections(ITestOutputHelper output): DaemonContext(ou
             boardSummary.Board.ShouldNotBeNull();
         }
 
-        // This block is pulled into docs/events/projections/read-aggregates.md, so it stays
-        // free of TestContext.Current.CancellationToken -- threading a test-only cancellation
-        // token here would publish it to users as if it were guidance (#5067). The pragma sits
-        // OUTSIDE the region markers on purpose: anything inside them lands in the docs.
-#pragma warning disable xUnit1051
-
+        // Keep this block free of TestContext.Current.CancellationToken: it is rendered into
+        // docs/events/projections/read-aggregates.md. xUnit1051 is switched off for this file
+        // in src/.editorconfig rather than with a pragma here (#5067).
         #region sample_querying_for_non_stale_projection_data
 
         // _compositeSession is an IDocumentSession
@@ -330,8 +327,6 @@ public class multi_stage_projections(ITestOutputHelper output): DaemonContext(ou
             .ToListAsync();
 
         #endregion
-
-#pragma warning restore xUnit1051
 
         summaries.Count.ShouldBe(12);
 

--- a/src/Tests.props
+++ b/src/Tests.props
@@ -10,13 +10,29 @@
         <OutputType>Exe</OutputType>
 
         <!-- xUnit1051: "pass TestContext.Current.CancellationToken to methods accepting a
-             CancellationToken". New in the v3 analyzers, and still suppressed by default
-             because there are ~5,650 candidate call sites across the DB-heavy suites (2,955
-             of them plain SaveChangesAsync()). The rule is being adopted per-project rather
-             than in one repo-wide sweep — a project that has been swept sets
+             CancellationToken". New in the v3 analyzers.
+
+             Suppressed by default, and DELIBERATELY LEFT THAT WAY for the remaining suites.
+             This is a settled decision, not unfinished work — please don't sweep the rest.
+
+             The rule is on in the 13 projects that already carry it (DaemonTests plus the 12
+             swept in #5084), where a hung test now gets cancelled and reported instead of
+             running until CI's own job timeout. Those projects set
              <ThreadTestCancellationToken>true</ThreadTestCancellationToken> BEFORE importing
-             this file, which turns the warning back on so new unthreaded calls can't creep
-             back in. See #5067. -->
+             this file, which keeps the warning enforced so unthreaded calls can't creep back.
+
+             The other suites stay suppressed because of the doc samples. Of the 7,930 flagged
+             sites across the solution, 400 sit inside `#region sample_*` blocks that
+             mdsnippets pulls into the VitePress docs, spread over ~82 files in
+             EventSourcingTests, DocumentDbTests, LinqTests, ValueTypeTests, CoreTests and
+             PatchingTests. Threading a test-only cancellation token there would publish
+             `await session.SaveChangesAsync(TestContext.Current.CancellationToken)` to users
+             as if it were guidance, and enforcing the rule around those blocks means
+             bracketing every one with a pragma pair placed outside the region markers
+             (a pragma inside a region is rendered into the docs). Clean sample code is worth
+             more than analyzer coverage in suites where the payoff is small.
+
+             See #5067 for the full per-project table. -->
         <NoWarn Condition="'$(ThreadTestCancellationToken)' != 'true'">$(NoWarn);xUnit1051</NoWarn>
 
         <!-- xunit.v3 supplies the entry point. Microsoft.NET.Test.Sdk will also emit a


### PR DESCRIPTION
Closes #5067.

Two related changes: record the decision to stop adopting xUnit1051, and remove the one pragma the earlier sweep left behind.

## 1. Record the decision (`Tests.props`)

The comment described the per-project adoption as *in progress*, which would invite the next person to pick up the remaining ~6,500 sites. It now states the decision and the reason, next to the switch itself.

**The rule stays ON in the 13 projects that already carry it** — DaemonTests (#5083) plus the 12 swept in #5084, 1,423 sites. That is where it pays: a hung daemon test gets cancelled and reported instead of running until CI's own job timeout.

**It stays suppressed everywhere else, because of the doc samples.** Of the 7,930 flagged sites, **400 sit inside `#region sample_*` blocks** rendered into the VitePress docs — ~82 files across EventSourcingTests, DocumentDbTests, LinqTests, ValueTypeTests, CoreTests and PatchingTests. Sweeping them would publish

```csharp
await session.SaveChangesAsync(TestContext.Current.CancellationToken);
```

to users as though it were guidance. Clean sample code is worth more than analyzer coverage in suites where the benefit is small.

## 2. Drop the pragma (`src/.editorconfig`)

The DaemonTests sweep left the repo's only `#pragma warning disable xUnit1051`, bracketing that project's single sample region. It worked — the pragma sat outside the region markers so the rendered snippet stayed clean — but it put a suppression in the source right beside user-facing sample code. It is now a file-scoped `.editorconfig` entry instead:

```ini
[DaemonTests/Composites/multi_stage_projections.cs]
dotnet_diagnostic.xUnit1051.severity = none
```

**Trade-off, stated plainly:** the rule no longer covers the rest of that file, not just the sample. A short comment outside the region still says not to thread a token into the block, since the analyzer no longer will.

## Verification

- **The `.editorconfig` entry provably does the work, rather than passing by accident.** With the glob pointed at a nonexistent file the warning returns at the sample's `ToListAsync()` (line 322); with the real glob, DaemonTests builds on **net9.0 and net10.0 with 0 errors and 0 xUnit1051**.
- `Tests.props` still parses — it embeds an XML-ish property name inside a comment, so worth checking rather than assuming — and a consuming test project still builds.
- **mdsnippets gate:** 22 drifted doc files, exactly the pre-existing master baseline, and `read-aggregates.md` changes by one line — the snippet source-link range moving `L322-L332` → `L319-L329` because three lines came out above the region. No rendered content change, zero occurrences of the token under `docs/`. Regenerated and committed. markdownlint and cspell clean.

Note for future gating: master already carries pre-existing mdsnippets drift in 22 files, so this cannot be gated on a clean working tree — it has to be "no content change versus the master baseline", which is how it was checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)