### PR TITLE
Stop conjoined_multi_tenancy and its partitioning twin sharing a schema

### DIFF
--- a/docs/documents/multi-tenancy.md
+++ b/docs/documents/multi-tenancy.md
@@ -140,12 +140,12 @@ using (var session = store.QuerySession())
     (await session.Query<Target>().CountAsync(x => x.TenantIsOneOf("Red"))).ShouldBe(11);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs#L274-L341' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-mixed-tenancy-non-tenancy-sample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs#L276-L343' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-mixed-tenancy-non-tenancy-sample' title='Start of snippet'>anchor</a></sup>
 <a id='snippet-sample_tenancy-mixed-tenancy-non-tenancy-sample-1'></a>
 ```cs
 using var store = DocumentStore.For(opts =>
 {
-    opts.DatabaseSchemaName = "mixed_multi_tenants";
+    opts.DatabaseSchemaName = "mixed_multi_tenants_conjoined";
     opts.Connection(ConnectionSource.ConnectionString);
     opts.Schema.For<Target>().MultiTenanted(); // tenanted
     opts.Schema.For<User>(); // non-tenanted
@@ -208,7 +208,7 @@ using (var session = store.QuerySession())
     (await session.Query<Target>().CountAsync(x => x.TenantIsOneOf("Red"))).ShouldBe(11);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs#L244-L311' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-mixed-tenancy-non-tenancy-sample-1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs#L249-L316' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-mixed-tenancy-non-tenancy-sample-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In some cases, You may want to disable using the default tenant for storing documents, set `StoreOptions.Advanced.DefaultTenantUsageEnabled` to `false`. With this option disabled, Tenant (non-default tenant) should be passed via method argument or `SessionOptions` when creating a session using document store. Marten will throw an exception `DefaultTenantUsageDisabledException` if a session is created using default tenant.
@@ -244,14 +244,14 @@ filter:
 var actual = await query.Query<Target>().Where(x => x.TenantIsOneOf("Green", "Red") && x.Flag)
     .OrderBy(x => x.Id).Select(x => x.Id).ToListAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs#L418-L424' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenant_is_one_of' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs#L420-L426' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenant_is_one_of' title='Start of snippet'>anchor</a></sup>
 <a id='snippet-sample_tenant_is_one_of-1'></a>
 ```cs
 // query data for a selected list of tenants
 var actual = await query.Query<Target>().Where(x => x.TenantIsOneOf("Green", "Red") && x.Flag)
     .OrderBy(x => x.Id).Select(x => x.Id).ToListAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs#L388-L394' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenant_is_one_of-1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs#L393-L399' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenant_is_one_of-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or the `AnyTenant()` filter:
@@ -263,14 +263,14 @@ Or the `AnyTenant()` filter:
 var actual =(await  query.Query<Target>().Where(x => x.AnyTenant() && x.Flag)
     .OrderBy(x => x.Id).Select(x => x.Id).ToListAsync());
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs#L363-L369' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_any_tenant' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs#L365-L371' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_any_tenant' title='Start of snippet'>anchor</a></sup>
 <a id='snippet-sample_any_tenant-1'></a>
 ```cs
 // query data across all tenants
 var actual =(await  query.Query<Target>().Where(x => x.AnyTenant() && x.Flag)
     .OrderBy(x => x.Id).Select(x => x.Id).ToListAsync());
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs#L333-L339' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_any_tenant-1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs#L338-L344' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_any_tenant-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Configuring Tenancy
@@ -465,7 +465,7 @@ builder.Services.AddMarten(opts =>
     opts.Policies.PartitionMultiTenantedDocumentsUsingMartenManagement("tenants");
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs#L249-L266' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configure_marten_managed_tenant_partitioning' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs#L256-L273' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configure_marten_managed_tenant_partitioning' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The tenant to partition name mapping will be stored in a table created by Marten called `mt_tenant_partitions` with
@@ -511,7 +511,7 @@ public class DocThatShouldBeExempted1
     public Guid Id { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs#L296-L304' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_donotpartitionattribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs#L303-L311' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_donotpartitionattribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 or exempt a single document type through the fluent interface:
@@ -545,7 +545,7 @@ public static async Task delete_all_tenant_data(IDocumentStore store, Cancellati
     await store.Advanced.DeleteAllTenantDataAsync("AAA", token);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs#L22-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_delete_all_data_by_tenant' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs#L27-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_delete_all_data_by_tenant' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This API will:

--- a/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs
+++ b/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs
@@ -17,6 +17,11 @@ using Xunit;
 
 namespace DocumentDbTests.MultiTenancy;
 
+// Shares the mixed-tenancy store below with conjoined_multi_tenancy_with_partitioning. Both build
+// their own DocumentStore on a fixed schema, wipe it and assert on global counts, so they must not
+// run concurrently -- xunit v3 puts un-attributed classes in separate collections and runs them in
+// parallel, which had them seeing each other's rows (2 users became 4).
+[Collection("mixed_multi_tenancy")]
 public class conjoined_multi_tenancy: StoreContext<MultiTenancyFixture>, IClassFixture<MultiTenancyFixture>, IAsyncLifetime
 {
     #region sample_delete_all_data_by_tenant
@@ -245,7 +250,7 @@ public class conjoined_multi_tenancy: StoreContext<MultiTenancyFixture>, IClassF
 
         using var store = DocumentStore.For(opts =>
         {
-            opts.DatabaseSchemaName = "mixed_multi_tenants";
+            opts.DatabaseSchemaName = "mixed_multi_tenants_conjoined";
             opts.Connection(ConnectionSource.ConnectionString);
             opts.Schema.For<Target>().MultiTenanted(); // tenanted
             opts.Schema.For<User>(); // non-tenanted

--- a/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs
+++ b/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs
@@ -17,6 +17,8 @@ using Xunit;
 
 namespace DocumentDbTests.MultiTenancy;
 
+// See the note on conjoined_multi_tenancy: these two must not run concurrently.
+[Collection("mixed_multi_tenancy")]
 public class conjoined_multi_tenancy_with_partitioning: OneOffConfigurationsContext, IAsyncLifetime
 {
     private readonly Target[] _greens = Target.GenerateRandomData(100).ToArray();


### PR DESCRIPTION
Fixes the CI failure that blocked #5085 from merging. Not caused by that PR — it is a latent isolation bug of the same family as #5070, exposed by xunit v3's parallelism rather than created by it.

## The failure

```
await session.Query<User>().CountAsync()  should be 2 but was 4
```

hitting `can_query_on_multi_tenanted_and_non_tenanted_documents` in **both** `conjoined_multi_tenancy` **and** `conjoined_multi_tenancy_with_partitioning`, in the same run. Two independent flakes don't synchronise like that; a contended shared resource does.

## Cause

Both classes build their own `DocumentStore` on the same hard-coded schema:

```csharp
opts.DatabaseSchemaName = "mixed_multi_tenants";
```

then `DeleteAllDocumentsAsync()`, bulk-insert two `User` rows, and assert the count is 2. Neither class carried a `[Collection]` attribute, so **xunit v3 puts them in separate collections and runs them in parallel** — both insert before either counts, and both see 4.

## Fix, from both directions

- The two classes now share the `mixed_multi_tenancy` collection, so xunit will not run them concurrently.
- `conjoined_multi_tenancy` gets its own schema, `mixed_multi_tenants_conjoined`, so they no longer touch the same tables at all.

## The docs wrinkle

The schema name sits **inside** `#region sample_tenancy-mixed-tenancy-non-tenancy-sample` in both files — and mdsnippets renders **both** into `docs/documents/multi-tenancy.md`, the second as a duplicate `-sample-1` anchor. (That duplication is a pre-existing wart worth cleaning up separately: the same sample is published twice.)

So the rename was applied to the copy that only feeds the **duplicate** anchor. The primary sample readers actually see is byte-identical; the regenerated duplicate block is committed. The `[Collection]` attributes sit outside the region markers, so they don't appear in the docs at all.

## Verification

- **DocumentDbTests: 1089/1090, 0 failures on both net9.0 and net10.0.**
- mdsnippets gate clean — the only doc content change is the one schema line inside the duplicate block, confirmed by line position to be after the `-sample-1` anchor and not in the primary. markdownlint and cspell clean.

**Being straight about what the green run does and doesn't prove:** the suite also passed on clean master, so a passing local run does not by itself demonstrate the fix — the collision needed CI's parallel timing to surface. The justification is the mechanism (shared literal schema + separate collections + wipe-then-count), and CI is where it gets exercised for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)