### PR TITLE
Marten-owned rolling range partitions for time-series tables (#5093)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -288,9 +288,17 @@
          narrowing cast (#4614/#4742), so on 9.18.0–9.20.1 the column landed in Columns.Different, the table
          was classified Update, and AssertDatabaseMatchesConfigurationAsync threw with an EMPTY change set —
          Bug_4614_revision_column_int_for_IRevisioned's assert-check test fails on every version in that
-         range. 9.18/9.19/9.20 are otherwise additive for Marten and ride along (compile-verified). -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.20.2" />
-    <PackageVersion Include="Weasel.Storage" Version="9.20.2" />
+         range. 9.18/9.19/9.20 are otherwise additive for Marten and ride along (compile-verified).
+         9.21.0 (weasel#401, marten#5093): ManagedRangePartitions — the RANGE analogue of
+         ManagedListPartitions. A RollingWindowPolicy (period size, periods ahead, periods retained)
+         attached through RangePartitioning.UsePartitionManager makes the partition set a pure function
+         of the clock, so RangePartitioning.CreateDelta turns purely ADDITIVE instead of resolving a
+         rolled-forward window to PartitionDelta.Rebuild. That is what lets Marten own a time-series
+         document table's partitions end to end (PartitioningExpression.ByRollingRange) rather than
+         pushing users onto ByExternallyManagedRangePartitions, which also opts them out of Weasel's
+         ordering and dependency management (see JasperFx/CritterWatch#886). -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.21.0" />
+    <PackageVersion Include="Weasel.Storage" Version="9.21.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <!-- The whole test suite is on xunit v3. VSTest stays the execution mode, so the
          Nuke targets and the GitHub workflows are unaffected. -->

--- a/docs/documents/storage.md
+++ b/docs/documents/storage.md
@@ -205,10 +205,74 @@ Weasel compare the declared bounds against the database by instant, so the parti
 deployments and across servers configured with different time zones.
 :::
 
-More commonly for time-series data, teams roll partitions forward with a scheduler or
-[pg_partman](https://github.com/pgpartman/pg_partman) rather than declaring every partition up front. Use
-the externally managed variant so Marten creates the partitioned parent table but leaves the individual
-partitions alone:
+#### Rolling Time Windows <Badge type="tip" text="9.22" />
+
+Declaring every partition up front only works while the set of partitions is fixed. Real time-series
+storage needs the partition set to *move*: provision next month, drop last year. Rather than hand-writing
+that DDL, describe the window and let Marten own it:
+
+<!-- snippet: sample_partitioning_document_by_rolling_range -->
+<a id='snippet-sample_partitioning_document_by_rolling_range'></a>
+```cs
+opts.Schema.For<MetricsSample>()
+    .Duplicate(x => x.BucketEnd)
+    // Keep 12 months of history, provision 3 months ahead. Marten creates the partitions at the
+    // leading edge and drops the aged ones at the trailing edge -- no application-authored DDL.
+    .PartitionOn(x => x.BucketEnd,
+        x => x.ByRollingRange(PartitionPeriod.Month, periodsAhead: 3, periodsBehind: 12));
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Partitioning/rolling_range_partitioning.cs#L36-L45' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_partitioning_document_by_rolling_range' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The window — periods retained behind, the current period, periods provisioned ahead — is a pure function
+of the policy and the clock, which is what makes this safe: a window that has rolled forward differs from
+the database by exactly one new partition at the leading edge and one aged partition at the trailing edge.
+Marten's schema migration only ever *adds* the new one, so rolling forward never triggers a destructive
+table rebuild the way a moved list of declared ranges would. Partitions are named `m202607`, `d20260730`,
+`y2026` and so on after the period they cover, and a `DEFAULT` overflow partition is always created, so a
+row written outside the provisioned window is stored rather than rejected.
+
+`PartitionPeriod` supports `Hour`, `Day`, `Week`, `Month`, and `Year`.
+
+Marten runs the maintenance pass — roll forward, then drop everything below the retention floor — at
+startup, alongside the [schema changes it already applies](/schema/migrations):
+
+```cs
+builder.Services.AddMarten(opts =>
+{
+    // ... the ByRollingRange() configuration above
+}).ApplyAllDatabaseChangesOnStartup();
+```
+
+Dropping an aged partition is a `DROP TABLE` of one child table. That is the whole point: retention reclaim
+stays O(1) instead of being a mass `DELETE` that bloats the table and forces vacuum churn. Only partitions
+the policy itself named are ever dropped, so a hand-created partition, or one left over from a different
+period size, is left strictly alone.
+
+If a process is long-lived enough to outrun the number of periods you provision ahead — an hourly window
+especially — run the pass yourself on whatever cadence the period size demands:
+
+<!-- snippet: sample_applying_rolling_partitions -->
+<a id='snippet-sample_applying_rolling_partitions'></a>
+```cs
+// Roll every rolling-window table forward to its current window and drop the partitions that have
+// aged past their retention floor. Idempotent, and safe to run from several nodes at once.
+await store.Advanced.ApplyRollingPartitionsAsync(token);
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Partitioning/rolling_range_partitioning.cs#L50-L56' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_applying_rolling_partitions' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: warning
+`ApplyRollingPartitionsAsync()` deletes data by design: everything in the aged partitions goes with them.
+Use `Advanced.RollPartitionsForwardAsync()` for the purely additive half if you want to provision without
+making a retention decision, and `Advanced.DropAgedRollingPartitionsAsync()` for retention alone.
+:::
+
+#### Externally Managed Range Partitions
+
+If something outside Marten genuinely owns the partitions — [pg_partman](https://github.com/pgpartman/pg_partman),
+or a migration tool of your own — use the externally managed variant so Marten creates the partitioned
+parent table but leaves the individual partitions alone:
 
 <!-- snippet: sample_partitioning_document_by_date_externally_managed -->
 <a id='snippet-sample_partitioning_document_by_date_externally_managed'></a>

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -26,6 +26,9 @@
         <PackageReference Include="Jil" />
         <PackageReference Include="Microsoft.FeatureManagement" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <!-- #5093: the rolling range partition tests roll the window forward by moving the clock,
+             not by waiting for a calendar month. -->
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
         <PackageReference Include="Npgsql.DependencyInjection" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>

--- a/src/CoreTests/Partitioning/rolling_range_partitioning.cs
+++ b/src/CoreTests/Partitioning/rolling_range_partitioning.cs
@@ -1,0 +1,350 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Time.Testing;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Core.Partitioning;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+
+namespace CoreTests.Partitioning;
+
+public class RollingMetricsSample
+{
+    public Guid Id { get; set; }
+
+    // Duplicated so it exists as a real timestamptz column, which is what the RANGE partition keys on.
+    public DateTimeOffset BucketEnd { get; set; }
+
+    public double Value { get; set; }
+}
+
+public static class RollingRangePartitionSamples
+{
+    public static void configure_a_rolling_monthly_window(StoreOptions opts)
+    {
+        #region sample_partitioning_document_by_rolling_range
+
+        opts.Schema.For<MetricsSample>()
+            .Duplicate(x => x.BucketEnd)
+            // Keep 12 months of history, provision 3 months ahead. Marten creates the partitions at the
+            // leading edge and drops the aged ones at the trailing edge -- no application-authored DDL.
+            .PartitionOn(x => x.BucketEnd,
+                x => x.ByRollingRange(PartitionPeriod.Month, periodsAhead: 3, periodsBehind: 12));
+
+        #endregion
+    }
+
+    public static async Task run_the_maintenance_pass_yourself(IDocumentStore store, CancellationToken token)
+    {
+        #region sample_applying_rolling_partitions
+
+        // Roll every rolling-window table forward to its current window and drop the partitions that have
+        // aged past their retention floor. Idempotent, and safe to run from several nodes at once.
+        await store.Advanced.ApplyRollingPartitionsAsync(token);
+
+        #endregion
+    }
+}
+
+/// <summary>
+/// #5093 — Marten owns the partition set of a time-series document table through Weasel's
+/// <see cref="ManagedRangePartitions"/> rolling window (weasel#401), so nothing has to reach for
+/// <c>ByExternallyManagedRangePartitions()</c> and hand-write <c>CREATE TABLE ... PARTITION OF</c> /
+/// <c>DROP TABLE</c>. The window is a pure function of the policy and the clock, so these tests move a
+/// <see cref="FakeTimeProvider"/> rather than the calendar.
+/// </summary>
+public class rolling_range_partitioning: IAsyncLifetime
+{
+    private readonly string _schema = "rolling5093_p" + Environment.ProcessId;
+
+    private static readonly DateTimeOffset July2026 = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync(_schema);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private DocumentStore buildStore(TimeProvider clock, int periodsAhead = 1, int periodsBehind = 2) =>
+        (DocumentStore)DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = _schema;
+
+            opts.Schema.For<RollingMetricsSample>()
+                .Duplicate(x => x.BucketEnd)
+                .PartitionOn(x => x.BucketEnd,
+                    x => x.ByRollingRange(PartitionPeriod.Month, periodsAhead, periodsBehind, clock));
+        });
+
+    private async Task<string[]> partitionNames()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        var names = new List<string>();
+        await using var reader = await conn.CreateCommand(
+                """
+                select c.relname
+                from pg_inherits i
+                join pg_class c on c.oid = i.inhrelid
+                join pg_class p on p.oid = i.inhparent
+                join pg_namespace n on n.oid = p.relnamespace
+                where n.nspname = :schema and p.relname = 'mt_doc_rollingmetricssample'
+                """)
+            .With("schema", _schema)
+            .ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
+        {
+            names.Add(await reader.GetFieldValueAsync<string>(0));
+        }
+
+        return names.OrderBy(x => x).ToArray();
+    }
+
+    [Fact]
+    public void the_table_keeps_marten_managed_partition_reconciliation()
+    {
+        using var store = buildStore(new FakeTimeProvider(July2026));
+
+        var table = new DocumentTable(store.Options.Storage.MappingFor(typeof(RollingMetricsSample)));
+
+        var partitioning = table.Partitioning.ShouldBeOfType<RangePartitioning>();
+        partitioning.Columns.Single().ShouldBe("bucket_end");
+        partitioning.PartitionManager.ShouldBeOfType<ManagedRangePartitions>()
+            .Policy.Period.ShouldBe(PartitionPeriod.Month);
+
+        // The entire point of #5093: unlike ByExternallyManagedRangePartitions(), Marten keeps reconciling
+        // this table's partitions instead of stepping out of the way.
+        table.IgnorePartitionsInMigration.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void the_declared_window_is_the_policy_window()
+    {
+        using var store = buildStore(new FakeTimeProvider(July2026));
+
+        var partitioning = (RangePartitioning)new DocumentTable(
+            store.Options.Storage.MappingFor(typeof(RollingMetricsSample))).Partitioning!;
+
+        // periodsBehind: 2, current, periodsAhead: 1
+        partitioning.PartitionManager!.Partitions().Select(x => x.Suffix)
+            .ShouldBe(["m202605", "m202606", "m202607", "m202608"]);
+    }
+
+    [Fact]
+    public async Task creates_the_whole_window_plus_a_default_overflow_partition()
+    {
+        await using var store = buildStore(new FakeTimeProvider(July2026));
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await partitionNames()).ShouldBe([
+            "mt_doc_rollingmetricssample_default",
+            "mt_doc_rollingmetricssample_m202605",
+            "mt_doc_rollingmetricssample_m202606",
+            "mt_doc_rollingmetricssample_m202607",
+            "mt_doc_rollingmetricssample_m202608"
+        ]);
+    }
+
+    [Fact]
+    public async Task re_applying_an_unmoved_window_is_a_no_op()
+    {
+        await using (var store = buildStore(new FakeTimeProvider(July2026)))
+        {
+            await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+
+        await using var second = buildStore(new FakeTimeProvider(July2026));
+        (await second.Storage.CreateMigrationAsync()).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task rolling_the_window_forward_is_additive_and_never_a_rebuild()
+    {
+        await using (var store = buildStore(new FakeTimeProvider(July2026)))
+        {
+            await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+            await using var session = store.LightweightSession();
+            session.Store(new RollingMetricsSample
+            {
+                Id = Guid.NewGuid(), BucketEnd = new DateTimeOffset(2026, 6, 10, 0, 0, 0, TimeSpan.Zero), Value = 1
+            });
+            session.Store(new RollingMetricsSample
+            {
+                Id = Guid.NewGuid(), BucketEnd = July2026, Value = 2
+            });
+            await session.SaveChangesAsync();
+        }
+
+        // Two months later the declared window has both gained a leading-edge period and lost two trailing
+        // ones. Before #5093 that shape resolved to PartitionDelta.Rebuild — a CREATE _temp / copy of a
+        // multi-gigabyte table — which is exactly why teams reached for the externally-managed escape hatch.
+        var clock = new FakeTimeProvider(July2026.AddMonths(2));
+        await using var later = buildStore(clock);
+
+        var migration = await later.Storage.CreateMigrationAsync();
+        migration.Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await later.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var names = await partitionNames();
+
+        // Additive: the new leading edge exists...
+        names.ShouldContain("mt_doc_rollingmetricssample_m202610");
+        // ...and the aged partitions are still on disk. Migration NEVER destroys data — retention is a
+        // separate, explicit policy pass (see drops_partitions_that_have_aged_past_the_retention_floor).
+        names.ShouldContain("mt_doc_rollingmetricssample_m202605");
+
+        // And the data from before the roll survived it.
+        await using var query = later.QuerySession();
+        (await query.Query<RollingMetricsSample>().CountAsync()).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task drops_partitions_that_have_aged_past_the_retention_floor()
+    {
+        await using (var store = buildStore(new FakeTimeProvider(July2026)))
+        {
+            await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+            await using var session = store.LightweightSession();
+            session.Store(new RollingMetricsSample
+            {
+                Id = Guid.NewGuid(), BucketEnd = new DateTimeOffset(2026, 5, 10, 0, 0, 0, TimeSpan.Zero), Value = 1
+            });
+            session.Store(new RollingMetricsSample
+            {
+                Id = Guid.NewGuid(), BucketEnd = July2026, Value = 2
+            });
+            await session.SaveChangesAsync();
+        }
+
+        await using var later = buildStore(new FakeTimeProvider(July2026.AddMonths(2)));
+        await later.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await later.Advanced.ApplyRollingPartitionsAsync(CancellationToken.None);
+
+        var names = await partitionNames();
+
+        // Retention floor at 2026-09 minus 2 periods is 2026-07, so May and June are gone in O(1)...
+        names.ShouldNotContain("mt_doc_rollingmetricssample_m202605");
+        names.ShouldNotContain("mt_doc_rollingmetricssample_m202606");
+        // ...and everything inside the window, plus the DEFAULT overflow, stayed.
+        names.ShouldContain("mt_doc_rollingmetricssample_m202607");
+        names.ShouldContain("mt_doc_rollingmetricssample_m202610");
+        names.ShouldContain("mt_doc_rollingmetricssample_default");
+
+        // The May row went with its partition; the July row is untouched.
+        await using var query = later.QuerySession();
+        (await query.Query<RollingMetricsSample>().CountAsync()).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task the_host_startup_pass_rolls_the_window_forward_and_retires_the_aged_partitions()
+    {
+        await using (var store = buildStore(new FakeTimeProvider(July2026)))
+        {
+            await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+
+        // Redeploy two months later. Nothing here authors any DDL: startup rolls the window forward and
+        // drops what has aged out, on exactly the schedule Marten already applies schema changes on.
+        var clock = new FakeTimeProvider(July2026.AddMonths(2));
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DatabaseSchemaName = _schema;
+
+                    opts.Schema.For<RollingMetricsSample>()
+                        .Duplicate(x => x.BucketEnd)
+                        .PartitionOn(x => x.BucketEnd, x => x.ByRollingRange(PartitionPeriod.Month, 1, 2, clock));
+                }).ApplyAllDatabaseChangesOnStartup();
+            })
+            .StartAsync();
+
+        var names = await partitionNames();
+
+        names.ShouldContain("mt_doc_rollingmetricssample_m202610");
+        names.ShouldNotContain("mt_doc_rollingmetricssample_m202605");
+        names.ShouldNotContain("mt_doc_rollingmetricssample_m202606");
+
+        await host.StopAsync();
+    }
+
+    [Fact]
+    public async Task the_apply_pass_is_idempotent_and_safe_to_run_concurrently()
+    {
+        var clock = new FakeTimeProvider(July2026);
+        await using var store = buildStore(clock);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var before = await partitionNames();
+
+        // Several nodes starting at once all run the same pass.
+        await Task.WhenAll(Enumerable.Range(0, 4)
+            .Select(_ => store.Advanced.ApplyRollingPartitionsAsync(CancellationToken.None)));
+
+        (await partitionNames()).ShouldBe(before);
+    }
+
+    [Fact]
+    public async Task rows_outside_the_provisioned_window_land_in_the_default_partition()
+    {
+        await using var store = buildStore(new FakeTimeProvider(July2026));
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Far outside [2026-05, 2026-09). A managed rolling range always carries a DEFAULT partition
+        // precisely so this is stored rather than rejected with a 23514 check violation.
+        await using var session = store.LightweightSession();
+        session.Store(new RollingMetricsSample
+        {
+            Id = Guid.NewGuid(), BucketEnd = new DateTimeOffset(2001, 1, 1, 0, 0, 0, TimeSpan.Zero), Value = 3
+        });
+        await session.SaveChangesAsync();
+
+        await using var query = store.QuerySession();
+        (await query.Query<RollingMetricsSample>().CountAsync()).ShouldBe(1);
+    }
+
+    [Fact]
+    public void refuses_a_partition_key_that_is_not_a_point_in_time()
+    {
+        using var store = (DocumentStore)DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = _schema;
+
+            opts.Schema.For<RollingMetricsSample>()
+                .Duplicate(x => x.Value)
+                .PartitionOn(x => x.Value, x => x.ByRollingRange(PartitionPeriod.Month, 1, 2));
+        });
+
+        // A rolling window is a function of the clock, so a non-temporal partition key is caught at
+        // configuration with a message that names the member, not as an opaque partition-bound error
+        // during the first migration.
+        Should.Throw<InvalidOperationException>(() => store.Options.Storage.MappingFor(typeof(RollingMetricsSample)))
+            .Message.ShouldContain("DateTime or DateTimeOffset");
+    }
+}

--- a/src/Marten/AdvancedOperations.cs
+++ b/src/Marten/AdvancedOperations.cs
@@ -404,6 +404,61 @@ public class AdvancedOperations
     }
 
     /// <summary>
+    ///     Roll every document table configured with <c>PartitionOn(x =&gt; x.Timestamp, x =&gt; x.ByRollingRange(...))</c>
+    ///     forward to its current window and drop the partitions that have aged past the policy's retention
+    ///     floor. Idempotent and safe to run concurrently from several nodes.
+    ///     <para>
+    ///         Marten already runs this at startup when the host applies database changes on startup. Call it
+    ///         yourself on whatever cadence the period size demands (an hourly window needs a much tighter
+    ///         cadence than a monthly one) if the process is long-lived enough to outrun the number of periods
+    ///         provisioned ahead. Rows outside the provisioned window are never rejected in the meantime —
+    ///         a managed rolling range always carries a DEFAULT overflow partition.
+    ///     </para>
+    ///     <para>
+    ///         Dropping an aged partition destroys the rows in it. That is the point: it is what makes
+    ///         time-based retention an O(1) <c>DROP TABLE</c> instead of a mass <c>DELETE</c>. Use
+    ///         <see cref="RollPartitionsForwardAsync" /> for the purely additive half.
+    ///     </para>
+    /// </summary>
+    /// <seealso href="https://github.com/JasperFx/marten/issues/5093" />
+    public async Task<TablePartitionStatus[]> ApplyRollingPartitionsAsync(CancellationToken token)
+    {
+        var databases = await _store.Tenancy.BuildDatabases().ConfigureAwait(false);
+        return await RollingPartitions
+            .ApplyAsync(databases.OfType<PostgresqlDatabase>(), rollingPartitionLogger(), rollForward: true,
+                dropAged: true, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     The purely additive half of <see cref="ApplyRollingPartitionsAsync" />: create the partitions of the
+    ///     current rolling window that do not exist yet, plus the DEFAULT overflow partition. Nothing is ever
+    ///     dropped, so this is safe to run without making a retention decision.
+    /// </summary>
+    public async Task<TablePartitionStatus[]> RollPartitionsForwardAsync(CancellationToken token)
+    {
+        var databases = await _store.Tenancy.BuildDatabases().ConfigureAwait(false);
+        return await RollingPartitions
+            .ApplyAsync(databases.OfType<PostgresqlDatabase>(), rollingPartitionLogger(), rollForward: true,
+                dropAged: false, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     The retention half of <see cref="ApplyRollingPartitionsAsync" />: drop every rolling-range partition
+    ///     older than its policy's retention floor. Only partitions the policy itself named are considered, so
+    ///     a hand-created partition, or one left over from a different period size, is left strictly alone.
+    /// </summary>
+    public async Task<TablePartitionStatus[]> DropAgedRollingPartitionsAsync(CancellationToken token)
+    {
+        var databases = await _store.Tenancy.BuildDatabases().ConfigureAwait(false);
+        return await RollingPartitions
+            .ApplyAsync(databases.OfType<PostgresqlDatabase>(), rollingPartitionLogger(), rollForward: false,
+                dropAged: true, token).ConfigureAwait(false);
+    }
+
+    private ILogger rollingPartitionLogger() =>
+        _store.Options.LogFactory?.CreateLogger<DocumentStore>() ?? NullLogger<DocumentStore>.Instance;
+
+    /// <summary>
     ///     "Upsert" tenant ids and matching partition suffixes to all conjoined, multi-tenanted
     ///     tables *if* Marten-managed partitioning is applied to this store. This assumes a 1-1
     ///     relationship between tenant ids and table partitions

--- a/src/Marten/PartitioningExpression.cs
+++ b/src/Marten/PartitioningExpression.cs
@@ -1,5 +1,9 @@
 #nullable enable
+using System;
+using System.Linq;
+using JasperFx.Core.Reflection;
 using Marten.Schema;
+using Weasel.Core.Partitioning;
 using Weasel.Postgresql.Tables.Partitioning;
 
 namespace Marten;
@@ -86,5 +90,85 @@ public class PartitioningExpression
         _mapping.Partitioning = partitioning;
 
         return partitioning;
+    }
+
+    /// <summary>
+    /// Direct Marten to use PostgreSQL RANGE partitioning over a *rolling time window* that Marten itself
+    /// owns: it provisions the periods at the leading edge and drops the aged periods at the trailing edge
+    /// on the same schedule it applies every other schema change. This is the supported way to run a
+    /// time-series document table -- retention becomes a <c>DROP TABLE</c> of one partition (O(1), no mass
+    /// <c>DELETE</c>, no bloat, no vacuum storm) without giving up Weasel's schema ordering and dependency
+    /// management the way <see cref="ByExternallyManagedRangePartitions"/> does.
+    /// <para>
+    /// The partitioned member must be a date/time member that has also been duplicated into a real column
+    /// (<c>Duplicate(x => x.Timestamp)</c>), and the window is always computed in UTC.
+    /// </para>
+    /// </summary>
+    /// <param name="period">The size of a single partition -- hour, day, week, month or year.</param>
+    /// <param name="periodsAhead">
+    /// How many periods beyond the current one to provision. At least one is strongly recommended so that
+    /// rows written at the very end of a period always have a partition waiting for them.
+    /// </param>
+    /// <param name="periodsBehind">
+    /// How many completed periods to retain. Partitions older than this are dropped by the retention pass.
+    /// </param>
+    /// <param name="timeProvider">Clock used to resolve "now". Defaults to <see cref="TimeProvider.System"/>.</param>
+    /// <seealso href="https://github.com/JasperFx/marten/issues/5093"/>
+    public ManagedRangePartitions ByRollingRange(PartitionPeriod period, int periodsAhead, int periodsBehind,
+        TimeProvider? timeProvider = null)
+        => ByRollingRange(new RollingWindowPolicy(period, periodsAhead, periodsBehind), timeProvider);
+
+    /// <summary>
+    /// Direct Marten to use PostgreSQL RANGE partitioning over a rolling time window described by
+    /// <paramref name="policy"/>. See <see cref="ByRollingRange(PartitionPeriod,int,int,TimeProvider)"/>.
+    /// </summary>
+    public ManagedRangePartitions ByRollingRange(RollingWindowPolicy policy, TimeProvider? timeProvider = null)
+        => ByRollingRange(new ManagedRangePartitions(policy, timeProvider));
+
+    /// <summary>
+    /// Direct Marten to use PostgreSQL RANGE partitioning over a rolling time window owned by a
+    /// pre-built <see cref="ManagedRangePartitions"/>. Pass the *same* manager instance to several
+    /// document types to roll every one of their tables forward in a single pass.
+    /// </summary>
+    public ManagedRangePartitions ByRollingRange(ManagedRangePartitions partitions)
+    {
+        ArgumentNullException.ThrowIfNull(partitions);
+
+        assertPartitionedOnATimestamp(partitions.Policy);
+
+        var partitioning = new RangePartitioning { Columns = _columnNames }.UsePartitionManager(partitions);
+        _mapping.Partitioning = partitioning;
+
+        return partitions;
+    }
+
+    /// <summary>
+    /// A rolling window is a function of the clock, so the partition key has to actually be a point in time.
+    /// Failing here -- at configuration -- turns what would otherwise surface as an opaque PostgreSQL
+    /// "partition bound" error during the first migration into a message that names the member.
+    /// </summary>
+    private void assertPartitionedOnATimestamp(RollingWindowPolicy policy)
+    {
+        if (_columnNames.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"A rolling range partition ({policy}) is keyed on a single date/time member, but {_mapping.DocumentType.FullNameInCode()} was partitioned on {_columnNames.Length} columns ({string.Join(", ", _columnNames)}).");
+        }
+
+        var columnName = _columnNames[0];
+        var field = _mapping.DuplicatedFields.FirstOrDefault(x => x.ColumnName == columnName);
+
+        if (field == null)
+        {
+            throw new InvalidOperationException(
+                $"A rolling range partition ({policy}) has to be keyed on a duplicated date/time member of {_mapping.DocumentType.FullNameInCode()}, but there is no duplicated field for column '{columnName}'. Add a Duplicate(x => x.{columnName}) call for the partitioned member.");
+        }
+
+        var memberType = Nullable.GetUnderlyingType(field.MemberType) ?? field.MemberType;
+        if (memberType != typeof(DateTimeOffset) && memberType != typeof(DateTime))
+        {
+            throw new InvalidOperationException(
+                $"A rolling range partition ({policy}) has to be keyed on a DateTime or DateTimeOffset member, but {_mapping.DocumentType.FullNameInCode()}.{field.MemberName} is {memberType.FullNameInCode()}.");
+        }
     }
 }

--- a/src/Marten/Schema/RollingPartitions.cs
+++ b/src/Marten/Schema/RollingPartitions.cs
@@ -1,0 +1,89 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Tables.Partitioning;
+
+namespace Marten.Schema;
+
+/// <summary>
+/// Drives the rolling time-window RANGE partitions configured through
+/// <see cref="PartitioningExpression.ByRollingRange(Weasel.Core.Partitioning.PartitionPeriod,int,int,System.TimeProvider)"/>
+/// (marten#5093, built on weasel#401).
+///
+/// <para>
+/// Provisioning at the leading edge is already covered by ordinary schema migration: with a partition
+/// manager attached, <c>RangePartitioning.CreateDelta</c> is purely additive, so a window that has rolled
+/// forward diffs as "create the new partition" rather than as a rebuild of a multi-gigabyte table. What
+/// migration deliberately does NOT do is remove data, so retiring the aged partitions at the trailing edge
+/// has to be driven explicitly — that is what this type is for, and it is why the maintenance pass runs
+/// alongside the startup schema application rather than inside it.
+/// </para>
+///
+/// <para>
+/// The managers are discovered from the database's own schema objects rather than tracked in
+/// <see cref="StoreOptions"/>, so this stays correct for any table that grows a rolling window later, and
+/// re-running it is always idempotent.
+/// </para>
+/// </summary>
+internal static class RollingPartitions
+{
+    /// <summary>
+    /// Every distinct rolling-window partition manager attached to a table of this database. Reference
+    /// identity is the key: <see cref="ManagedRangePartitions.ResolveManagedTables"/> matches tables to
+    /// their manager the same way, so one manager shared across several document types rolls all of their
+    /// tables forward in a single pass.
+    /// </summary>
+    public static IReadOnlyList<ManagedRangePartitions> ManagersFor(PostgresqlDatabase database)
+    {
+        var managers = new List<ManagedRangePartitions>();
+
+        foreach (var table in database.AllObjects().OfType<Table>())
+        {
+            if (table.Partitioning is RangePartitioning { PartitionManager: ManagedRangePartitions manager }
+                && !managers.Any(x => ReferenceEquals(x, manager)))
+            {
+                managers.Add(manager);
+            }
+        }
+
+        return managers;
+    }
+
+    /// <summary>
+    /// Run the maintenance pass over every database.
+    /// </summary>
+    /// <param name="rollForward">Create the partitions of the current window that do not exist yet.</param>
+    /// <param name="dropAged">
+    /// Drop the partitions that have fallen below the policy's retention floor. This removes data by design
+    /// — dropping the partition is what reclaims the storage in O(1).
+    /// </param>
+    public static async Task<TablePartitionStatus[]> ApplyAsync(IEnumerable<PostgresqlDatabase> databases,
+        ILogger logger, bool rollForward, bool dropAged, CancellationToken token)
+    {
+        var statuses = new List<TablePartitionStatus>();
+
+        foreach (var database in databases)
+        {
+            foreach (var manager in ManagersFor(database))
+            {
+                var results = (rollForward, dropAged) switch
+                {
+                    (true, true) => await manager.ApplyAsync(database, logger, token).ConfigureAwait(false),
+                    (true, false) => await manager.RollForwardAsync(database, logger, token).ConfigureAwait(false),
+                    (false, true) => await manager.DropAgedPartitionsAsync(database, logger, token)
+                        .ConfigureAwait(false),
+                    _ => []
+                };
+
+                statuses.AddRange(results);
+            }
+        }
+
+        return statuses.ToArray();
+    }
+}

--- a/src/Marten/Services/MartenActivator.cs
+++ b/src/Marten/Services/MartenActivator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx;
@@ -109,6 +110,18 @@ internal class MartenActivator: IHostedService, IGlobalLock<NpgsqlConnection>
                         database.Identifier);
                 }
             }
+
+            // #5093: roll every configured rolling-window RANGE partition forward and retire the aged ones.
+            // The migration above already provisions the leading edge — with a partition manager attached the
+            // delta is additive — but migration never removes data, so the retention drop has to be driven
+            // separately. Gated on the same opt-in as the migration itself: applying changes on startup is
+            // how a host says "Marten owns this schema", and dropping partitions is emphatically a schema
+            // change. It runs BEFORE the assert below on purpose — once the clock crosses a period boundary
+            // the database is legitimately missing the new leading-edge partition, and asserting first would
+            // fail a deployment over a difference this pass is about to close.
+            await RollingPartitions
+                .ApplyAsync(databases.OfType<PostgresqlDatabase>(), _logger, rollForward: true, dropAged: true,
+                    cancellationToken).ConfigureAwait(false);
         }
 
         if (Store.Options.ShouldAssertDatabaseMatchesConfigurationOnStartup)


### PR DESCRIPTION
Closes #5093. Depends on JasperFx/weasel#401, shipped in **Weasel 9.21.0** (bumped here from 9.20.2).

## Problem

`PartitionOn(x => x.When, x => x.ByExternallyManagedRangePartitions())` was the only workable option for a **time-series** document table, and its contract is "Marten builds the partitioned parent, and the application writes the child-partition DDL itself."

Any table partitioned by time needs its partition set to *move*: provision next month, drop last year. `RangePartitioning`'s declared-list delta reads both halves of that as drift — a moved window means actual has partitions the declaration no longer lists — which resolves to `PartitionDelta.Rebuild`. On a multi-gigabyte table that is unusable, so applications take the externally-managed door and hand-write `CREATE TABLE … PARTITION OF` / `DROP TABLE`.

Opting out of Weasel means opting out of its **ordering and dependency management**, not just its DDL generation. Field case in JasperFx/CritterWatch#886: a hand-rolled rebuild of a partitioned metrics table re-created it in a schema where `mt_immutable_timestamptz` had not been created yet, so an ordinary computed index over a `DateTimeOffset` member failed with `42883`. The index was correct; bypassing Weasel was the defect — and that failure mode is available to any Marten user doing time-series partitioning today.

## What this adds

```csharp
opts.Schema.For<MetricsSample>()
    .Duplicate(x => x.BucketEnd)
    // Keep 12 months of history, provision 3 months ahead.
    .PartitionOn(x => x.BucketEnd,
        x => x.ByRollingRange(PartitionPeriod.Month, periodsAhead: 3, periodsBehind: 12));
```

`PartitionPeriod` covers `Hour`, `Day`, `Week`, `Month`, `Year`. Overloads also take a `RollingWindowPolicy` directly, or a pre-built `ManagedRangePartitions` — pass the *same* manager to several document types to roll all of their tables forward in one pass. A `TimeProvider` is injectable so the window is testable without waiting on the calendar.

### How the two halves are driven

| | Driven by | Why |
|---|---|---|
| **Provision** the leading edge | ordinary schema migration | with a manager attached `CreateDelta` is purely additive, so a rolled-forward window is a `CREATE`, never a rebuild |
| **Retire** the trailing edge | `MartenActivator` startup pass + `Advanced.*` | migration never removes data, so the retention drop has to be driven separately |

The startup pass is gated on the same opt-in as the migration itself (`ApplyAllDatabaseChangesOnStartup`) — that is how a host says "Marten owns this schema", and dropping a partition is emphatically a schema change. It runs *before* `AssertDatabaseMatchesConfigurationAsync`, on purpose: once the clock crosses a period boundary the database is legitimately missing the new leading-edge partition, and asserting first would fail a deployment over a difference the pass is about to close.

For hosts whose processes outlive `periodsAhead` — an hourly window especially — `AdvancedOperations` gains `ApplyRollingPartitionsAsync`, plus `RollPartitionsForwardAsync` (additive only) and `DropAgedRollingPartitionsAsync` (retention only) for callers who want the halves separately.

### Design notes

- Managers are discovered from the database's own schema objects rather than tracked on `StoreOptions`. That stays correct for any table that grows a rolling window later, and makes re-running the pass unconditionally idempotent.
- `ByRollingRange` asserts at *configuration* time that the partition key is a duplicated `DateTime`/`DateTimeOffset` member. A window keyed on anything else is not a window, and this turns what would be an opaque partition-bound error during the first migration into a message that names the member.
- A `DEFAULT` overflow partition is always created, so a row written outside the provisioned window is stored rather than rejected with a 23514.
- `ByExternallyManagedRangePartitions()` remains, now documented for what it is actually for: genuinely external ownership (pg_partman).

## Acceptance criteria from the issue

- [x] A rolling monthly document table needs no application-authored DDL
- [x] Rolling the window forward never produces `PartitionDelta.Rebuild` — `rolling_the_window_forward_is_additive_and_never_a_rebuild` pins the diff at `Update`
- [x] Aged partitions dropped as a policy outcome, retention reclaim O(1) — `drops_partitions_that_have_aged_past_the_retention_floor`
- [x] Safe and idempotent when several nodes start concurrently — `the_apply_pass_is_idempotent_and_safe_to_run_concurrently`

## Tests

10 new tests in `src/CoreTests/Partitioning/rolling_range_partitioning.cs`, driving the window with a `FakeTimeProvider` rather than the calendar: configuration shape, the declared window, initial creation of the whole window + `DEFAULT`, no-op re-apply, additive roll-forward with data survival, retention drop, the full host-startup pass through `ApplyAllDatabaseChangesOnStartup`, concurrent idempotency, overflow rows landing in `DEFAULT`, and the non-temporal partition key rejection.

Green locally on net9.0 (and the partitioning tests on net10.0): CoreTests 504, DocumentDbTests 1090, MultiTenancyTests 159, TenantPartitionedEventsTests 240, EventSourcingTests 1478 — the last four also serving as the regression gate on the Weasel bump.

Known consumer: JasperFx/CritterWatch hand-writes exactly this for `mt_doc_metricssample` and can delete that code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)