### PR TITLE
Migrate raw-DocumentStore.For event sourcing tests onto standard harnesses

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4619_archive_stream_explicit_column_list_after_column_add.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4619_archive_stream_explicit_column_list_after_column_add.cs
@@ -36,23 +36,13 @@ namespace EventSourcingTests.Bugs;
 /// is robust to physical-order drift.
 /// </para>
 /// </summary>
-public class Bug_4619_archive_stream_explicit_column_list_after_column_add
+public class Bug_4619_archive_stream_explicit_column_list_after_column_add: BugIntegrationContext
 {
     [Fact]
     public async Task archive_stream_succeeds_after_a_post_creation_column_add()
     {
-        var schema = $"bug4619_{Environment.ProcessId}_{Guid.NewGuid():N}".Substring(0, 32);
-
-        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        var store = StoreOptions(opts =>
         {
-            await conn.OpenAsync();
-            try { await conn.DropSchemaAsync(schema); } catch { }
-        }
-
-        using var store = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = schema;
             opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
             // UseArchivedStreamPartitioning routes archives through the bulk
             // function variant (writeWithPartitioning) — the broken positional
@@ -85,8 +75,8 @@ public class Bug_4619_archive_stream_explicit_column_list_after_column_add
         await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
         {
             await conn.OpenAsync();
-            await conn.CreateCommand($"alter table {schema}.mt_events drop column bdata").ExecuteNonQueryAsync();
-            await conn.CreateCommand($"alter table {schema}.mt_events add column bdata bytea null").ExecuteNonQueryAsync();
+            await conn.CreateCommand($"alter table {SchemaName}.mt_events drop column bdata").ExecuteNonQueryAsync();
+            await conn.CreateCommand($"alter table {SchemaName}.mt_events add column bdata bytea null").ExecuteNonQueryAsync();
         }
 
         // Archive — the positional INSERT inside mt_archive_stream would

--- a/src/EventSourcingTests/Bugs/Bug_4625_bulk_insert_events_derives_aggregate_type_name.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4625_bulk_insert_events_derives_aggregate_type_name.cs
@@ -33,22 +33,13 @@ namespace EventSourcingTests.Bugs;
 /// callers needing to reach for the <c>internal set</c>.
 /// </para>
 /// </summary>
-public class Bug_4625_bulk_insert_events_derives_aggregate_type_name
+public class Bug_4625_bulk_insert_events_derives_aggregate_type_name: BugIntegrationContext
 {
     [Fact]
     public async Task BulkInsertEventsAsync_writes_mt_streams_type_from_AggregateType()
     {
-        var schema = $"bug4625_{Environment.ProcessId}_{Guid.NewGuid():N}".Substring(0, 32);
-        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        var store = StoreOptions(opts =>
         {
-            await conn.OpenAsync();
-            try { await conn.DropSchemaAsync(schema); } catch { }
-        }
-
-        using var store = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = schema;
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
             opts.Events.StreamIdentity = StreamIdentity.AsString;
             opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
@@ -71,7 +62,7 @@ public class Bug_4625_bulk_insert_events_derives_aggregate_type_name
         await using var conn2 = new NpgsqlConnection(ConnectionSource.ConnectionString);
         await conn2.OpenAsync();
         await using var cmd = conn2.CreateCommand(
-            $"select type from {schema}.mt_streams where id = @id and tenant_id = @tid");
+            $"select type from {SchemaName}.mt_streams where id = @id and tenant_id = @tid");
         cmd.Parameters.AddWithValue("id", streamKey);
         cmd.Parameters.AddWithValue("tid", "alpha");
         var typeName = (string?)await cmd.ExecuteScalarAsync();
@@ -91,17 +82,8 @@ public class Bug_4625_bulk_insert_events_derives_aggregate_type_name
         // type was lost (NULL) can't take any further appends — the mandatory
         // guard fires on every subsequent operation. Post-fix, the bulk-inserted
         // stream's type IS set, so appends work.
-        var schema = $"bug4625b_{Environment.ProcessId}_{Guid.NewGuid():N}".Substring(0, 32);
-        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        var store = StoreOptions(opts =>
         {
-            await conn.OpenAsync();
-            try { await conn.DropSchemaAsync(schema); } catch { }
-        }
-
-        using var store = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = schema;
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
             opts.Events.StreamIdentity = StreamIdentity.AsString;
             opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;

--- a/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/Bug_4261_multistream_sample_coverage.cs
+++ b/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/Bug_4261_multistream_sample_coverage.cs
@@ -30,7 +30,7 @@ namespace EventSourcingTests.Projections.MultiStreamProjections.CustomGroupers;
 /// https://github.com/JasperFx/marten/discussions/3615.
 /// Pattern 3 should pass because the derived event carries the group key directly.
 /// </summary>
-public partial class Bug_4261_multistream_sample_coverage
+public partial class Bug_4261_multistream_sample_coverage: OneOffConfigurationsContext
 {
     private readonly ITestOutputHelper _output;
 
@@ -44,10 +44,8 @@ public partial class Bug_4261_multistream_sample_coverage
     [Fact]
     public async Task pattern1_async_same_batch_link_and_usage_is_applied_correctly()
     {
-        await using var store = DocumentStore.For(opts =>
+        var store = StoreOptions(opts =>
         {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = $"b4261_p1_net{Environment.Version.Major}";
             opts.Events.StreamIdentity = StreamIdentity.AsString;
             opts.Events.AddEventType(typeof(P1.CustomerRegistered));
             opts.Events.AddEventType(typeof(P1.CustomerLinkedToExternalAccount));
@@ -56,8 +54,6 @@ public partial class Bug_4261_multistream_sample_coverage
             opts.Projections.Add<P1.ExternalAccountLinkProjection>(ProjectionLifecycle.Inline);
             opts.Projections.Add<P1.CustomerBillingProjection>(ProjectionLifecycle.Async);
         });
-
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
 
         using var daemon = await store.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -93,10 +89,8 @@ public partial class Bug_4261_multistream_sample_coverage
     {
         // Sanity baseline: when the link is committed first and the usage arrives
         // in a later batch, Pattern 1 should Just Work.
-        await using var store = DocumentStore.For(opts =>
+        var store = StoreOptions(opts =>
         {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = $"b4261_p1_seq_net{Environment.Version.Major}";
             opts.Events.StreamIdentity = StreamIdentity.AsString;
             opts.Events.AddEventType(typeof(P1.CustomerRegistered));
             opts.Events.AddEventType(typeof(P1.CustomerLinkedToExternalAccount));
@@ -105,8 +99,6 @@ public partial class Bug_4261_multistream_sample_coverage
             opts.Projections.Add<P1.ExternalAccountLinkProjection>(ProjectionLifecycle.Inline);
             opts.Projections.Add<P1.CustomerBillingProjection>(ProjectionLifecycle.Async);
         });
-
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
 
         using var daemon = await store.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -157,10 +149,8 @@ public partial class Bug_4261_multistream_sample_coverage
         //
         // If a future engine change makes Pattern 2 work under same-batch ordering,
         // this test will fail and should be retired.
-        await using var store = DocumentStore.For(opts =>
+        var store = StoreOptions(opts =>
         {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = $"b4261_p2_net{Environment.Version.Major}";
             opts.Events.StreamIdentity = StreamIdentity.AsString;
             opts.Events.AddEventType(typeof(P2.CustomerRegistered));
             opts.Events.AddEventType(typeof(P2.CustomerLinkedToExternalAccount));
@@ -168,8 +158,6 @@ public partial class Bug_4261_multistream_sample_coverage
 
             opts.Projections.Add<P2.CustomerBillingProjection>(ProjectionLifecycle.Async);
         });
-
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
 
         using var daemon = await store.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -204,10 +192,8 @@ public partial class Bug_4261_multistream_sample_coverage
     {
         // Sanity baseline: when the link arrives first and is already applied to the
         // projection, Pattern 2's containment query in a later batch finds the owner.
-        await using var store = DocumentStore.For(opts =>
+        var store = StoreOptions(opts =>
         {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = $"b4261_p2_seq_net{Environment.Version.Major}";
             opts.Events.StreamIdentity = StreamIdentity.AsString;
             opts.Events.AddEventType(typeof(P2.CustomerRegistered));
             opts.Events.AddEventType(typeof(P2.CustomerLinkedToExternalAccount));
@@ -215,8 +201,6 @@ public partial class Bug_4261_multistream_sample_coverage
 
             opts.Projections.Add<P2.CustomerBillingProjection>(ProjectionLifecycle.Async);
         });
-
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
 
         using var daemon = await store.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -259,10 +243,8 @@ public partial class Bug_4261_multistream_sample_coverage
         // to pick up link events that share the same daemon cycle as the usage
         // event. This is the recommended pattern when link+usage events can
         // appear in a single SaveChangesAsync.
-        await using var store = DocumentStore.For(opts =>
+        var store = StoreOptions(opts =>
         {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = $"b4261_p4_net{Environment.Version.Major}";
             opts.Events.StreamIdentity = StreamIdentity.AsString;
             opts.Events.AddEventType(typeof(P4.CustomerRegistered));
             opts.Events.AddEventType(typeof(P4.CustomerLinkedToExternalAccount));
@@ -271,8 +253,6 @@ public partial class Bug_4261_multistream_sample_coverage
             opts.Projections.Add<P4.ExternalAccountLinkProjection>(ProjectionLifecycle.Inline);
             opts.Projections.Add<P4.CustomerBillingProjection>(ProjectionLifecycle.Async);
         });
-
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
 
         using var daemon = await store.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -304,10 +284,8 @@ public partial class Bug_4261_multistream_sample_coverage
     {
         // Baseline: Pattern 4 must also handle the case where the link event
         // was committed in a prior batch. The DB fallback covers that.
-        await using var store = DocumentStore.For(opts =>
+        var store = StoreOptions(opts =>
         {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = $"b4261_p4_seq_net{Environment.Version.Major}";
             opts.Events.StreamIdentity = StreamIdentity.AsString;
             opts.Events.AddEventType(typeof(P4.CustomerRegistered));
             opts.Events.AddEventType(typeof(P4.CustomerLinkedToExternalAccount));
@@ -316,8 +294,6 @@ public partial class Bug_4261_multistream_sample_coverage
             opts.Projections.Add<P4.ExternalAccountLinkProjection>(ProjectionLifecycle.Inline);
             opts.Projections.Add<P4.CustomerBillingProjection>(ProjectionLifecycle.Async);
         });
-
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
 
         using var daemon = await store.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -357,16 +333,12 @@ public partial class Bug_4261_multistream_sample_coverage
     {
         // Pattern 3 keeps the grouping key (CustomerId) on the terminal event itself,
         // so same-batch ordering cannot create a race.
-        await using var store = DocumentStore.For(opts =>
+        var store = StoreOptions(opts =>
         {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = $"b4261_p3_net{Environment.Version.Major}";
             opts.Events.AddEventType(typeof(P3.ShipmentBilled));
 
             opts.Projections.Add<P3.CustomerBillingProjection>(ProjectionLifecycle.Async);
         });
-
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
 
         using var daemon = await store.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();

--- a/src/EventSourcingTests/rebuild_concurrency_cap_resolution.cs
+++ b/src/EventSourcingTests/rebuild_concurrency_cap_resolution.cs
@@ -12,29 +12,19 @@ namespace EventSourcingTests;
 
 // jasperfx#420 / marten#4710: resolution of the per-database rebuild concurrency cap
 // surfaced through IEventStore.MaxConcurrentRebuildsPerDatabase.
-public class rebuild_concurrency_cap_resolution
+public class rebuild_concurrency_cap_resolution: OneOffConfigurationsContext
 {
-    private static DocumentStore storeWith(Action<StoreOptions> configure)
-    {
-        return DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "rebuild_cap";
-            configure(opts);
-        });
-    }
-
     [Fact]
     public void configured_value_wins_over_derived_default()
     {
-        using var store = storeWith(opts => opts.Projections.MaxConcurrentRebuildsPerDatabase = 3);
+        var store = SeparateStore(opts => opts.Projections.MaxConcurrentRebuildsPerDatabase = 3);
         ((IEventStore)store).MaxConcurrentRebuildsPerDatabase.ShouldBe(3);
     }
 
     [Fact]
     public void non_positive_configured_value_disables_the_cap()
     {
-        using var store = storeWith(opts => opts.Projections.MaxConcurrentRebuildsPerDatabase = 0);
+        var store = SeparateStore(opts => opts.Projections.MaxConcurrentRebuildsPerDatabase = 0);
         ((IEventStore)store).MaxConcurrentRebuildsPerDatabase.ShouldBeNull();
     }
 
@@ -46,11 +36,7 @@ public class rebuild_concurrency_cap_resolution
             MaxPoolSize = 64
         }.ConnectionString;
 
-        using var store = DocumentStore.For(opts =>
-        {
-            opts.Connection(connectionString);
-            opts.DatabaseSchemaName = "rebuild_cap";
-        });
+        var store = SeparateStore(opts => opts.Connection(connectionString));
 
         ((IEventStore)store).MaxConcurrentRebuildsPerDatabase.ShouldBe(8);
     }
@@ -63,11 +49,7 @@ public class rebuild_concurrency_cap_resolution
             MaxPoolSize = 5
         }.ConnectionString;
 
-        using var store = DocumentStore.For(opts =>
-        {
-            opts.Connection(connectionString);
-            opts.DatabaseSchemaName = "rebuild_cap";
-        });
+        var store = SeparateStore(opts => opts.Connection(connectionString));
 
         ((IEventStore)store).MaxConcurrentRebuildsPerDatabase.ShouldBe(1);
     }
@@ -77,7 +59,7 @@ public class rebuild_concurrency_cap_resolution
     {
         // jasperfx#434: CritterWatch#309's rebuild dispatcher reads the effective cap
         // off the EventStoreUsage descriptor rather than guessing.
-        using var store = storeWith(opts => opts.Projections.MaxConcurrentRebuildsPerDatabase = 6);
+        var store = SeparateStore(opts => opts.Projections.MaxConcurrentRebuildsPerDatabase = 6);
 
         var usage = await ((IEventStore)store).TryCreateUsage(CancellationToken.None);
 


### PR DESCRIPTION
Phase 2 (partial) of the test-harness standardization program (`HANDOFF-test-harness-standardization.md`): the EventSourcingTests files that build raw `DocumentStore.For` stores per `[Fact]` move onto the standard contexts, retiring their hand-rolled schema naming + drop + dispose boilerplate.

| File | Now | Notes |
|---|---|---|
| `Bugs/Bug_4625_bulk_insert_events_derives_aggregate_type_name.cs` | `BugIntegrationContext` | 2 ad-hoc pid+guid schemas → `bugs` schema via `StoreOptions()` |
| `Bugs/Bug_4619_archive_stream_explicit_column_list_after_column_add.cs` | `BugIntegrationContext` | same |
| `Projections/.../Bug_4261_multistream_sample_coverage.cs` | `OneOffConfigurationsContext` | 7 hand-numbered TFM-suffixed schemas → one per-class schema |
| `rebuild_concurrency_cap_resolution.cs` | `OneOffConfigurationsContext` + `SeparateStore()` | retires the shared `rebuild_cap` schema literal |

**Deliberately not migrated** (with reasons, so the next sweep doesn't re-litigate):
- `Projections/testing_projections.cs`, `Examples/*` — test bodies are published doc snippets (`#region sample_*`); raw `DocumentStore.For`/`AddMarten` with visible connection strings is the documented content.
- `Bugs/Bug_4557_...` — asserts `DocumentStore.For` **throws** at construction; the raw call is the act under test.
- `Bugs/Bug_5044_natural_key_foreign_key_guard.cs` — requires two simultaneous schemas in one database (that's the bug); no standard context models that.
- Config-only files (`cannot_register_duplicate_projections_by_name`, `ignoring_indexes_on_event_store_tables`, `blue_green_deployment_of_aggregates`, `aggregation_projection_validation_rules`, `when_registering_a_custom_projection_type`) — pure option assertions, no DB; effectively unit tests.

Verification: all 15 tests across the four migrated files pass on net9.0; full ES suite run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U99pVx6kXwiGmaBUGLv7jB