### PR TITLE
Add HostedStoreContext harness for IHost + AddMarten tests

### DIFF
--- a/src/EventSourcingTests/Aggregation/ancillary_store_enrichment_tests.cs
+++ b/src/EventSourcingTests/Aggregation/ancillary_store_enrichment_tests.cs
@@ -18,40 +18,27 @@ namespace EventSourcingTests.Aggregation;
 // Marker interface for the ancillary store that holds reference products
 public interface IProductStore : IDocumentStore;
 
-public class ancillary_store_enrichment_tests : IAsyncLifetime
+public class ancillary_store_enrichment_tests : HostedStoreContext
 {
     private IHost _host = null!;
     private IDocumentStore _primaryStore = null!;
 
-    public async ValueTask InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
-        _host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
+        _host = await StartHostAsync(
+            opts => opts.Projections.Add<OrderProjection>(ProjectionLifecycle.Async),
+            configureMarten: marten => marten.ApplyAllDatabaseChangesOnStartup(),
+            configureServices: services =>
             {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DatabaseSchemaName = "ancillary_enrich_primary";
-                    opts.Projections.Add<OrderProjection>(ProjectionLifecycle.Async);
-                })
-                .ApplyAllDatabaseChangesOnStartup();
-
                 services.AddMartenStore<IProductStore>(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DatabaseSchemaName = "ancillary_enrich_products";
-                })
-                .ApplyAllDatabaseChangesOnStartup();
-            })
-            .StartAsync();
+                    {
+                        opts.Connection(ConnectionSource.ConnectionString);
+                        opts.DatabaseSchemaName = $"{SchemaName}_products";
+                    })
+                    .ApplyAllDatabaseChangesOnStartup();
+            });
 
         _primaryStore = _host.Services.GetRequiredService<IDocumentStore>();
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await _host.StopAsync();
-        _host.Dispose();
     }
 
     [Fact]

--- a/src/EventSourcingTests/Bugs/Bug_4441_force_catch_up_with_outbox.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4441_force_catch_up_with_outbox.cs
@@ -30,7 +30,7 @@ namespace EventSourcingTests.Bugs;
 // IMessageBatch must catch up cleanly and the listener hooks must fire even
 // when the projection raises no side effects.
 
-public class Bug_4441_force_catch_up_with_outbox
+public class Bug_4441_force_catch_up_with_outbox: HostedStoreContext
 {
     public class LetterCounts
     {
@@ -55,17 +55,9 @@ public class Bug_4441_force_catch_up_with_outbox
     [Fact(Timeout = 30000)]
     public async Task force_catch_up_returns_for_async_daemon_without_side_effects()
     {
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(s =>
-            {
-                s.AddMarten(m =>
-                {
-                    m.Connection(ConnectionSource.ConnectionString);
-                    m.DatabaseSchemaName = "bug4441_default";
-                    m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
-                }).AddAsyncDaemon(DaemonMode.Solo);
-            })
-            .StartAsync();
+        var host = await StartHostAsync(
+            m => m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async),
+            DaemonMode.Solo);
 
         var store = host.Services.GetRequiredService<IDocumentStore>();
         await store.Advanced.Clean.CompletelyRemoveAllAsync();
@@ -86,18 +78,12 @@ public class Bug_4441_force_catch_up_with_outbox
     {
         var outbox = new RecordingOutbox();
 
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(s =>
+        var host = await StartHostAsync(m =>
             {
-                s.AddMarten(m =>
-                {
-                    m.Connection(ConnectionSource.ConnectionString);
-                    m.DatabaseSchemaName = "bug4441_outbox";
-                    m.Events.MessageOutbox = outbox;
-                    m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
-                }).AddAsyncDaemon(DaemonMode.Solo);
-            })
-            .StartAsync();
+                m.Events.MessageOutbox = outbox;
+                m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
+            },
+            DaemonMode.Solo);
 
         var store = host.Services.GetRequiredService<IDocumentStore>();
         await store.Advanced.Clean.CompletelyRemoveAllAsync();

--- a/src/EventSourcingTests/Bugs/Bug_4904_force_catch_up_under_externally_managed.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4904_force_catch_up_under_externally_managed.cs
@@ -38,7 +38,7 @@ namespace EventSourcingTests.Bugs;
 // The mitigation degrades ForceAll under ExternallyManaged to a read-only wait-for-non-stale that never
 // starts, stops, or drives an agent — so it can neither throw on the missing coordinator nor race the
 // externally-owned agents into an out-of-order progression write. This test pins that Marten-side contract.
-public class Bug_4904_force_catch_up_under_externally_managed
+public class Bug_4904_force_catch_up_under_externally_managed: HostedStoreContext
 {
     public class LetterCounts
     {
@@ -63,17 +63,9 @@ public class Bug_4904_force_catch_up_under_externally_managed
     [Fact(Timeout = 30000)]
     public async Task force_catch_up_under_externally_managed_does_not_resolve_a_coordinator()
     {
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(s =>
-            {
-                s.AddMarten(m =>
-                {
-                    m.Connection(ConnectionSource.ConnectionString);
-                    m.DatabaseSchemaName = "bug4904_externally_managed";
-                    m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
-                }).AddAsyncDaemon(DaemonMode.ExternallyManaged);
-            })
-            .StartAsync();
+        var host = await StartHostAsync(
+            m => m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async),
+            DaemonMode.ExternallyManaged);
 
         var store = host.Services.GetRequiredService<IDocumentStore>();
         await store.Advanced.Clean.CompletelyRemoveAllAsync();

--- a/src/EventSourcingTests/EventSourcingTests.csproj
+++ b/src/EventSourcingTests/EventSourcingTests.csproj
@@ -78,6 +78,9 @@
         <Compile Include="..\Marten.Testing\Harness\DestructiveIntegrationContext.cs">
             <Link>Harness\DestructiveIntegrationContext.cs</Link>
         </Compile>
+        <Compile Include="..\Marten.Testing\Harness\HostedStoreContext.cs">
+            <Link>Harness\HostedStoreContext.cs</Link>
+        </Compile>
         <Compile Include="..\Marten.Testing\Harness\IntegrationContext.cs">
             <Link>Harness\IntegrationContext.cs</Link>
         </Compile>

--- a/src/EventSourcingTests/determining_the_event_store_identity.cs
+++ b/src/EventSourcingTests/determining_the_event_store_identity.cs
@@ -11,27 +11,19 @@ using Xunit;
 
 namespace EventSourcingTests;
 
-public class determining_the_event_store_identity
+public class determining_the_event_store_identity: HostedStoreContext
 {
     [Fact]
     public async Task use_correct_identities()
     {
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
+        var host = await StartHostAsync(_ => { }, configureServices: services =>
+        {
+            services.AddMartenStore<IThingStore>(m =>
             {
-                services.AddMarten(m =>
-                {
-                    m.Connection(ConnectionSource.ConnectionString);
-                    m.DatabaseSchemaName = "es_identity";
-                });
-
-                services.AddMartenStore<IThingStore>(m =>
-                {
-                    m.Connection(ConnectionSource.ConnectionString);
-                    m.DatabaseSchemaName = "things";
-                });
-
-            }).StartAsync();
+                m.Connection(ConnectionSource.ConnectionString);
+                m.DatabaseSchemaName = $"{SchemaName}_things";
+            });
+        });
 
         var stores = host.Services.GetServices<IEventStore>().ToArray();
         stores.Single(x => x.GetType() == typeof(DocumentStore)).As<IEventStore>().Identity.ShouldBe(new EventStoreIdentity("main", "marten"));

--- a/src/EventSourcingTests/generating_event_store_descriptors.cs
+++ b/src/EventSourcingTests/generating_event_store_descriptors.cs
@@ -20,25 +20,18 @@ using Xunit;
 
 namespace EventSourcingTests;
 
-public class generating_event_store_descriptors
+public class generating_event_store_descriptors: HostedStoreContext
 {
     [Fact]
     public async Task find_default_capability_with_events_and_projections()
     {
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DatabaseSchemaName = "capabilities";
-
-                    opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Async);
-                    opts.Projections.Add<LapMultiStreamProjection>(ProjectionLifecycle.Inline);
-                    opts.Projections.LiveStreamAggregation<QuestParty>();
-                    opts.Projections.Add<MyAggregateProjection>(ProjectionLifecycle.Inline);
-                });
-            }).StartAsync();
+        var host = await StartHostAsync(opts =>
+        {
+            opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Async);
+            opts.Projections.Add<LapMultiStreamProjection>(ProjectionLifecycle.Inline);
+            opts.Projections.LiveStreamAggregation<QuestParty>();
+            opts.Projections.Add<MyAggregateProjection>(ProjectionLifecycle.Inline);
+        });
 
         var capabilities = host.Services.GetServices<IEventStore>().ToArray();
         capabilities.Length.ShouldBe(1);
@@ -54,19 +47,12 @@ public class generating_event_store_descriptors
     [Fact]
     public async Task subscription_descriptors_carry_implementation_and_aggregate_types()
     {
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DatabaseSchemaName = "descriptor_enrichment";
-
-                    opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Async);
-                    opts.Projections.Add<LapMultiStreamProjection>(ProjectionLifecycle.Inline);
-                    opts.Projections.Add<MyAggregateProjection>(ProjectionLifecycle.Inline);
-                });
-            }).StartAsync();
+        var host = await StartHostAsync(opts =>
+        {
+            opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Async);
+            opts.Projections.Add<LapMultiStreamProjection>(ProjectionLifecycle.Inline);
+            opts.Projections.Add<MyAggregateProjection>(ProjectionLifecycle.Inline);
+        });
 
         var capability = host.Services.GetRequiredService<IEventStore>();
         var usage = await capability.TryCreateUsage(CancellationToken.None);
@@ -96,15 +82,7 @@ public class generating_event_store_descriptors
     [Fact]
     public async Task max_event_sequence_matches_highest_persisted_seq_id()
     {
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DatabaseSchemaName = "max_seq_usage";
-                });
-            }).StartAsync();
+        var host = await StartHostAsync(_ => { });
 
         var store = host.Services.GetRequiredService<IDocumentStore>();
 

--- a/src/EventSourcingTests/propagate_logger_to_projections.cs
+++ b/src/EventSourcingTests/propagate_logger_to_projections.cs
@@ -14,23 +14,16 @@ using Xunit;
 
 namespace EventSourcingTests;
 
-public class propagate_logger_to_projections
+public class propagate_logger_to_projections: HostedStoreContext
 {
     [Fact]
     public async Task loggers_exist_on_projections()
     {
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMarten(m =>
-                {
-                    m.Connection(ConnectionSource.ConnectionString);
-                    m.DatabaseSchemaName = "system_part";
-
-                    m.Projections.Add<SampleEventProjection>(ProjectionLifecycle.Inline);
-                    m.Projections.Add<TestOrderingEventProjection>(ProjectionLifecycle.Inline);
-                });
-            }).StartAsync();
+        var host = await StartHostAsync(m =>
+        {
+            m.Projections.Add<SampleEventProjection>(ProjectionLifecycle.Inline);
+            m.Projections.Add<TestOrderingEventProjection>(ProjectionLifecycle.Inline);
+        });
 
         var store = host.DocumentStore();
         var projections = store.Options.As<StoreOptions>().Projections.All;

--- a/src/Marten.Testing/Harness/HostedStoreContext.cs
+++ b/src/Marten.Testing/Harness/HostedStoreContext.cs
@@ -1,0 +1,110 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+using JasperFx.Events.Daemon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Marten.Testing.Harness
+{
+    /// <summary>
+    /// Base for tests that need a real <see cref="IHost"/> with AddMarten —
+    /// daemon coordination, DI-registered projections, ancillary stores —
+    /// rather than a bare DocumentStore. Owns host lifetime: every host
+    /// started through <see cref="StartHostAsync"/> is stopped and disposed
+    /// (newest first) when the test class completes.
+    /// </summary>
+    /// <remarks>
+    /// The main store gets this class's <see cref="SchemaName"/> (derived from
+    /// the test class name, like OneOffConfigurationsContext). Tests adding
+    /// secondary stores via <c>AddMartenStore&lt;T&gt;</c> in the
+    /// <c>configureServices</c> callback should derive their schema from
+    /// <see cref="SchemaName"/> too (e.g. <c>$"{SchemaName}_products"</c>) so
+    /// the whole class stays isolated under one prefix.
+    /// </remarks>
+    public abstract class HostedStoreContext: IAsyncLifetime
+    {
+        private readonly List<IHost> _hosts = new();
+
+        protected HostedStoreContext()
+        {
+            SchemaName = GetType().Name.ToLower().Sanitize();
+        }
+
+        protected string SchemaName { get; }
+
+        /// <summary>
+        /// Start (and track) a host whose main Marten store is pre-configured
+        /// with the test connection string, <see cref="SchemaName"/>, and
+        /// Npgsql logging disabled. <paramref name="daemonMode"/> maps to
+        /// AddAsyncDaemon; <paramref name="configureMarten"/> receives the
+        /// AddMarten fluent expression for chained calls like
+        /// ApplyAllDatabaseChangesOnStartup; <paramref name="configureServices"/>
+        /// runs after AddMarten for extra registrations (ancillary stores,
+        /// logging...).
+        /// </summary>
+        protected async Task<IHost> StartHostAsync(
+            Action<StoreOptions> configure,
+            DaemonMode? daemonMode = null,
+            Action<IServiceCollection>? configureServices = null,
+            Action<MartenServiceCollectionExtensions.MartenConfigurationExpression>? configureMarten = null)
+        {
+            var host = await Host.CreateDefaultBuilder()
+                .ConfigureServices(services =>
+                {
+                    var marten = services.AddMarten(opts =>
+                    {
+                        opts.Connection(ConnectionSource.ConnectionString);
+                        opts.DisableNpgsqlLogging = true;
+                        opts.DatabaseSchemaName = SchemaName;
+
+                        configure(opts);
+                    });
+
+                    if (daemonMode.HasValue)
+                    {
+                        marten.AddAsyncDaemon(daemonMode.Value);
+                    }
+
+                    configureMarten?.Invoke(marten);
+
+                    configureServices?.Invoke(services);
+                }).StartAsync();
+
+            _hosts.Add(host);
+
+            return host;
+        }
+
+        protected static DocumentStore StoreOf(IHost host)
+        {
+            return (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+        }
+
+        public virtual ValueTask InitializeAsync()
+        {
+            return default;
+        }
+
+        public virtual async ValueTask DisposeAsync()
+        {
+            for (var i = _hosts.Count - 1; i >= 0; i--)
+            {
+                var host = _hosts[i];
+                try
+                {
+                    await host.StopAsync(TimeSpan.FromSeconds(10));
+                }
+                finally
+                {
+                    host.Dispose();
+                }
+            }
+
+            _hosts.Clear();
+        }
+    }
+}


### PR DESCRIPTION
Phase 2 (continued) of the test-harness standardization program (`HANDOFF-test-harness-standardization.md`): a shared harness for the ~37 event-sourcing test files that inline `Host.CreateDefaultBuilder` + `AddMarten` + `StartAsync` with hard-coded schema literals.

## The harness

`Marten.Testing/Harness/HostedStoreContext`:
- `StartHostAsync(configure, daemonMode?, configureServices?, configureMarten?)` — main store pre-wired with the test connection string, a per-class schema name (same convention as `OneOffConfigurationsContext`), and `DisableNpgsqlLogging`. `daemonMode` maps to `AddAsyncDaemon`; `configureMarten` receives the AddMarten fluent expression (`ApplyAllDatabaseChangesOnStartup` etc.); `configureServices` covers ancillary `AddMartenStore<T>` registrations.
- Every started host is tracked and stopped + disposed newest-first at class teardown — several of the old inline blocks never stopped their hosts at all.
- Linked into `EventSourcingTests.csproj`; other projects opt in by adding the Compile link when they migrate.

## First six migrations (proof of shape)

`determining_the_event_store_identity`, `propagate_logger_to_projections`, `generating_event_store_descriptors`, `Bug_4441_force_catch_up_with_outbox`, `Bug_4904_force_catch_up_under_externally_managed`, `ancillary_store_enrichment_tests` — retiring ~10 hard-coded schema literals. All 9 tests across the six files pass on net9.0.

**Deliberately untouched:** `Examples/*` + `testing_projections.cs` (the inline host is the published doc sample), and `Daemon/postgres_listen_notify_wakeup_tests.cs` (uncommitted #4961 work in flight on that file). The remaining inline-host files in DaemonTests/TPE are follow-up material; DaemonTests' `DaemonContext` host helpers (hard-wired to `TripProjectionWithCustomName`) can be reimplemented on this base in a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U99pVx6kXwiGmaBUGLv7jB