### PR TITLE
Absorb the sharded scrub template in TenantPartitionedEventsTests/Sharded

### DIFF
--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4679_sharded_catch_up_23505.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4679_sharded_catch_up_23505.cs
@@ -55,33 +55,14 @@ namespace TenantPartitionedEventsTests.Sharded;
 /// </para>
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public partial class Bug_4679_sharded_catch_up_23505: IAsyncLifetime
+public partial class Bug_4679_sharded_catch_up_23505: ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
     private readonly ITestOutputHelper _output;
 
-    public Bug_4679_sharded_catch_up_23505(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    public Bug_4679_sharded_catch_up_23505(ShardedPartitionedFixture fixture, ITestOutputHelper output): base(fixture)
     {
-        _fixture = fixture;
         _output = output;
     }
-
-    public async ValueTask InitializeAsync()
-    {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public ValueTask DisposeAsync() => default;
 
     public class Bug4679Trip
     {
@@ -130,7 +111,7 @@ public partial class Bug_4679_sharded_catch_up_23505: IAsyncLifetime
             x.SchemaName = "sharded";
             x.PartitionSchemaName = "tenants";
 
-            foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+            foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
             {
                 x.AddDatabase(dbName, connStr);
             }
@@ -159,14 +140,14 @@ public partial class Bug_4679_sharded_catch_up_23505: IAsyncLifetime
         var tenants = new[] { "tA", "tB", "tC", "tD", "tE" };
         var shardAssignment = new Dictionary<string, string>
         {
-            ["tA"] = _fixture.DbNames[0],
-            ["tB"] = _fixture.DbNames[0],
-            ["tC"] = _fixture.DbNames[0],
-            ["tD"] = _fixture.DbNames[1],
-            ["tE"] = _fixture.DbNames[2],
+            ["tA"] = Fixture.DbNames[0],
+            ["tB"] = Fixture.DbNames[0],
+            ["tC"] = Fixture.DbNames[0],
+            ["tD"] = Fixture.DbNames[1],
+            ["tE"] = Fixture.DbNames[2],
         };
 
-        await using var store = (DocumentStore)DocumentStore.For(configure);
+        var store = TrackStore((DocumentStore)DocumentStore.For(configure));
         foreach (var tenant in tenants)
         {
             await store.Advanced.AddTenantToShardAsync(tenant, shardAssignment[tenant], CancellationToken.None);
@@ -210,7 +191,7 @@ public partial class Bug_4679_sharded_catch_up_23505: IAsyncLifetime
         // TENANT-SCOPED (…:All:{tenant}); there is NO bare store-global …:All row (which is what
         // the user reports colliding). This is the guard that would flip red if the per-tenant
         // catch-up ever started writing store-global progression names.
-        var names = await progressionNamesAsync(_fixture.ConnectionStrings[shardAssignment["tA"]]);
+        var names = await progressionNamesAsync(Fixture.ConnectionStrings[shardAssignment["tA"]]);
         names.ShouldContain("Bug4679ShardedTrip:All:tA");
         names.ShouldContain("Bug4679ShardedTrip:All:tB");
         names.ShouldNotContain("Bug4679ShardedTrip:All");
@@ -225,7 +206,7 @@ public partial class Bug_4679_sharded_catch_up_23505: IAsyncLifetime
             x.SchemaName = "sharded";
             x.PartitionSchemaName = "tenants";
 
-            foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+            foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
             {
                 x.AddDatabase(dbName, connStr);
             }
@@ -255,14 +236,14 @@ public partial class Bug_4679_sharded_catch_up_23505: IAsyncLifetime
         var tenants = new[] { "tA", "tB", "tC", "tD", "tE" };
         var shardAssignment = new Dictionary<string, string>
         {
-            ["tA"] = _fixture.DbNames[0],
-            ["tB"] = _fixture.DbNames[0],
-            ["tC"] = _fixture.DbNames[0],
-            ["tD"] = _fixture.DbNames[1],
-            ["tE"] = _fixture.DbNames[2],
+            ["tA"] = Fixture.DbNames[0],
+            ["tB"] = Fixture.DbNames[0],
+            ["tC"] = Fixture.DbNames[0],
+            ["tD"] = Fixture.DbNames[1],
+            ["tE"] = Fixture.DbNames[2],
         };
 
-        await using var store = (DocumentStore)DocumentStore.For(configureComposite);
+        var store = TrackStore((DocumentStore)DocumentStore.For(configureComposite));
         foreach (var tenant in tenants)
         {
             await store.Advanced.AddTenantToShardAsync(tenant, shardAssignment[tenant], CancellationToken.None);
@@ -294,7 +275,7 @@ public partial class Bug_4679_sharded_catch_up_23505: IAsyncLifetime
             _output.WriteLine(e.ToString());
         }
 
-        var names = await progressionNamesAsync(_fixture.ConnectionStrings[shardAssignment["tA"]]);
+        var names = await progressionNamesAsync(Fixture.ConnectionStrings[shardAssignment["tA"]]);
         _output.WriteLine("=== mt_event_progression rows on shard_a ===");
         foreach (var n in names) _output.WriteLine(n);
 

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4706_sharded_partitioned_doc_rebuild.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4706_sharded_partitioned_doc_rebuild.cs
@@ -30,41 +30,23 @@ public class Bug4706Doc
 /// is fine. A single-DB managed-ByList store is idempotent; this exercises the sharded path.
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public class Bug_4706_sharded_partitioned_doc_rebuild: IAsyncLifetime
+public class Bug_4706_sharded_partitioned_doc_rebuild: ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
     private readonly ITestOutputHelper _output;
 
-    public Bug_4706_sharded_partitioned_doc_rebuild(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    public Bug_4706_sharded_partitioned_doc_rebuild(ShardedPartitionedFixture fixture, ITestOutputHelper output): base(fixture)
     {
-        _fixture = fixture;
         _output = output;
     }
 
-    public async ValueTask InitializeAsync()
-    {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public ValueTask DisposeAsync() => default;
-
-    private DocumentStore BuildStore() => (DocumentStore)DocumentStore.For(opts =>
+    private DocumentStore BuildStore() => TrackStore((DocumentStore)DocumentStore.For(opts =>
     {
         opts.MultiTenantedWithShardedDatabases(x =>
         {
             x.ConnectionString = ConnectionSource.ConnectionString;
             x.SchemaName = "sharded";
             x.PartitionSchemaName = "tenants";
-            foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+            foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
             {
                 x.AddDatabase(dbName, connStr);
             }
@@ -78,24 +60,24 @@ public class Bug_4706_sharded_partitioned_doc_rebuild: IAsyncLifetime
             .MultiTenantedWithPartitioning(x => x.ByList())
             .Index(x => x.Name)
             .StartIndexesByTenantId();
-    });
+    }));
 
     [Fact]
     public async Task reapply_over_existing_tenant_data_is_idempotent()
     {
         var assignment = new Dictionary<string, string>
         {
-            ["tA"] = _fixture.DbNames[0],
-            ["tB"] = _fixture.DbNames[1],
-            ["tC"] = _fixture.DbNames[2],
+            ["tA"] = Fixture.DbNames[0],
+            ["tB"] = Fixture.DbNames[1],
+            ["tC"] = Fixture.DbNames[2],
         };
 
         // First deploy: production eager-apply shape — create the parent partitioned
         // schema on every shard up front (per database, sequentially), THEN provision
         // tenants (which adds each tenant's partition to its shard via the additive
         // path), THEN write data.
-        await using (var store = BuildStore())
         {
+            var store = BuildStore();
             var databases = await store.Options.Tenancy.BuildDatabases();
             foreach (var db in databases.OfType<IMartenDatabase>())
             {
@@ -118,8 +100,8 @@ public class Bug_4706_sharded_partitioned_doc_rebuild: IAsyncLifetime
         // Second deploy (nothing changed): re-apply across all shards via the store-wide
         // path (Parallel.ForEachAsync over databases — the #4706 trigger). Must be
         // idempotent: no destructive rebuild of the per-tenant partitioned tables, no 23514.
-        await using (var store = BuildStore())
         {
+            var store = BuildStore();
             var ex = await Record.ExceptionAsync(() =>
                 store.Storage.ApplyAllConfiguredChangesToDatabaseAsync());
 

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4713_sharded_reapply_same_store.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4713_sharded_reapply_same_store.cs
@@ -43,41 +43,23 @@ public class Bug4713Doc
 /// </para>
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public class Bug_4713_sharded_reapply_same_store: IAsyncLifetime
+public class Bug_4713_sharded_reapply_same_store: ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
     private readonly ITestOutputHelper _output;
 
-    public Bug_4713_sharded_reapply_same_store(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    public Bug_4713_sharded_reapply_same_store(ShardedPartitionedFixture fixture, ITestOutputHelper output): base(fixture)
     {
-        _fixture = fixture;
         _output = output;
     }
 
-    public async ValueTask InitializeAsync()
-    {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public ValueTask DisposeAsync() => default;
-
-    private DocumentStore BuildStore() => (DocumentStore)DocumentStore.For(opts =>
+    private DocumentStore BuildStore() => TrackStore((DocumentStore)DocumentStore.For(opts =>
     {
         opts.MultiTenantedWithShardedDatabases(x =>
         {
             x.ConnectionString = ConnectionSource.ConnectionString;
             x.SchemaName = "sharded";
             x.PartitionSchemaName = "tenants";
-            foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+            foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
             {
                 x.AddDatabase(dbName, connStr);
             }
@@ -91,20 +73,20 @@ public class Bug_4713_sharded_reapply_same_store: IAsyncLifetime
             .MultiTenantedWithPartitioning(x => x.ByList())
             .Index(x => x.Name)
             .StartIndexesByTenantId();
-    });
+    }));
 
     [Fact]
     public async Task reapply_on_same_store_after_provisioning_is_idempotent()
     {
         var assignment = new Dictionary<string, string>
         {
-            ["tA"] = _fixture.DbNames[0],
-            ["tB"] = _fixture.DbNames[1],
-            ["tC"] = _fixture.DbNames[2],
+            ["tA"] = Fixture.DbNames[0],
+            ["tB"] = Fixture.DbNames[1],
+            ["tC"] = Fixture.DbNames[2],
         };
 
         // ONE store instance for the whole test — this is the distinguishing factor from #4706.
-        await using var store = BuildStore();
+        var store = BuildStore();
 
         var databases = await store.Options.Tenancy.BuildDatabases();
         foreach (var db in databases.OfType<IMartenDatabase>())
@@ -128,11 +110,11 @@ public class Bug_4713_sharded_reapply_same_store: IAsyncLifetime
 
         // Capture the partition layout each shard has AFTER provisioning. #4713 is specifically about
         // re-apply IDEMPOTENCY, so this is the baseline a no-op re-apply must preserve.
-        var shards = _fixture.ConnectionStrings.Keys.ToList();
+        var shards = Fixture.ConnectionStrings.Keys.ToList();
         var before = new Dictionary<string, List<string>>();
         foreach (var shard in shards)
         {
-            before[shard] = await partitionsOf(_fixture.ConnectionStrings[shard], "mt_doc_bug4713doc");
+            before[shard] = await partitionsOf(Fixture.ConnectionStrings[shard], "mt_doc_bug4713doc");
             _output.WriteLine($"[before][{shard}] {string.Join(", ", before[shard])}");
         }
 
@@ -156,7 +138,7 @@ public class Bug_4713_sharded_reapply_same_store: IAsyncLifetime
         // #4713 fix restores (flag stays set → ListPartitioning.CreateDelta → None on every shard).
         foreach (var shard in shards)
         {
-            var after = await partitionsOf(_fixture.ConnectionStrings[shard], "mt_doc_bug4713doc");
+            var after = await partitionsOf(Fixture.ConnectionStrings[shard], "mt_doc_bug4713doc");
             _output.WriteLine($"[after][{shard}] {string.Join(", ", after)}");
             after.ShouldBe(before[shard],
                 $"re-applying the schema must not change shard {shard}'s per-tenant partitions (#4713)");

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4751_composite_catchup_under_sharded.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4751_composite_catchup_under_sharded.cs
@@ -63,48 +63,27 @@ public partial class CmpTripCountProjection: SingleStreamProjection<CmpTripCount
 /// </para>
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public class Bug_4751_composite_catchup_under_sharded: IAsyncLifetime
+public class Bug_4751_composite_catchup_under_sharded: ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
     private readonly ITestOutputHelper _output;
     private DocumentStore _store = null!;
 
-    public Bug_4751_composite_catchup_under_sharded(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    public Bug_4751_composite_catchup_under_sharded(ShardedPartitionedFixture fixture, ITestOutputHelper output): base(fixture)
     {
-        _fixture = fixture;
         _output = output;
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (_store != null!) await _store.DisposeAsync();
     }
 
     [Fact]
     public async Task composite_reaches_non_stale_via_normal_daemon_catchup()
     {
-        _store = (DocumentStore)DocumentStore.For(opts =>
+        _store = TrackStore((DocumentStore)DocumentStore.For(opts =>
         {
             opts.MultiTenantedWithShardedDatabases(x =>
             {
                 x.ConnectionString = ConnectionSource.ConnectionString;
                 x.SchemaName = "sharded";
                 x.PartitionSchemaName = "tenants";
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
                 {
                     x.AddDatabase(dbName, connStr);
                 }
@@ -124,9 +103,9 @@ public class Bug_4751_composite_catchup_under_sharded: IAsyncLifetime
 
             opts.Schema.For<CmpTrip>().DocumentAlias("cmp_trip");
             opts.Schema.For<CmpTripCount>().DocumentAlias("cmp_trip_count");
-        });
+        }));
 
-        var shard = _fixture.DbNames[0];
+        var shard = Fixture.DbNames[0];
         await _store.Advanced.AddTenantToShardAsync("tenant_a", shard, CancellationToken.None);
 
         const int streams = 10;

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4753_sharded_partitioned_event_rebuild.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4753_sharded_partitioned_event_rebuild.cs
@@ -32,41 +32,23 @@ namespace TenantPartitionedEventsTests.Sharded;
 /// </para>
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public class Bug_4753_sharded_partitioned_event_rebuild: IAsyncLifetime
+public class Bug_4753_sharded_partitioned_event_rebuild: ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
     private readonly ITestOutputHelper _output;
 
-    public Bug_4753_sharded_partitioned_event_rebuild(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    public Bug_4753_sharded_partitioned_event_rebuild(ShardedPartitionedFixture fixture, ITestOutputHelper output): base(fixture)
     {
-        _fixture = fixture;
         _output = output;
     }
 
-    public async ValueTask InitializeAsync()
-    {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public ValueTask DisposeAsync() => default;
-
-    private DocumentStore BuildStore() => (DocumentStore)DocumentStore.For(opts =>
+    private DocumentStore BuildStore() => TrackStore((DocumentStore)DocumentStore.For(opts =>
     {
         opts.MultiTenantedWithShardedDatabases(x =>
         {
             x.ConnectionString = ConnectionSource.ConnectionString;
             x.SchemaName = "sharded";
             x.PartitionSchemaName = "tenants";
-            foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+            foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
             {
                 x.AddDatabase(dbName, connStr);
             }
@@ -76,23 +58,23 @@ public class Bug_4753_sharded_partitioned_event_rebuild: IAsyncLifetime
         opts.Events.TenancyStyle = TenancyStyle.Conjoined;
         opts.Events.UseTenantPartitionedEvents = true;
         opts.Events.AddEventType<Bug4753ShardedEvent>();
-    });
+    }));
 
     [Fact]
     public async Task reapply_over_existing_tenant_partitioned_events_is_idempotent()
     {
         var assignment = new Dictionary<string, string>
         {
-            ["tA"] = _fixture.DbNames[0],
-            ["tB"] = _fixture.DbNames[1],
-            ["tC"] = _fixture.DbNames[2],
+            ["tA"] = Fixture.DbNames[0],
+            ["tB"] = Fixture.DbNames[1],
+            ["tC"] = Fixture.DbNames[2],
         };
 
         // First deploy: create the parent partitioned schema on every shard, provision tenants
         // (additive per-tenant partitions on mt_streams / mt_events), then APPEND EVENTS so the
         // partitioned event tables actually hold rows.
-        await using (var store = BuildStore())
         {
+            var store = BuildStore();
             var databases = await store.Options.Tenancy.BuildDatabases();
             foreach (var db in databases.OfType<IMartenDatabase>())
             {
@@ -116,8 +98,8 @@ public class Bug_4753_sharded_partitioned_event_rebuild: IAsyncLifetime
         // path. Pre-fix this destructively rebuilds the partitioned mt_streams / mt_events on each shard
         // and the INSERT…SELECT of the existing events fails with 23514. With IgnorePartitionsInMigration
         // set on the event tables it is a no-op.
-        await using (var store = BuildStore())
         {
+            var store = BuildStore();
             var ex = await Record.ExceptionAsync(() =>
                 store.Storage.ApplyAllConfiguredChangesToDatabaseAsync());
 

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4761_per_tenant_progression_same_shard.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4761_per_tenant_progression_same_shard.cs
@@ -41,48 +41,27 @@ namespace TenantPartitionedEventsTests.Sharded;
 /// </para>
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public class Bug_4761_per_tenant_progression_same_shard: IAsyncLifetime
+public class Bug_4761_per_tenant_progression_same_shard: ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
     private readonly ITestOutputHelper _output;
     private DocumentStore _store = null!;
 
-    public Bug_4761_per_tenant_progression_same_shard(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    public Bug_4761_per_tenant_progression_same_shard(ShardedPartitionedFixture fixture, ITestOutputHelper output): base(fixture)
     {
-        _fixture = fixture;
         _output = output;
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (_store != null!) await _store.DisposeAsync();
     }
 
     [Fact]
     public async Task per_tenant_progression_rows_exist_when_two_tenants_share_a_shard()
     {
-        _store = (DocumentStore)DocumentStore.For(opts =>
+        _store = TrackStore((DocumentStore)DocumentStore.For(opts =>
         {
             opts.MultiTenantedWithShardedDatabases(x =>
             {
                 x.ConnectionString = ConnectionSource.ConnectionString;
                 x.SchemaName = "sharded";
                 x.PartitionSchemaName = "tenants";
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
                 {
                     x.AddDatabase(dbName, connStr);
                 }
@@ -96,11 +75,11 @@ public class Bug_4761_per_tenant_progression_same_shard: IAsyncLifetime
 
             opts.Projections.Add<ShardedDaemonProjection>(ProjectionLifecycle.Async);
             opts.Schema.For<ShardedDaemonCounter>().DocumentAlias("p4761_sdc");
-        });
+        }));
 
         // Both tenants on the SAME shard, with DIFFERENT event counts so their per-tenant
         // sequences diverge (x: 3, y: 2) and their seq_id ranges overlap.
-        var shard = _fixture.DbNames[0];
+        var shard = Fixture.DbNames[0];
         await _store.Advanced.AddTenantToShardAsync("tenant_x", shard, CancellationToken.None);
         await _store.Advanced.AddTenantToShardAsync("tenant_y", shard, CancellationToken.None);
 

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4763_reassign_count_divergence.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4763_reassign_count_divergence.cs
@@ -26,48 +26,27 @@ namespace TenantPartitionedEventsTests.Sharded;
 /// (0 active tenants). It fails because A's count remains 1.</para>
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public class Bug_4763_reassign_count_divergence: IAsyncLifetime
+public class Bug_4763_reassign_count_divergence: ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
     private readonly ITestOutputHelper _output;
     private DocumentStore _store = null!;
 
-    public Bug_4763_reassign_count_divergence(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    public Bug_4763_reassign_count_divergence(ShardedPartitionedFixture fixture, ITestOutputHelper output): base(fixture)
     {
-        _fixture = fixture;
         _output = output;
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (_store != null!) await _store.DisposeAsync();
     }
 
     [Fact]
     public async Task reassigning_a_tenant_decrements_the_source_shard_count()
     {
-        _store = (DocumentStore)DocumentStore.For(opts =>
+        _store = TrackStore((DocumentStore)DocumentStore.For(opts =>
         {
             opts.MultiTenantedWithShardedDatabases(x =>
             {
                 x.ConnectionString = ConnectionSource.ConnectionString;
                 x.SchemaName = "sharded";
                 x.PartitionSchemaName = "tenants";
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
                 {
                     x.AddDatabase(dbName, connStr);
                 }
@@ -79,10 +58,10 @@ public class Bug_4763_reassign_count_divergence: IAsyncLifetime
             opts.Events.UseTenantPartitionedEvents = true;
             opts.Events.AddEventType<ShardedDaemonEvent>();
             opts.Schema.For<ShardedDaemonCounter>().DocumentAlias("p4763_sdc");
-        });
+        }));
 
-        var shardA = _fixture.DbNames[0];
-        var shardB = _fixture.DbNames[1];
+        var shardA = Fixture.DbNames[0];
+        var shardB = Fixture.DbNames[1];
 
         // Assign the tenant to A, then move it to B.
         await _store.Advanced.AddTenantToShardAsync("mover", shardA, CancellationToken.None);

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4942_auto_assign_provisioning_repair.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4942_auto_assign_provisioning_repair.cs
@@ -39,72 +39,23 @@ public class Bug4942Doc
 /// most one batch of IF NOT EXISTS catalog checks per tenant per process.
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public class Bug_4942_auto_assign_provisioning_repair : IAsyncLifetime
+public class Bug_4942_auto_assign_provisioning_repair : ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
-    private readonly List<IDocumentStore> _stores = new();
-
-    public Bug_4942_auto_assign_provisioning_repair(ShardedPartitionedFixture fixture)
+    public Bug_4942_auto_assign_provisioning_repair(ShardedPartitionedFixture fixture): base(fixture)
     {
-        _fixture = fixture;
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public ValueTask DisposeAsync()
-    {
-        foreach (var store in _stores)
-        {
-            store.Dispose();
-        }
-
-        return default;
     }
 
     private IDocumentStore BuildStore()
     {
-        var store = DocumentStore.For(opts =>
+        return BuildShardedStore(opts =>
         {
-            opts.MultiTenantedWithShardedDatabases(x =>
-            {
-                x.ConnectionString = ConnectionSource.ConnectionString;
-                x.SchemaName = "sharded";
-                x.PartitionSchemaName = "tenants";
-
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
-                {
-                    x.AddDatabase(dbName, connStr);
-                }
-
-                x.UseSmallestDatabaseAssignment();
-            });
-
             opts.AutoCreateSchemaObjects = AutoCreate.All;
 
-            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
-            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
-            opts.Events.UseTenantPartitionedEvents = true;
             opts.Events.AddEventType<ShardedTestEvent>();
 
             opts.Schema.For<Bug4942Doc>()
                 .MultiTenantedWithPartitioning(x => x.ByList());
         });
-
-        _stores.Add(store);
-        return store;
     }
 
     /// <summary>
@@ -133,7 +84,6 @@ public class Bug_4942_auto_assign_provisioning_repair : IAsyncLifetime
         await assertSequenceState(dbId, tenantId, shouldExist: true, "after initial provisioning");
 
         store.Dispose();
-        _stores.Remove(store);
 
         await damageTenantAsync(dbId, tenantId);
         return dbId;
@@ -141,7 +91,7 @@ public class Bug_4942_auto_assign_provisioning_repair : IAsyncLifetime
 
     private async Task damageTenantAsync(string dbId, string tenantId)
     {
-        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await using var conn = new NpgsqlConnection(Fixture.ConnectionStrings[dbId]);
         await conn.OpenAsync();
         await conn.CreateCommand($"drop table if exists public.mt_doc_bug4942doc_{tenantId}")
             .ExecuteNonQueryAsync();
@@ -252,7 +202,7 @@ public class Bug_4942_auto_assign_provisioning_repair : IAsyncLifetime
 
     private async Task assertDocPartitionExists(string dbId, string tenantId)
     {
-        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await using var conn = new NpgsqlConnection(Fixture.ConnectionStrings[dbId]);
         await conn.OpenAsync();
         var tables = await conn.ExistingTablesAsync();
         tables.Any(t => t.Name == $"mt_doc_bug4942doc_{tenantId}").ShouldBeTrue(
@@ -261,7 +211,7 @@ public class Bug_4942_auto_assign_provisioning_repair : IAsyncLifetime
 
     private async Task assertSequenceState(string dbId, string tenantId, bool shouldExist, string because)
     {
-        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await using var conn = new NpgsqlConnection(Fixture.ConnectionStrings[dbId]);
         await conn.OpenAsync();
         var count = (long)(await conn.CreateCommand(
                 "select count(*) from pg_sequences where schemaname = 'public' and sequencename = :n")

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4944_database_driven_partition_sweep.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4944_database_driven_partition_sweep.cs
@@ -54,28 +54,20 @@ public class Bug4944Gamma
 /// INCOMPLETE registration — a test that provisions from a fully-registered store proves nothing.
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public class Bug_4944_database_driven_partition_sweep : IAsyncLifetime
+public class Bug_4944_database_driven_partition_sweep : ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
-    private readonly List<IDocumentStore> _stores = new();
-
-    public Bug_4944_database_driven_partition_sweep(ShardedPartitionedFixture fixture)
+    public Bug_4944_database_driven_partition_sweep(ShardedPartitionedFixture fixture): base(fixture)
     {
-        _fixture = fixture;
     }
 
-    public async ValueTask InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
+        await base.InitializeAsync();
 
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        foreach (var connStr in Fixture.ConnectionStrings.Values)
         {
             await using var tenantConn = new NpgsqlConnection(connStr);
             await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
 
             // The fixture's cleaner only knows how to drop mt_* objects; these tests plant
             // non-Marten partitioned tables to prove the sweep does NOT touch them.
@@ -83,16 +75,6 @@ public class Bug_4944_database_driven_partition_sweep : IAsyncLifetime
             await tenantConn.CreateCommand("drop table if exists public.other_app_ledger cascade")
                 .ExecuteNonQueryAsync();
         }
-    }
-
-    public ValueTask DisposeAsync()
-    {
-        foreach (var store in _stores)
-        {
-            store.Dispose();
-        }
-
-        return default;
     }
 
     /// <summary>
@@ -120,34 +102,14 @@ public class Bug_4944_database_driven_partition_sweep : IAsyncLifetime
 
     private IDocumentStore buildStore(Action<StoreOptions> configure)
     {
-        var store = DocumentStore.For(opts =>
+        return BuildShardedStore(opts =>
         {
-            opts.MultiTenantedWithShardedDatabases(x =>
-            {
-                x.ConnectionString = ConnectionSource.ConnectionString;
-                x.SchemaName = "sharded";
-                x.PartitionSchemaName = "tenants";
-
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
-                {
-                    x.AddDatabase(dbName, connStr);
-                }
-
-                x.UseSmallestDatabaseAssignment();
-            });
-
             opts.AutoCreateSchemaObjects = AutoCreate.All;
 
-            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
-            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
-            opts.Events.UseTenantPartitionedEvents = true;
             opts.Events.AddEventType<ShardedTestEvent>();
 
             configure(opts);
         });
-
-        _stores.Add(store);
-        return store;
     }
 
     /// <summary>
@@ -272,7 +234,7 @@ public class Bug_4944_database_driven_partition_sweep : IAsyncLifetime
     {
         var tenantId = "t4944_delta";
 
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        foreach (var connStr in Fixture.ConnectionStrings.Values)
         {
             await using var conn = new NpgsqlConnection(connStr);
             await conn.OpenAsync(TestContext.Current.CancellationToken);
@@ -307,7 +269,7 @@ public class Bug_4944_database_driven_partition_sweep : IAsyncLifetime
 
     private async Task assertPartitionExists(string dbId, string partitionTableName)
     {
-        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await using var conn = new NpgsqlConnection(Fixture.ConnectionStrings[dbId]);
         await conn.OpenAsync();
         var tables = await conn.ExistingTablesAsync();
         tables.Any(t => t.Schema == "public" && t.Name == partitionTableName).ShouldBeTrue(
@@ -316,7 +278,7 @@ public class Bug_4944_database_driven_partition_sweep : IAsyncLifetime
 
     private async Task assertPartitionMissing(string dbId, string partitionTableName)
     {
-        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await using var conn = new NpgsqlConnection(Fixture.ConnectionStrings[dbId]);
         await conn.OpenAsync();
         var tables = await conn.ExistingTablesAsync();
         tables.Any(t => t.Schema == "public" && t.Name == partitionTableName).ShouldBeFalse(
@@ -329,7 +291,7 @@ public class Bug_4944_database_driven_partition_sweep : IAsyncLifetime
     /// </summary>
     private async Task assertNoPartitionsOf(string dbId, string schema, string tableName)
     {
-        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await using var conn = new NpgsqlConnection(Fixture.ConnectionStrings[dbId]);
         await conn.OpenAsync();
 
         var count = (long)(await conn.CreateCommand(

--- a/src/TenantPartitionedEventsTests/Sharded/ShardedPartitionedContext.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/ShardedPartitionedContext.cs
@@ -1,0 +1,114 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Npgsql;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+/// <summary>
+/// Base for test classes on the "sharded-tenant-partitioned" collection.
+/// Owns the per-test scrub that every class used to re-declare (drop the
+/// master <c>sharded</c> schema, then per shard: drop <c>tenants</c> and wipe
+/// every <c>mt_*</c> object from public), plus tracked disposal for however
+/// many stores a test builds.
+/// </summary>
+/// <remarks>
+/// Subclasses still carry their own <c>[Collection("sharded-tenant-partitioned")]</c>
+/// attribute — xUnit reads it from the concrete class. Stores built through
+/// <see cref="BuildShardedStore"/> get the standard three-shard wiring
+/// (master schema <c>sharded</c>, partition schema <c>tenants</c>, smallest-
+/// database assignment) and the common partitioned-event config; the
+/// configure callback runs last so files can override or extend any of it.
+/// AutoCreateSchemaObjects is deliberately NOT set here — files split
+/// between All and the default. Tests whose store wiring deviates from the
+/// standard block (per-database partitioning, custom assignment...) should
+/// build their own store and hand it to <see cref="TrackStore"/> for
+/// disposal.
+/// </remarks>
+public abstract class ShardedPartitionedContext: IAsyncLifetime
+{
+    private readonly List<IDocumentStore> _stores = new();
+
+    protected ShardedPartitionedContext(ShardedPartitionedFixture fixture)
+    {
+        Fixture = fixture;
+    }
+
+    protected ShardedPartitionedFixture Fixture { get; }
+
+    public virtual async ValueTask InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+
+        foreach (var connStr in Fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    /// <summary>
+    /// Track an externally built store for disposal at class teardown.
+    /// </summary>
+    protected T TrackStore<T>(T store) where T : IDocumentStore
+    {
+        _stores.Add(store);
+        return store;
+    }
+
+    /// <summary>
+    /// Build (and track) a store with the standard three-shard wiring and the
+    /// common partitioned-event config. <paramref name="configure"/> runs
+    /// last, so it can add event types/projections or override any common
+    /// line.
+    /// </summary>
+    protected DocumentStore BuildShardedStore(Action<StoreOptions>? configure = null)
+    {
+        var store = DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+                foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+                x.UseSmallestDatabaseAssignment();
+            });
+
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+
+            configure?.Invoke(opts);
+        });
+
+        return TrackStore(store);
+    }
+
+    public virtual ValueTask DisposeAsync()
+    {
+        foreach (var store in _stores)
+        {
+            store.Dispose();
+        }
+
+        _stores.Clear();
+
+        return default;
+    }
+}

--- a/src/TenantPartitionedEventsTests/Sharded/composite_side_effects_rebuild_under_sharded_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/composite_side_effects_rebuild_under_sharded_partitioning.cs
@@ -40,34 +40,15 @@ namespace TenantPartitionedEventsTests.Sharded;
 /// rebuild completes (no deadlock) and every tenant's documents on the multi-tenant shard materialize.
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public partial class composite_side_effects_rebuild_under_sharded_partitioning: IAsyncLifetime
+public partial class composite_side_effects_rebuild_under_sharded_partitioning: ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
     private readonly ITestOutputHelper _output;
     private readonly RecordingOutbox _outbox = new();
 
-    public composite_side_effects_rebuild_under_sharded_partitioning(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    public composite_side_effects_rebuild_under_sharded_partitioning(ShardedPartitionedFixture fixture, ITestOutputHelper output): base(fixture)
     {
-        _fixture = fixture;
         _output = output;
     }
-
-    public async ValueTask InitializeAsync()
-    {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public ValueTask DisposeAsync() => default;
 
     public record TripStarted(Guid Id);
     public record TripLeg(double Distance);
@@ -116,7 +97,7 @@ public partial class composite_side_effects_rebuild_under_sharded_partitioning: 
             x.SchemaName = "sharded";
             x.PartitionSchemaName = "tenants";
 
-            foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+            foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
             {
                 x.AddDatabase(dbName, connStr);
             }
@@ -148,14 +129,14 @@ public partial class composite_side_effects_rebuild_under_sharded_partitioning: 
         var tenants = new[] { "tA", "tB", "tC", "tD", "tE" };
         var shardAssignment = new Dictionary<string, string>
         {
-            ["tA"] = _fixture.DbNames[0],
-            ["tB"] = _fixture.DbNames[0],
-            ["tC"] = _fixture.DbNames[0],
-            ["tD"] = _fixture.DbNames[1],
-            ["tE"] = _fixture.DbNames[2],
+            ["tA"] = Fixture.DbNames[0],
+            ["tB"] = Fixture.DbNames[0],
+            ["tC"] = Fixture.DbNames[0],
+            ["tD"] = Fixture.DbNames[1],
+            ["tE"] = Fixture.DbNames[2],
         };
 
-        await using var store = (DocumentStore)DocumentStore.For(configure);
+        var store = TrackStore((DocumentStore)DocumentStore.For(configure));
         foreach (var tenant in tenants)
         {
             await store.Advanced.AddTenantToShardAsync(tenant, shardAssignment[tenant], CancellationToken.None);

--- a/src/TenantPartitionedEventsTests/Sharded/sharded_daemon_per_shard_progression.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/sharded_daemon_per_shard_progression.cs
@@ -51,41 +51,18 @@ namespace TenantPartitionedEventsTests.Sharded;
 /// </para>
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public class sharded_daemon_per_shard_progression : IAsyncLifetime
+public class sharded_daemon_per_shard_progression : ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
     private IDocumentStore _store = null!;
 
-    public sharded_daemon_per_shard_progression(ShardedPartitionedFixture fixture)
+    public sharded_daemon_per_shard_progression(ShardedPartitionedFixture fixture): base(fixture)
     {
-        _fixture = fixture;
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public ValueTask DisposeAsync()
-    {
-        _store?.Dispose();
-        return default;
     }
 
     [Fact]
     public async Task daemon_catches_up_tenants_on_separate_shards_independently()
     {
-        _store = DocumentStore.For(opts =>
+        _store = TrackStore(DocumentStore.For(opts =>
         {
             opts.MultiTenantedWithShardedDatabases(x =>
             {
@@ -93,7 +70,7 @@ public class sharded_daemon_per_shard_progression : IAsyncLifetime
                 x.SchemaName = "sharded";
                 x.PartitionSchemaName = "tenants";
 
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
                 {
                     x.AddDatabase(dbName, connStr);
                 }
@@ -109,12 +86,12 @@ public class sharded_daemon_per_shard_progression : IAsyncLifetime
             opts.Projections.Add<ShardedDaemonProjection>(ProjectionLifecycle.Async);
 
             opts.Schema.For<ShardedDaemonCounter>().DocumentAlias("p2c_sdc");
-        });
+        }));
 
         // Assign each tenant to a DIFFERENT shard to exercise the cross-shard
         // daemon catch-up path explicitly.
-        var shardA = _fixture.DbNames[0];
-        var shardB = _fixture.DbNames[1];
+        var shardA = Fixture.DbNames[0];
+        var shardB = Fixture.DbNames[1];
         await _store.Advanced.AddTenantToShardAsync("tenant_on_a", shardA, CancellationToken.None);
         await _store.Advanced.AddTenantToShardAsync("tenant_on_b", shardB, CancellationToken.None);
 
@@ -175,7 +152,7 @@ public class sharded_daemon_per_shard_progression : IAsyncLifetime
     [Fact]
     public async Task progression_row_for_each_tenant_lives_on_its_own_shard()
     {
-        _store = DocumentStore.For(opts =>
+        _store = TrackStore(DocumentStore.For(opts =>
         {
             opts.MultiTenantedWithShardedDatabases(x =>
             {
@@ -183,7 +160,7 @@ public class sharded_daemon_per_shard_progression : IAsyncLifetime
                 x.SchemaName = "sharded";
                 x.PartitionSchemaName = "tenants";
 
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
                 {
                     x.AddDatabase(dbName, connStr);
                 }
@@ -196,10 +173,10 @@ public class sharded_daemon_per_shard_progression : IAsyncLifetime
             opts.Events.AddEventType<ShardedDaemonEvent>();
             opts.Projections.Add<ShardedDaemonProjection>(ProjectionLifecycle.Async);
             opts.Schema.For<ShardedDaemonCounter>().DocumentAlias("p2c_sdc");
-        });
+        }));
 
-        var shardA = _fixture.DbNames[0];
-        var shardB = _fixture.DbNames[2];
+        var shardA = Fixture.DbNames[0];
+        var shardB = Fixture.DbNames[2];
         await _store.Advanced.AddTenantToShardAsync("progress_a", shardA, CancellationToken.None);
         await _store.Advanced.AddTenantToShardAsync("progress_c", shardB, CancellationToken.None);
 
@@ -230,8 +207,8 @@ public class sharded_daemon_per_shard_progression : IAsyncLifetime
         // row name is the projection name (or composed with tenant id when
         // per-tenant tracking is on); the row's last_seq_id must be > 0
         // because at least one event flowed.
-        var shardAConnStr = _fixture.ConnectionStrings[shardA];
-        var shardBConnStr = _fixture.ConnectionStrings[shardB];
+        var shardAConnStr = Fixture.ConnectionStrings[shardA];
+        var shardBConnStr = Fixture.ConnectionStrings[shardB];
 
         // Poll for the per-tenant progression rows. WaitForNonStaleData can return before a per-tenant
         // agent has committed on a partitioned store (its caught-up check counts store-global shards,

--- a/src/TenantPartitionedEventsTests/Sharded/sharded_eager_apply_per_tenant_events.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/sharded_eager_apply_per_tenant_events.cs
@@ -35,57 +35,19 @@ namespace TenantPartitionedEventsTests.Sharded;
 /// </para>
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public class sharded_eager_apply_per_tenant_events : IAsyncLifetime
+public class sharded_eager_apply_per_tenant_events : ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
     private IDocumentStore _store = null!;
 
-    public sharded_eager_apply_per_tenant_events(ShardedPartitionedFixture fixture)
+    public sharded_eager_apply_per_tenant_events(ShardedPartitionedFixture fixture): base(fixture)
     {
-        _fixture = fixture;
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public ValueTask DisposeAsync()
-    {
-        _store?.Dispose();
-        return default;
     }
 
     private IDocumentStore CreateStore()
     {
-        _store = DocumentStore.For(opts =>
+        _store = BuildShardedStore(opts =>
         {
-            opts.MultiTenantedWithShardedDatabases(x =>
-            {
-                x.ConnectionString = ConnectionSource.ConnectionString;
-                x.SchemaName = "sharded";
-                x.PartitionSchemaName = "tenants";
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
-                {
-                    x.AddDatabase(dbName, connStr);
-                }
-                x.UseSmallestDatabaseAssignment();
-            });
-
             opts.AutoCreateSchemaObjects = AutoCreate.All;
-            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
-            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
-            opts.Events.UseTenantPartitionedEvents = true;
             opts.Events.AddEventType<ShardedTestEvent>();
         });
 
@@ -121,7 +83,7 @@ public class sharded_eager_apply_per_tenant_events : IAsyncLifetime
         await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Sanity: the partition lives in the assigned shard.
-        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await using var conn = new NpgsqlConnection(Fixture.ConnectionStrings[dbId]);
         await conn.OpenAsync(TestContext.Current.CancellationToken);
         var tables = await conn.ExistingTablesAsync(ct: TestContext.Current.CancellationToken);
         tables.Any(t => t.Name == "mt_events_alpha").ShouldBeTrue(

--- a/src/TenantPartitionedEventsTests/Sharded/sharded_one_database_per_shard.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/sharded_one_database_per_shard.cs
@@ -28,41 +28,18 @@ namespace TenantPartitionedEventsTests.Sharded;
 /// its sessions continue to read/write through that database.
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public class sharded_one_database_per_shard : IAsyncLifetime
+public class sharded_one_database_per_shard : ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
     private IDocumentStore _store = null!;
 
-    public sharded_one_database_per_shard(ShardedPartitionedFixture fixture)
+    public sharded_one_database_per_shard(ShardedPartitionedFixture fixture): base(fixture)
     {
-        _fixture = fixture;
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public ValueTask DisposeAsync()
-    {
-        _store?.Dispose();
-        return default;
     }
 
     [Fact]
     public async Task two_tenants_on_the_same_shard_share_one_MartenDatabase_instance()
     {
-        _store = DocumentStore.For(opts =>
+        _store = TrackStore(DocumentStore.For(opts =>
         {
             opts.MultiTenantedWithShardedDatabases(x =>
             {
@@ -70,7 +47,7 @@ public class sharded_one_database_per_shard : IAsyncLifetime
                 x.SchemaName = "sharded";
                 x.PartitionSchemaName = "tenants";
 
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
                 {
                     x.AddDatabase(dbName, connStr);
                 }
@@ -81,12 +58,12 @@ public class sharded_one_database_per_shard : IAsyncLifetime
             opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
             opts.Events.UseTenantPartitionedEvents = true;
             opts.Events.AddEventType<ShardedTestEvent>();
-        });
+        }));
 
         // Explicitly assign two tenants to the SAME shard so we can pin the
         // one-MartenDatabase-per-shard invariant without depending on the
         // hash-distribution choice an auto-assigner would make.
-        var sharedShard = _fixture.DbNames[0];
+        var sharedShard = Fixture.DbNames[0];
         await _store.Advanced.AddTenantToShardAsync("alpha", sharedShard, CancellationToken.None);
         await _store.Advanced.AddTenantToShardAsync("beta", sharedShard, CancellationToken.None);
 
@@ -104,7 +81,7 @@ public class sharded_one_database_per_shard : IAsyncLifetime
     [Fact]
     public async Task disabling_tenant_A_on_shared_shard_does_not_break_tenant_B_appends()
     {
-        _store = DocumentStore.For(opts =>
+        _store = TrackStore(DocumentStore.For(opts =>
         {
             opts.MultiTenantedWithShardedDatabases(x =>
             {
@@ -112,7 +89,7 @@ public class sharded_one_database_per_shard : IAsyncLifetime
                 x.SchemaName = "sharded";
                 x.PartitionSchemaName = "tenants";
 
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
                 {
                     x.AddDatabase(dbName, connStr);
                 }
@@ -123,10 +100,10 @@ public class sharded_one_database_per_shard : IAsyncLifetime
             opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
             opts.Events.UseTenantPartitionedEvents = true;
             opts.Events.AddEventType<ShardedTestEvent>();
-        });
+        }));
 
         // Both tenants on the same shard.
-        var sharedShard = _fixture.DbNames[1];
+        var sharedShard = Fixture.DbNames[1];
         await _store.Advanced.AddTenantToShardAsync("disabletest_a", sharedShard, CancellationToken.None);
         await _store.Advanced.AddTenantToShardAsync("disabletest_b", sharedShard, CancellationToken.None);
 

--- a/src/TenantPartitionedEventsTests/Sharded/sharded_tenancy_per_tenant_events.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/sharded_tenancy_per_tenant_events.cs
@@ -34,41 +34,17 @@ namespace TenantPartitionedEventsTests.Sharded;
 /// auto-assign override so CritterWatch can provision store-agnostically.
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
-public class sharded_tenancy_per_tenant_events : IAsyncLifetime
+public class sharded_tenancy_per_tenant_events : ShardedPartitionedContext
 {
-    private readonly ShardedPartitionedFixture _fixture;
     private IDocumentStore _store = null!;
 
-    public sharded_tenancy_per_tenant_events(ShardedPartitionedFixture fixture)
+    public sharded_tenancy_per_tenant_events(ShardedPartitionedFixture fixture): base(fixture)
     {
-        _fixture = fixture;
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        // Clean schemas before each test — both the master pool DB and each shard.
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        try { await conn.DropSchemaAsync("sharded"); } catch { }
-
-        foreach (var connStr in _fixture.ConnectionStrings.Values)
-        {
-            await using var tenantConn = new NpgsqlConnection(connStr);
-            await tenantConn.OpenAsync();
-            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
-        }
-    }
-
-    public ValueTask DisposeAsync()
-    {
-        _store?.Dispose();
-        return default;
     }
 
     private IDocumentStore CreateStore(Action<ShardedTenancyOptions>? customConfig = null, Action<StoreOptions>? storeConfig = null)
     {
-        _store = DocumentStore.For(opts =>
+        _store = TrackStore(DocumentStore.For(opts =>
         {
             opts.MultiTenantedWithShardedDatabases(x =>
             {
@@ -76,7 +52,7 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
                 x.SchemaName = "sharded";
                 x.PartitionSchemaName = "tenants";
 
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
                 {
                     x.AddDatabase(dbName, connStr);
                 }
@@ -97,7 +73,7 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
             opts.Events.AddEventType<ShardedTestEvent>();
 
             storeConfig?.Invoke(opts);
-        });
+        }));
 
         return _store;
     }
@@ -156,7 +132,7 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
         // in mt_events but the post-process guard tombstoned the StartStream, so the
         // mt_streams row never landed — that's why a later Append threw NonExistentStream.
         await assertStreamRowExistsWithType(
-            _fixture.ConnectionStrings[dbId!],
+            Fixture.ConnectionStrings[dbId!],
             streamId,
             tenantId: "india",
             // EventGraph.AggregateAliasFor for a non-generic type = type.Name.ToTableAlias()
@@ -239,9 +215,9 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
         // not other shards). That placement is what the fix has to get right — calling
         // EnsureSequencesAsync against `Tenancy.Default.Database` would create the
         // sequence in the wrong place and the assigned shard would still fail on append.
-        await assertSequenceExists(_fixture.ConnectionStrings[dbId], expected: "mt_events_sequence_bravo");
+        await assertSequenceExists(Fixture.ConnectionStrings[dbId], expected: "mt_events_sequence_bravo");
 
-        foreach (var (otherDbName, otherConnStr) in _fixture.ConnectionStrings)
+        foreach (var (otherDbName, otherConnStr) in Fixture.ConnectionStrings)
         {
             if (otherDbName == dbId) continue;
             await assertSequenceDoesNotExist(otherConnStr, "mt_events_sequence_bravo",
@@ -270,7 +246,7 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
         // The original report observed that AddTenantToShardAsync created the document
         // LIST partitions but not the event partition. This pins both ends — event
         // partition + sequence — for the runtime-provisioning path.
-        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await using var conn = new NpgsqlConnection(Fixture.ConnectionStrings[dbId]);
         await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         var tables = await conn.ExistingTablesAsync(ct: TestContext.Current.CancellationToken);
@@ -288,9 +264,9 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
         // Explicit-target overload — different ShardedTenancy entry (AssignTenantAsync)
         // but must converge on the same createPartitionsForTenant path so the fix covers
         // it too.
-        await _store.Advanced.AddTenantToShardAsync("delta", _fixture.DbNames[1], CancellationToken.None);
+        await _store.Advanced.AddTenantToShardAsync("delta", Fixture.DbNames[1], CancellationToken.None);
 
-        await assertSequenceExists(_fixture.ConnectionStrings[_fixture.DbNames[1]],
+        await assertSequenceExists(Fixture.ConnectionStrings[Fixture.DbNames[1]],
             expected: "mt_events_sequence_delta");
     }
 
@@ -305,8 +281,8 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
         var source = (IDynamicTenantSource<string>)_store.Options.Tenancy;
         var dbId = await source.AddTenantAsync("echo", CancellationToken.None);
 
-        dbId.ShouldBeOneOf(_fixture.DbNames);
-        await assertSequenceExists(_fixture.ConnectionStrings[dbId], expected: "mt_events_sequence_echo");
+        dbId.ShouldBeOneOf(Fixture.DbNames);
+        await assertSequenceExists(Fixture.ConnectionStrings[dbId], expected: "mt_events_sequence_echo");
 
         // And the append actually works — the full surface this enables.
         await using var session = _store.LightweightSession("echo");
@@ -320,12 +296,12 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
         CreateStore();
 
         var source = (IDynamicTenantSource<string>)_store.Options.Tenancy;
-        await source.AddTenantAsync("foxtrot", _fixture.DbNames[2]);
+        await source.AddTenantAsync("foxtrot", Fixture.DbNames[2]);
 
         var sharded = (ShardedTenancy)_store.Options.Tenancy;
         (await sharded.FindDatabaseForTenantAsync("foxtrot", CancellationToken.None))
-            .ShouldBe(_fixture.DbNames[2]);
-        await assertSequenceExists(_fixture.ConnectionStrings[_fixture.DbNames[2]],
+            .ShouldBe(Fixture.DbNames[2]);
+        await assertSequenceExists(Fixture.ConnectionStrings[Fixture.DbNames[2]],
             expected: "mt_events_sequence_foxtrot");
     }
 
@@ -345,7 +321,7 @@ public class sharded_tenancy_per_tenant_events : IAsyncLifetime
                 x.ConnectionString = ConnectionSource.ConnectionString;
                 x.SchemaName = "sharded";
                 x.PartitionSchemaName = "tenants";
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                foreach (var (dbName, connStr) in Fixture.ConnectionStrings)
                 {
                     x.AddDatabase(dbName, connStr);
                 }


### PR DESCRIPTION
Continuation of the test-harness standardization program: the 14 uniform classes on the `sharded-tenant-partitioned` collection re-declared the same per-test scrub (drop master `sharded` schema → per shard: drop `tenants` + wipe `mt_*` from public) and store-disposal bookkeeping. They now inherit `Sharded/ShardedPartitionedContext`. **Net −351 lines.**

Design notes:
- `BuildShardedStore(configure)` provides the standard three-shard wiring + common partitioned-event config (`AutoCreate` deliberately left per-file — files split between `All` and the default). Only 3 files matched it exactly.
- The other 11 keep their `DocumentStore.For` wiring **verbatim** (most omit `UseSmallestDatabaseAssignment`; two add doc-level partitioning; one has a config hook inside the sharding block) and are just wrapped in `TrackStore` — no store configuration changed, only lifecycle absorbed.
- `Bug_4944` keeps its extra non-Marten `foreign_app`/`other_app_ledger` cleanup via an `InitializeAsync` override on top of the base scrub.
- Note: setting `AppendMode = QuickWithServerTimestamps` in the builder is behavior-neutral for files that omitted the line — it's the V9 default (`EventGraph.cs:99`), which defuses the classification concern about the 4 files without it.

**Left alone:** `Bug_4863_4855` (own collection + 2-shard fixture + own schemas), `sharded_progress_reading_4797` (drops a different schema set, skips the public-schema wipe), `multi_node_hotcold_sharded_partitioned_events` + `dynamic_tenant_lifecycle_on_shard_during_daemon` (IHost-based — candidates for `HostedStoreContext` follow-up).

Verification: TPE suite net9.0 **238 passed / 0 failed / 2 pre-existing skips** (includes the mid-test store-dispose case in `Bug_4942`); net10.0 compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U99pVx6kXwiGmaBUGLv7jB