### PR TITLE
Migrate DaemonTests inline-host tests onto HostedStoreContext

### DIFF
--- a/src/DaemonTests.ManualOnly/Coordination/blue_green_projection_deployments.cs
+++ b/src/DaemonTests.ManualOnly/Coordination/blue_green_projection_deployments.cs
@@ -19,7 +19,7 @@ using IProjectionCoordinator = Marten.Events.Daemon.Coordination.IProjectionCoor
 namespace DaemonTests.ManualOnly.Coordination;
 
 [Collection("OneOffs")]
-public class blue_green_projection_deployments
+public class blue_green_projection_deployments: HostedStoreContext
 {
     [Fact]
     public void shard_name_uses_non_1_as_suffix_in_shard_name_identifier()
@@ -63,14 +63,14 @@ public class blue_green_projection_deployments
         {
             opts.Connection(ConnectionSource.ConnectionString);
             opts.Projections.Add<BlueProjection>(ProjectionLifecycle.Async);
-            opts.DatabaseSchemaName = "bluegreen";
+            opts.DatabaseSchemaName = SchemaName;
         });
 
         await using var greenStore = DocumentStore.For(opts =>
         {
             opts.Connection(ConnectionSource.ConnectionString);
             opts.Projections.Add<GreenProjection>(ProjectionLifecycle.Async);
-            opts.DatabaseSchemaName = "bluegreen";
+            opts.DatabaseSchemaName = SchemaName;
         });
 
         using var blueDaemon = await blueStore.BuildProjectionDaemonAsync();
@@ -125,29 +125,15 @@ public class blue_green_projection_deployments
     [Fact]
     public async Task test_through_host()
     {
-        using var blueHost = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.Projections.Add<BlueProjection>(ProjectionLifecycle.Async);
-                    opts.DatabaseSchemaName = "bluegreen";
-                }).AddAsyncDaemon(DaemonMode.HotCold);
-            }).StartAsync(TestContext.Current.CancellationToken);
+        var blueHost = await StartHostAsync(
+            opts => opts.Projections.Add<BlueProjection>(ProjectionLifecycle.Async),
+            DaemonMode.HotCold);
 
         var blueStore = blueHost.Services.GetRequiredService<IDocumentStore>();
 
-        using var greenHost = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.Projections.Add<GreenProjection>(ProjectionLifecycle.Async);
-                    opts.DatabaseSchemaName = "bluegreen";
-                }).AddAsyncDaemon(DaemonMode.HotCold);
-            }).StartAsync(TestContext.Current.CancellationToken);
+        var greenHost = await StartHostAsync(
+            opts => opts.Projections.Add<GreenProjection>(ProjectionLifecycle.Async),
+            DaemonMode.HotCold);
 
         var greenStore = greenHost.Services.GetRequiredService<IDocumentStore>();
 
@@ -198,7 +184,7 @@ public class blue_green_projection_deployments
     }
 }
 
-public class BlueProjection: SingleStreamProjection<EventSourcingTests.Aggregation.MyAggregate, Guid>
+public partial class BlueProjection: SingleStreamProjection<EventSourcingTests.Aggregation.MyAggregate, Guid>
 {
     public BlueProjection()
     {
@@ -226,7 +212,7 @@ public class BlueProjection: SingleStreamProjection<EventSourcingTests.Aggregati
     }
 }
 
-public class GreenProjection: SingleStreamProjection<EventSourcingTests.Aggregation.MyAggregate, Guid>
+public partial class GreenProjection: SingleStreamProjection<EventSourcingTests.Aggregation.MyAggregate, Guid>
 {
     public GreenProjection()
     {

--- a/src/DaemonTests/Bugs/Bug_2073_tenancy_problems.cs
+++ b/src/DaemonTests/Bugs/Bug_2073_tenancy_problems.cs
@@ -20,26 +20,13 @@ using Xunit;
 
 namespace DaemonTests.Bugs;
 
-public class Bug_2073_tenancy_problems
+public class Bug_2073_tenancy_problems: HostedStoreContext
 {
     [Fact]
     public async Task do_not_throw_tenancy_errors()
     {
-        var builder = new HostBuilder();
-        builder.ConfigureServices(services =>
-        {
-            services.AddLogging(logging =>
+        var host = await StartHostAsync(options =>
             {
-                logging.AddConsole();
-                logging.SetMinimumLevel(LogLevel.Debug);
-            });
-
-            services.AddMarten(options =>
-            {
-                options.Connection(ConnectionSource.ConnectionString);
-                options.DisableNpgsqlLogging = true;
-                options.DatabaseSchemaName = "bug2073";
-
                 // Multi tenancy
                 options.Policies.AllDocumentsAreMultiTenanted();
                 options.Advanced.DefaultTenantUsageEnabled = false;
@@ -49,10 +36,12 @@ public class Bug_2073_tenancy_problems
 
                 // Add projections
                 options.Projections.Add<DocumentProjection>(ProjectionLifecycle.Async);
-            });
-        });
-
-        using var host = await builder.StartAsync(TestContext.Current.CancellationToken);
+            },
+            configureServices: services => services.AddLogging(logging =>
+            {
+                logging.AddConsole();
+                logging.SetMinimumLevel(LogLevel.Debug);
+            }));
 
         var store = host.Services.GetRequiredService<IDocumentStore>();
         await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);

--- a/src/DaemonTests/Bugs/Bug_3059_double_application.cs
+++ b/src/DaemonTests/Bugs/Bug_3059_double_application.cs
@@ -21,7 +21,7 @@ using IProjectionCoordinator = Marten.Events.Daemon.Coordination.IProjectionCoor
 
 namespace DaemonTests.Bugs;
 
-public class Bug_3059_double_application
+public class Bug_3059_double_application: HostedStoreContext
 {
     [Fact]
     public async Task work_correctly()
@@ -29,24 +29,16 @@ public class Bug_3059_double_application
         using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
         {
             await conn.OpenAsync(TestContext.Current.CancellationToken);
-            await conn.DropSchemaAsync("bug3059", TestContext.Current.CancellationToken);
+            await conn.DropSchemaAsync(SchemaName, TestContext.Current.CancellationToken);
             await conn.CloseAsync();
         }
 
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
+        var host = await StartHostAsync(opts =>
             {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DisableNpgsqlLogging = true;
-                    opts.DatabaseSchemaName = "bug3059";
-
-                    opts.Projections.LiveStreamAggregation<Incident>();
-                    opts.Projections.Snapshot<IncidentDetailsSnapshotAsyncProjection>(SnapshotLifecycle.Async);
-                })
-                .AddAsyncDaemon(DaemonMode.Solo);
-            }).StartAsync(TestContext.Current.CancellationToken);
+                opts.Projections.LiveStreamAggregation<Incident>();
+                opts.Projections.Snapshot<IncidentDetailsSnapshotAsyncProjection>(SnapshotLifecycle.Async);
+            },
+            DaemonMode.Solo);
 
         var store = host.Services.GetRequiredService<IDocumentStore>();
 

--- a/src/DaemonTests/Composites/Feature_4284_composite_projection_with_services.cs
+++ b/src/DaemonTests/Composites/Feature_4284_composite_projection_with_services.cs
@@ -15,29 +15,21 @@ using Xunit;
 
 namespace DaemonTests.Composites;
 
-public class Feature_4284_composite_projection_with_services
+public class Feature_4284_composite_projection_with_services: HostedStoreContext
 {
     [Fact]
     public async Task can_use_scoped_services_in_projection_registered_under_composite()
     {
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
+        var host = await StartHostAsync(opts =>
             {
-                services.AddScoped<ICompositePriceLookup, CompositePriceLookup>();
-
-                services.AddMarten(opts =>
-                    {
-                        opts.Connection(ConnectionSource.ConnectionString);
-                        opts.DatabaseSchemaName = "feature_4284_net" + Environment.Version.Major;
-                        opts.Projections.CompositeProjectionFor("Feature4284Products", projection =>
-                        {
-                            projection.AddProjectionWithServices<CompositeProductProjection>(ServiceLifetime.Scoped);
-                            projection.AddProjectionWithServices<CompositeProductMetricProjection>(ServiceLifetime.Scoped);
-                        });
-                    })
-                    .ApplyAllDatabaseChangesOnStartup();
-            })
-            .StartAsync(TestContext.Current.CancellationToken);
+                opts.Projections.CompositeProjectionFor("Feature4284Products", projection =>
+                {
+                    projection.AddProjectionWithServices<CompositeProductProjection>(ServiceLifetime.Scoped);
+                    projection.AddProjectionWithServices<CompositeProductMetricProjection>(ServiceLifetime.Scoped);
+                });
+            },
+            configureServices: services => services.AddScoped<ICompositePriceLookup, CompositePriceLookup>(),
+            configureMarten: marten => marten.ApplyAllDatabaseChangesOnStartup());
 
         var store = host.Services.GetRequiredService<IDocumentStore>();
         await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);

--- a/src/DaemonTests/Internals/pausing_and_resuming_the_daemon.cs
+++ b/src/DaemonTests/Internals/pausing_and_resuming_the_daemon.cs
@@ -12,23 +12,14 @@ using Xunit;
 
 namespace DaemonTests.Internals;
 
-public class pausing_and_resuming_the_daemon
+public class pausing_and_resuming_the_daemon: HostedStoreContext
 {
     [Fact]
     public async Task stop_and_resume_from_the_host_extensions()
     {
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DisableNpgsqlLogging = true;
-                    opts.DatabaseSchemaName = "coordinator";
-
-                    opts.Projections.Add<TestingSupport.TripProjection>(ProjectionLifecycle.Async);
-                }).AddAsyncDaemon(DaemonMode.Solo);
-            }).StartAsync(TestContext.Current.CancellationToken);
+        var host = await StartHostAsync(
+            opts => opts.Projections.Add<TestingSupport.TripProjection>(ProjectionLifecycle.Async),
+            DaemonMode.Solo);
 
         await host.PauseAllDaemonsAsync();
 

--- a/src/DaemonTests/Resiliency/skipping_unknown_event_types_in_continuous_builds.cs
+++ b/src/DaemonTests/Resiliency/skipping_unknown_event_types_in_continuous_builds.cs
@@ -21,36 +21,18 @@ using IProjectionCoordinator = Marten.Events.Daemon.Coordination.IProjectionCoor
 
 namespace DaemonTests.Resiliency;
 
-public class skipping_unknown_event_types_in_continuous_builds : IAsyncLifetime
+public class skipping_unknown_event_types_in_continuous_builds : HostedStoreContext
 {
     private IHost _appender;
     private IHost _processor;
 
-    public async ValueTask InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
-        await SchemaUtils.DropSchema(ConnectionSource.ConnectionString, "missing_events");
+        await SchemaUtils.DropSchema(ConnectionSource.ConnectionString, SchemaName);
 
-        _appender = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DisableNpgsqlLogging = true;
-                    opts.DatabaseSchemaName = "missing_events";
-                    opts.Events.MapEventType<MTAEvent>("TripleAAA");
-                }).ApplyAllDatabaseChangesOnStartup();
-
-            }).StartAsync();
-
-
-
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await _appender.StopAsync();
-        await _processor.StopAsync();
+        _appender = await StartHostAsync(
+            opts => opts.Events.MapEventType<MTAEvent>("TripleAAA"),
+            configureMarten: marten => marten.ApplyAllDatabaseChangesOnStartup());
     }
 
     [Fact]
@@ -68,21 +50,13 @@ public class skipping_unknown_event_types_in_continuous_builds : IAsyncLifetime
 
             // Rig up a bad, unknown event type
             session.QueueSqlCommand(
-                "update missing_events.mt_events set mt_dotnet_type = 'wrong, wrong' where version = 1");
+                $"update {SchemaName}.mt_events set mt_dotnet_type = 'wrong, wrong' where version = 1");
             await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
-        _processor = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DisableNpgsqlLogging = true;
-                    opts.DatabaseSchemaName = "missing_events";
-                    opts.Projections.Add(new WeirdCustomAggregation(), ProjectionLifecycle.Async);
-                }).AddAsyncDaemon(DaemonMode.Solo);
-            }).StartAsync(TestContext.Current.CancellationToken);
+        _processor = await StartHostAsync(
+            opts => opts.Projections.Add(new WeirdCustomAggregation(), ProjectionLifecycle.Async),
+            DaemonMode.Solo);
 
         var daemon = _processor.Services.GetRequiredService<IProjectionCoordinator>().DaemonForMainDatabase();
         await daemon.WaitForShardToBeRunning("Weird:All", 10.Seconds());

--- a/src/DaemonTests/Subscriptions/subscribe_from_present.cs
+++ b/src/DaemonTests/Subscriptions/subscribe_from_present.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace DaemonTests.Subscriptions;
 
 [Collection("subscriptions")]
-public class subscribe_from_present : IAsyncLifetime
+public class subscribe_from_present : HostedStoreContext
 {
     private readonly ITestOutputHelper _output;
     private readonly FakeSubscription theSubscription = new();
@@ -27,36 +27,22 @@ public class subscribe_from_present : IAsyncLifetime
         _output = output;
     }
 
-    public async ValueTask InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
-        await SchemaUtils.DropSchema(ConnectionSource.ConnectionString, "subscriptions_start");
+        await SchemaUtils.DropSchema(ConnectionSource.ConnectionString, SchemaName);
 
-        _host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DatabaseSchemaName = "subscriptions_start";
+        _host = await StartHostAsync(opts =>
+        {
+            opts.DotNetLogger = new TestLogger<FakeSubscription>(_output);
 
-                    opts.DotNetLogger = new TestLogger<FakeSubscription>(_output);
-                    opts.DisableNpgsqlLogging = true;
+            theSubscription.Options.SubscribeFromPresent();
+            opts.Events.Subscribe(theSubscription);
 
-                    theSubscription.Options.SubscribeFromPresent();
-                    opts.Events.Subscribe(theSubscription);
-
-                    opts.Events.TimeProvider = theProvider;
-                });
-            }).StartAsync();
+            opts.Events.TimeProvider = theProvider;
+        });
 
         var store = _host.Services.GetRequiredService<IDocumentStore>();
         await store.Advanced.Clean.DeleteAllEventDataAsync();
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await _host.StopAsync();
-        _host.Dispose();
     }
 
     [Fact]

--- a/src/DaemonTests/Subscriptions/subscriptions_end_to_end.cs
+++ b/src/DaemonTests/Subscriptions/subscriptions_end_to_end.cs
@@ -371,295 +371,6 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
     }
 
     [Fact]
-    public async Task use_from_service_provider_as_singleton()
-    {
-        await rewindState();
-
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DisableNpgsqlLogging = true;
-                    opts.DatabaseSchemaName = "ioc";
-                }).AddAsyncDaemon(DaemonMode.Solo).AddSubscriptionWithServices<SimpleSubscription>(
-                    ServiceLifetime.Singleton,
-                    o => o.Name = "Simple2");
-            }).StartAsync(TestContext.Current.CancellationToken);
-
-        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
-
-
-        store.Options.Projections.AllShards().Select(x => x.Name.Identity)
-            .ShouldContain("Simple2:All");
-
-        var events1 = new object[]
-        {
-            new EventSourcingTests.Aggregation.AEvent(), new EventSourcingTests.Aggregation.AEvent(),
-            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-        var events2 = new object[]
-        {
-            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.AEvent(),
-            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-        var events3 = new object[]
-        {
-            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.AEvent(),
-            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-        var events4 = new object[]
-        {
-            new EventSourcingTests.Aggregation.EEvent(), new EventSourcingTests.Aggregation.BEvent(),
-            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-
-        await using var session = store.LightweightSession();
-
-        session.Events.StartStream(Guid.NewGuid(), events1);
-        session.Events.StartStream(Guid.NewGuid(), events2);
-        session.Events.StartStream(Guid.NewGuid(), events3);
-        session.Events.StartStream(Guid.NewGuid(), events4);
-
-        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
-
-        await store.WaitForNonStaleProjectionDataAsync(60.Seconds());
-
-        SimpleSubscription.EventsEncountered[1].Count.ShouldBeGreaterThanOrEqualTo(16);
-
-        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1), token: TestContext.Current.CancellationToken);
-        progress.ShouldBeGreaterThanOrEqualTo(16);
-
-        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
-    }
-
-    [Fact]
-    public async Task use_from_service_provider_as_singleton_with_martenStore()
-    {
-        await rewindState();
-
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMartenStore<ICustomStore>(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DisableNpgsqlLogging = true;
-                    opts.DatabaseSchemaName = "ioc";
-                }).AddAsyncDaemon(DaemonMode.Solo).AddSubscriptionWithServices<SimpleSubscription>(
-                    ServiceLifetime.Singleton,
-                    o => o.Name = "Simple2");
-            }).StartAsync(TestContext.Current.CancellationToken);
-
-        var store = (DocumentStore)host.Services.GetRequiredService<ICustomStore>();
-
-
-        store.Options.Projections.AllShards().Select(x => x.Name.Identity)
-            .ShouldContain("Simple2:All");
-
-        var events1 = new object[]
-        {
-            new EventSourcingTests.Aggregation.AEvent(), new EventSourcingTests.Aggregation.AEvent(),
-            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-        var events2 = new object[]
-        {
-            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.AEvent(),
-            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-        var events3 = new object[]
-        {
-            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.AEvent(),
-            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-        var events4 = new object[]
-        {
-            new EventSourcingTests.Aggregation.EEvent(), new EventSourcingTests.Aggregation.BEvent(),
-            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-
-        await using var session = store.LightweightSession();
-
-        session.Events.StartStream(Guid.NewGuid(), events1);
-        session.Events.StartStream(Guid.NewGuid(), events2);
-        session.Events.StartStream(Guid.NewGuid(), events3);
-        session.Events.StartStream(Guid.NewGuid(), events4);
-
-        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
-
-        await store.WaitForNonStaleProjectionDataAsync(60.Seconds());
-
-        SimpleSubscription.EventsEncountered[1].Count.ShouldBeGreaterThanOrEqualTo(16);
-
-        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1), token: TestContext.Current.CancellationToken);
-        progress.ShouldBeGreaterThanOrEqualTo(16);
-
-        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
-    }
-
-    private async Task rewindState()
-    {
-        SimpleSubscription.Clear();
-        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
-        await conn.DropSchemaAsync("ioc");
-        await conn.CloseAsync();
-    }
-
-    [Fact]
-    public async Task use_from_service_provider_as_scoped()
-    {
-        await rewindState();
-
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DisableNpgsqlLogging = true;
-                    opts.DatabaseSchemaName = "ioc";
-                }).AddAsyncDaemon(DaemonMode.Solo).AddSubscriptionWithServices<SimpleSubscription>(
-                    ServiceLifetime.Scoped,
-                    o => o.Name = "Simple2");
-            }).StartAsync(TestContext.Current.CancellationToken);
-
-        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
-
-
-        store.Options.Projections.AllShards().Select(x => x.Name.Identity)
-            .ShouldContain("Simple2:All");
-
-        var events1 = new object[]
-        {
-            new EventSourcingTests.Aggregation.AEvent(), new EventSourcingTests.Aggregation.AEvent(),
-            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-        var events2 = new object[]
-        {
-            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.AEvent(),
-            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-        var events3 = new object[]
-        {
-            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.AEvent(),
-            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-        var events4 = new object[]
-        {
-            new EventSourcingTests.Aggregation.EEvent(), new EventSourcingTests.Aggregation.BEvent(),
-            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-
-        await using var session = store.LightweightSession();
-
-        session.Events.StartStream(Guid.NewGuid(), events1);
-        session.Events.StartStream(Guid.NewGuid(), events2);
-        session.Events.StartStream(Guid.NewGuid(), events3);
-        session.Events.StartStream(Guid.NewGuid(), events4);
-
-        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
-
-        await store.WaitForNonStaleProjectionDataAsync(60.Seconds());
-
-        SimpleSubscription.EventsEncountered.Sum(x => x.Count).ShouldBeGreaterThanOrEqualTo(16);
-
-        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1), token: TestContext.Current.CancellationToken);
-        progress.ShouldBeGreaterThanOrEqualTo(16);
-
-        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
-    }
-
-    [Fact]
-    public async Task subscriptions_are_part_of_the_event_store_usage()
-    {
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMartenStore<ICustomStore>(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DisableNpgsqlLogging = true;
-                    opts.DatabaseSchemaName = "ioc";
-                }).AddAsyncDaemon(DaemonMode.Solo).AddSubscriptionWithServices<SimpleSubscription>(
-                    ServiceLifetime.Scoped,
-                    o => o.Name = "Simple2");
-            }).StartAsync(TestContext.Current.CancellationToken);
-
-        var capabilities = host.Services.GetServices<IEventStore>().ToArray();
-        capabilities.Length.ShouldBe(1);
-
-        var usage = await capabilities[0].TryCreateUsage(CancellationToken.None);
-
-        usage.ShouldNotBeNull();
-    }
-
-    [Fact]
-    public async Task use_from_service_provider_as_scoped_with_martenStore()
-    {
-        await rewindState();
-
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddMartenStore<ICustomStore>(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DisableNpgsqlLogging = true;
-                    opts.DatabaseSchemaName = "ioc";
-                }).AddAsyncDaemon(DaemonMode.Solo).AddSubscriptionWithServices<SimpleSubscription>(
-                    ServiceLifetime.Scoped,
-                    o => o.Name = "Simple2");
-            }).StartAsync(TestContext.Current.CancellationToken);
-
-        var store = (DocumentStore)host.Services.GetRequiredService<ICustomStore>();
-
-
-        store.Options.Projections.AllShards().Select(x => x.Name.Identity)
-            .ShouldContain("Simple2:All");
-
-        var events1 = new object[]
-        {
-            new EventSourcingTests.Aggregation.AEvent(), new EventSourcingTests.Aggregation.AEvent(),
-            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-        var events2 = new object[]
-        {
-            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.AEvent(),
-            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-        var events3 = new object[]
-        {
-            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.AEvent(),
-            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-        var events4 = new object[]
-        {
-            new EventSourcingTests.Aggregation.EEvent(), new EventSourcingTests.Aggregation.BEvent(),
-            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.CEvent()
-        };
-
-        await using var session = store.LightweightSession();
-
-        session.Events.StartStream(Guid.NewGuid(), events1);
-        session.Events.StartStream(Guid.NewGuid(), events2);
-        session.Events.StartStream(Guid.NewGuid(), events3);
-        session.Events.StartStream(Guid.NewGuid(), events4);
-
-        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
-
-        await store.WaitForNonStaleProjectionDataAsync(60.Seconds());
-
-        SimpleSubscription.EventsEncountered.Sum(x => x.Count).ShouldBeGreaterThanOrEqualTo(16);
-
-        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1), token: TestContext.Current.CancellationToken);
-        progress.ShouldBeGreaterThanOrEqualTo(16);
-
-        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
-    }
-
-    [Fact]
     public void subscription_wrapper_copies_the_filters_from_subscription_base()
     {
         var services = new ServiceCollection();
@@ -693,6 +404,186 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
         wrapper.Options.MaximumHopperSize.ShouldBe(7777);
         wrapper.Name.ShouldBe("custom-subscription-name");
         wrapper.Version.ShouldBe(7u);
+    }
+}
+
+public class subscription_registrations_through_host: HostedStoreContext
+{
+    private async Task rewindState()
+    {
+        SimpleSubscription.Clear();
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync(SchemaName);
+        await conn.DropSchemaAsync($"{SchemaName}_custom");
+        await conn.CloseAsync();
+    }
+
+    private void addCustomStore(IServiceCollection services, ServiceLifetime subscriptionLifetime)
+    {
+        services.AddMartenStore<ICustomStore>(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DisableNpgsqlLogging = true;
+            opts.DatabaseSchemaName = $"{SchemaName}_custom";
+        }).AddAsyncDaemon(DaemonMode.Solo).AddSubscriptionWithServices<SimpleSubscription>(
+            subscriptionLifetime,
+            o => o.Name = "Simple2");
+    }
+
+    private static async Task publishFourStreams(DocumentStore store)
+    {
+        var events1 = new object[]
+        {
+            new EventSourcingTests.Aggregation.AEvent(), new EventSourcingTests.Aggregation.AEvent(),
+            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent()
+        };
+        var events2 = new object[]
+        {
+            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.AEvent(),
+            new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent()
+        };
+        var events3 = new object[]
+        {
+            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.AEvent(),
+            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.CEvent()
+        };
+        var events4 = new object[]
+        {
+            new EventSourcingTests.Aggregation.EEvent(), new EventSourcingTests.Aggregation.BEvent(),
+            new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.CEvent()
+        };
+
+        await using var session = store.LightweightSession();
+
+        session.Events.StartStream(Guid.NewGuid(), events1);
+        session.Events.StartStream(Guid.NewGuid(), events2);
+        session.Events.StartStream(Guid.NewGuid(), events3);
+        session.Events.StartStream(Guid.NewGuid(), events4);
+
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task use_from_service_provider_as_singleton()
+    {
+        await rewindState();
+
+        var host = await StartHostAsync(_ => { }, DaemonMode.Solo,
+            configureMarten: marten => marten.AddSubscriptionWithServices<SimpleSubscription>(
+                ServiceLifetime.Singleton,
+                o => o.Name = "Simple2"));
+
+        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+
+        store.Options.Projections.AllShards().Select(x => x.Name.Identity)
+            .ShouldContain("Simple2:All");
+
+        await publishFourStreams(store);
+
+        await store.WaitForNonStaleProjectionDataAsync(60.Seconds());
+
+        SimpleSubscription.EventsEncountered[1].Count.ShouldBeGreaterThanOrEqualTo(16);
+
+        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1), token: TestContext.Current.CancellationToken);
+        progress.ShouldBeGreaterThanOrEqualTo(16);
+
+        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task use_from_service_provider_as_singleton_with_martenStore()
+    {
+        await rewindState();
+
+        var host = await StartHostAsync(_ => { },
+            configureServices: services => addCustomStore(services, ServiceLifetime.Singleton));
+
+        var store = (DocumentStore)host.Services.GetRequiredService<ICustomStore>();
+
+        store.Options.Projections.AllShards().Select(x => x.Name.Identity)
+            .ShouldContain("Simple2:All");
+
+        await publishFourStreams(store);
+
+        await store.WaitForNonStaleProjectionDataAsync(60.Seconds());
+
+        SimpleSubscription.EventsEncountered[1].Count.ShouldBeGreaterThanOrEqualTo(16);
+
+        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1), token: TestContext.Current.CancellationToken);
+        progress.ShouldBeGreaterThanOrEqualTo(16);
+
+        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task use_from_service_provider_as_scoped()
+    {
+        await rewindState();
+
+        var host = await StartHostAsync(_ => { }, DaemonMode.Solo,
+            configureMarten: marten => marten.AddSubscriptionWithServices<SimpleSubscription>(
+                ServiceLifetime.Scoped,
+                o => o.Name = "Simple2"));
+
+        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+
+        store.Options.Projections.AllShards().Select(x => x.Name.Identity)
+            .ShouldContain("Simple2:All");
+
+        await publishFourStreams(store);
+
+        await store.WaitForNonStaleProjectionDataAsync(60.Seconds());
+
+        SimpleSubscription.EventsEncountered.Sum(x => x.Count).ShouldBeGreaterThanOrEqualTo(16);
+
+        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1), token: TestContext.Current.CancellationToken);
+        progress.ShouldBeGreaterThanOrEqualTo(16);
+
+        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task use_from_service_provider_as_scoped_with_martenStore()
+    {
+        await rewindState();
+
+        var host = await StartHostAsync(_ => { },
+            configureServices: services => addCustomStore(services, ServiceLifetime.Scoped));
+
+        var store = (DocumentStore)host.Services.GetRequiredService<ICustomStore>();
+
+        store.Options.Projections.AllShards().Select(x => x.Name.Identity)
+            .ShouldContain("Simple2:All");
+
+        await publishFourStreams(store);
+
+        await store.WaitForNonStaleProjectionDataAsync(60.Seconds());
+
+        SimpleSubscription.EventsEncountered.Sum(x => x.Count).ShouldBeGreaterThanOrEqualTo(16);
+
+        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1), token: TestContext.Current.CancellationToken);
+        progress.ShouldBeGreaterThanOrEqualTo(16);
+
+        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task subscriptions_are_part_of_the_event_store_usage()
+    {
+        // Deliberately not through StartHostAsync: this asserts exactly one
+        // IEventStore registration, and the harness's main AddMarten store
+        // would add a second one.
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services => addCustomStore(services, ServiceLifetime.Scoped))
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        var capabilities = host.Services.GetServices<IEventStore>().ToArray();
+        capabilities.Length.ShouldBe(1);
+
+        var usage = await capabilities[0].TryCreateUsage(CancellationToken.None);
+
+        usage.ShouldNotBeNull();
     }
 }
 

--- a/src/EventSourcingTests/event_append_observation.cs
+++ b/src/EventSourcingTests/event_append_observation.cs
@@ -35,12 +35,12 @@ public interface IObservationStore: IDocumentStore;
 /// events to the storage-agnostic <see cref="IEventStoreInstrumentation.AppendObserver"/>, so lifecycle
 /// tooling (CritterWatch) can record runtime-observed "appends" edges. Covers main and ancillary stores.
 /// </summary>
-public class event_append_observation
+public class event_append_observation: HostedStoreContext
 {
     [Fact]
     public async Task observer_receives_the_appended_events_with_metadata()
     {
-        using var host = await startHost("eao_basic", advancedTracking: true);
+        var host = await startHost("basic", advancedTracking: true);
         var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
 
         var observed = new List<IReadOnlyList<IEvent>>();
@@ -64,7 +64,7 @@ public class event_append_observation
     [Fact]
     public async Task no_listener_and_no_observation_when_advanced_tracking_is_off()
     {
-        using var host = await startHost("eao_off", advancedTracking: false);
+        var host = await startHost("off", advancedTracking: false);
         var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
 
         store.Options.Listeners.OfType<AppendEventObservationListener>().ShouldBeEmpty();
@@ -82,7 +82,7 @@ public class event_append_observation
     [Fact]
     public async Task observer_carries_the_stream_key_for_string_identified_streams()
     {
-        using var host = await startHost("eao_string", advancedTracking: true,
+        var host = await startHost("string", advancedTracking: true,
             opts => opts.Events.StreamIdentity = StreamIdentity.AsString);
         var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
 
@@ -99,7 +99,7 @@ public class event_append_observation
     [Fact]
     public async Task observer_carries_the_tenant_id_when_multi_tenanted()
     {
-        using var host = await startHost("eao_tenant", advancedTracking: true,
+        var host = await startHost("tenant", advancedTracking: true,
             opts => opts.Events.TenancyStyle = TenancyStyle.Conjoined);
         var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
 
@@ -116,7 +116,7 @@ public class event_append_observation
     [Fact]
     public async Task observer_does_not_fire_when_no_events_are_appended()
     {
-        using var host = await startHost("eao_doconly", advancedTracking: true);
+        var host = await startHost("doconly", advancedTracking: true);
         var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
 
         var fired = false;
@@ -132,7 +132,7 @@ public class event_append_observation
     [Fact]
     public async Task a_throwing_observer_does_not_break_save_changes()
     {
-        using var host = await startHost("eao_throw", advancedTracking: true);
+        var host = await startHost("throw", advancedTracking: true);
         var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
 
         store.Options.EventGraph.AppendObserver = _ => throw new InvalidOperationException("boom");
@@ -153,14 +153,15 @@ public class event_append_observation
     [Fact]
     public async Task observer_set_through_the_di_instrumentation_bridge_fires()
     {
-        await dropSchema("eao_bridge");
+        var schema = $"{SchemaName}_bridge";
+        await dropSchema(schema);
 
         var services = new ServiceCollection();
         services.AddJasperFx(o => o.EnableAdvancedTracking = true);
         services.AddMarten(opts =>
         {
             opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "eao_bridge";
+            opts.DatabaseSchemaName = schema;
         });
 
         await using var provider = services.BuildServiceProvider();
@@ -185,26 +186,21 @@ public class event_append_observation
     [Fact]
     public async Task listener_is_applied_to_ancillary_stores()
     {
-        await dropSchema("eao_anc_main");
-        await dropSchema("eao_anc_first");
+        await dropSchema(SchemaName);
+        await dropSchema($"{SchemaName}_first");
 
-        using var host = await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
+        var host = await StartHostAsync(
+            _ => { },
+            configureServices: services =>
             {
                 services.AddJasperFx(o => o.EnableAdvancedTracking = true);
-
-                services.AddMarten(m =>
-                {
-                    m.Connection(ConnectionSource.ConnectionString);
-                    m.DatabaseSchemaName = "eao_anc_main";
-                });
 
                 services.AddMartenStore<IObservationStore>(opts =>
                 {
                     opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DatabaseSchemaName = "eao_anc_first";
+                    opts.DatabaseSchemaName = $"{SchemaName}_first";
                 });
-            }).StartAsync();
+            });
 
         var ancillary = host.Services.GetRequiredService<IObservationStore>().As<DocumentStore>();
         ancillary.Options.Listeners.OfType<AppendEventObservationListener>().ShouldNotBeEmpty();
@@ -221,26 +217,24 @@ public class event_append_observation
         observed.Single().ShouldAllBe(e => e.StreamId == streamId);
     }
 
-    private static async Task<IHost> startHost(string schema, bool advancedTracking,
+    private async Task<IHost> startHost(string suffix, bool advancedTracking,
         Action<StoreOptions>? configure = null)
     {
+        var schema = $"{SchemaName}_{suffix}";
         await dropSchema(schema);
 
-        return await Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
+        return await StartHostAsync(opts =>
+            {
+                opts.DatabaseSchemaName = schema;
+                configure?.Invoke(opts);
+            },
+            configureServices: services =>
             {
                 if (advancedTracking)
                 {
                     services.AddJasperFx(o => o.EnableAdvancedTracking = true);
                 }
-
-                services.AddMarten(opts =>
-                {
-                    opts.Connection(ConnectionSource.ConnectionString);
-                    opts.DatabaseSchemaName = schema;
-                    configure?.Invoke(opts);
-                });
-            }).StartAsync();
+            });
     }
 
     private static async Task dropSchema(string schema)


### PR DESCRIPTION
Continues the phase-2 test-harness standardization (#5098–#5103). The DaemonTests side of the inline `Host.CreateDefaultBuilder` + `AddMarten` pattern moves onto the shared `HostedStoreContext` harness introduced in #5102 — per-class schema names instead of nine hard-coded literals (`bug2073`, `bug3059`, `coordinator`, `missing_events`, `subscriptions_start`, `ioc`, `bluegreen`, `feature_4284_net*`, `eao_*`), and host lifetime owned by the harness (hosts stopped and disposed newest-first at class teardown). Net −205 lines.

## Migrated

- `Bugs/Bug_2073_tenancy_problems`
- `Bugs/Bug_3059_double_application`
- `Composites/Feature_4284_composite_projection_with_services`
- `Internals/pausing_and_resuming_the_daemon`
- `Resiliency/skipping_unknown_event_types_in_continuous_builds` — also fixes the NRE in `DisposeAsync` when a test failed before `_processor` was assigned
- `Subscriptions/subscribe_from_present`
- `Subscriptions/subscriptions_end_to_end` — the five host-based tests split out of the `OneOffConfigurationsContext` class into a new `subscription_registrations_through_host: HostedStoreContext` class. `subscriptions_are_part_of_the_event_store_usage` keeps a hand-rolled host on purpose: it asserts exactly one `IEventStore` registration, and the harness's main `AddMarten` store would add a second.
- `EventSourcingTests/event_append_observation` — per-test schema suffixes now derive from `SchemaName`
- `DaemonTests.ManualOnly/Coordination/blue_green_projection_deployments`

## Drive-by fix: blue/green tests were broken on master

`BlueProjection`/`GreenProjection` use conventional `Apply` methods but were not declared `partial`, so 4 of the 5 blue/green tests failed on master with *"No source-generated dispatcher found"* (ManualOnly isn't in CI, so nothing caught it). Both are `partial` now and all 5 pass.

## Deliberately untouched

- `Internals/service_registrations` — `Build()`-only Lamar container assertions, no started host
- `Bugs/Bug_3080`, `MultiTenancy/dynamic_spin_up_of_dynamic_tenants`, `MultiTenancy/multi_tenancy_by_database` — real multi-database provisioning that doesn't fit the single-connection harness
- `Examples/*`, `Projections/testing_projections.cs` — doc snippets where the inline host is the sample
- `Daemon/postgres_listen_notify_wakeup_tests.cs` — #4961 work in flight
- The four TenantPartitionedEventsTests multi-node host files — follow-up

## Verification

net9.0 local: full DaemonTests suite 260/260, `event_append_observation` 8/8, ManualOnly `blue_green_projection_deployments` 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U99pVx6kXwiGmaBUGLv7jB