### PR TITLE
Migrate ValueTypeTests hand-rolled stores onto OneOffConfigurationsContext

### DIFF
--- a/src/ValueTypeTests/StrongTypedId/check_exists_with_strong_typed_ids.cs
+++ b/src/ValueTypeTests/StrongTypedId/check_exists_with_strong_typed_ids.cs
@@ -7,36 +7,8 @@ using Shouldly;
 
 namespace ValueTypeTests.StrongTypedId;
 
-public class check_exists_with_strong_typed_ids: IDisposable, IAsyncDisposable
+public class check_exists_with_strong_typed_ids: OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-    private IDocumentSession theSession;
-
-    public check_exists_with_strong_typed_ids()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed_exists";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public void Dispose()
-    {
-        theStore?.Dispose();
-        theSession?.Dispose();
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (theStore != null)
-        {
-            await theStore.DisposeAsync();
-        }
-    }
-
     [Fact]
     public async Task check_exists_with_guid_strong_typed_id_hit()
     {

--- a/src/ValueTypeTests/StrongTypedId/duplicated_value_type_field_operations.cs
+++ b/src/ValueTypeTests/StrongTypedId/duplicated_value_type_field_operations.cs
@@ -9,37 +9,15 @@ using StronglyTypedIds;
 
 namespace ValueTypeTests.StrongTypedId;
 
-public class duplicated_value_type_field_operations : IDisposable, IAsyncDisposable
+public class duplicated_value_type_field_operations : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-    private IDocumentSession theSession;
-
     public duplicated_value_type_field_operations()
     {
-        theStore = DocumentStore.For(opts =>
+        StoreOptions(opts =>
         {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "duplicated_value_type_field1";
-
             opts.RegisterValueType<DuplicateValueType>();
             opts.Schema.For<DuplicateValueTypeDoc>().Duplicate(x => x.DuplicateValueType);
         });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public void Dispose()
-    {
-        theStore?.Dispose();
-        theSession?.Dispose();
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (theStore != null)
-        {
-            await theStore.DisposeAsync();
-        }
     }
 
     [Fact]

--- a/src/ValueTypeTests/StrongTypedId/fsharp_discriminated_union_document_operations.cs
+++ b/src/ValueTypeTests/StrongTypedId/fsharp_discriminated_union_document_operations.cs
@@ -15,21 +15,10 @@ using Weasel.Core;
 
 namespace ValueTypeTests.StrongTypedId;
 
-public class fsharp_discriminated_union_document_operations: IDisposable, IAsyncDisposable
+public class fsharp_discriminated_union_document_operations: OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-    private readonly IDocumentSession theSession;
-
     public fsharp_discriminated_union_document_operations()
     {
-        var schemaName = "strong_typed_fsharp";
-        var options = new StoreOptions();
-        options.Connection(ConnectionSource.ConnectionString);
-
-        options.AutoCreateSchemaObjects = AutoCreate.All;
-        options.NameDataLength = 100;
-        options.DatabaseSchemaName = schemaName;
-
         //For docs on these options see: https://github.com/Tarmil/FSharp.SystemTextJson/blob/master/docs/Customizing.md
         var jsonFSharpOptions =
             JsonFSharpOptions
@@ -39,34 +28,13 @@ public class fsharp_discriminated_union_document_operations: IDisposable, IAsync
                 .WithUnionUnwrapSingleCaseUnions()
                 .WithSkippableOptionFields();
 
-        options.UseSystemTextJsonForSerialization(configure: (jsonOptions) =>
+        StoreOptions(options =>
         {
-            jsonFSharpOptions.AddToJsonSerializerOptions(jsonOptions);
+            options.UseSystemTextJsonForSerialization(configure: (jsonOptions) =>
+            {
+                jsonFSharpOptions.AddToJsonSerializerOptions(jsonOptions);
+            });
         });
-
-        // clean-up
-        using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        conn.Open();
-        conn.CreateCommand($"drop schema if exists {schemaName} cascade")
-            .ExecuteNonQuery();
-
-
-        theStore = new DocumentStore(options);
-        theSession = theStore.LightweightSession();
-    }
-
-    public void Dispose()
-    {
-        theStore?.Dispose();
-        theSession?.Dispose();
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (theStore != null)
-        {
-            await theStore.DisposeAsync();
-        }
     }
 
     [Fact]

--- a/src/ValueTypeTests/StrongTypedId/guid_based_document_operations.cs
+++ b/src/ValueTypeTests/StrongTypedId/guid_based_document_operations.cs
@@ -11,36 +11,8 @@ using Vogen;
 
 namespace ValueTypeTests.StrongTypedId;
 
-public class guid_id_document_operations : IDisposable, IAsyncDisposable
+public class guid_id_document_operations : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-
-    public guid_id_document_operations()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed1";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public void Dispose()
-    {
-        theStore?.Dispose();
-        theSession?.Dispose();
-    }
-
-    private IDocumentSession theSession;
-
-    public async ValueTask DisposeAsync()
-    {
-        if (theStore != null)
-        {
-            await theStore.DisposeAsync();
-        }
-    }
 
     [Fact]
     public void store_document_will_assign_the_identity()
@@ -293,36 +265,8 @@ public class Invoice3
     public string Name { get; set; }
 }
 
-public class guid_id_document_operations_with_non_nullable_identifier : IDisposable, IAsyncDisposable
+public class guid_id_document_operations_with_non_nullable_identifier : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-
-    public guid_id_document_operations_with_non_nullable_identifier()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed21";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public void Dispose()
-    {
-        theStore?.Dispose();
-        theSession?.Dispose();
-    }
-
-    private IDocumentSession theSession;
-
-    public async ValueTask DisposeAsync()
-    {
-        if (theStore != null)
-        {
-            await theStore.DisposeAsync();
-        }
-    }
 
     [Fact]
     public void store_document_will_assign_the_identity()

--- a/src/ValueTypeTests/StrongTypedId/int_based_document_operations.cs
+++ b/src/ValueTypeTests/StrongTypedId/int_based_document_operations.cs
@@ -10,33 +10,8 @@ using Vogen;
 
 namespace ValueTypeTests.StrongTypedId;
 
-public class int_based_document_operations : IAsyncLifetime
+public class int_based_document_operations : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-
-    public int_based_document_operations()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed2";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Order2));
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await theStore.DisposeAsync();
-        theSession?.Dispose();
-    }
-
-    private IDocumentSession theSession;
 
     [Fact]
     public void store_document_will_assign_the_identity()
@@ -278,33 +253,8 @@ public class Order3
     public string Name { get; set; }
 }
 
-public class int_based_document_operations_with_non_nullable_id : IAsyncLifetime
+public class int_based_document_operations_with_non_nullable_id : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-
-    public int_based_document_operations_with_non_nullable_id()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed20";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Order3));
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await theStore.DisposeAsync();
-        theSession?.Dispose();
-    }
-
-    private IDocumentSession theSession;
 
     [Fact]
     public void store_document_will_assign_the_identity()

--- a/src/ValueTypeTests/StrongTypedId/long_based_document_operations.cs
+++ b/src/ValueTypeTests/StrongTypedId/long_based_document_operations.cs
@@ -10,33 +10,8 @@ using Vogen;
 
 namespace ValueTypeTests.StrongTypedId;
 
-public class long_based_document_operations : IAsyncLifetime
+public class long_based_document_operations : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-
-    public long_based_document_operations()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed3";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Issue2));
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await theStore.DisposeAsync();
-        theSession?.Dispose();
-    }
-
-    private IDocumentSession theSession;
 
     [Fact]
     public void store_document_will_assign_the_identity()
@@ -281,33 +256,8 @@ public class Issue3
     public string Name { get; set; }
 }
 
-public class long_based_document_operations_with_non_nullable_id : IAsyncLifetime
+public class long_based_document_operations_with_non_nullable_id : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-
-    public long_based_document_operations_with_non_nullable_id()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed22";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Issue3));
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await theStore.DisposeAsync();
-        theSession?.Dispose();
-    }
-
-    private IDocumentSession theSession;
 
     [Fact]
     public void store_document_will_assign_the_identity()

--- a/src/ValueTypeTests/StrongTypedId/string_id_document_operations.cs
+++ b/src/ValueTypeTests/StrongTypedId/string_id_document_operations.cs
@@ -11,36 +11,8 @@ using Vogen;
 
 namespace ValueTypeTests.StrongTypedId;
 
-public class string_id_document_operations : IDisposable, IAsyncDisposable
+public class string_id_document_operations : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-
-    public string_id_document_operations()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed4";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public void Dispose()
-    {
-        theStore?.Dispose();
-        theSession?.Dispose();
-    }
-
-    private IDocumentSession theSession;
-
-    public async ValueTask DisposeAsync()
-    {
-        if (theStore != null)
-        {
-            await theStore.DisposeAsync();
-        }
-    }
 
     [Fact]
     public async Task store_a_document_smoke_test()
@@ -253,36 +225,8 @@ public class Team3
     public string Name { get; set; }
 }
 
-public class string_id_document_operations_with_non_nullable_id : IDisposable, IAsyncDisposable
+public class string_id_document_operations_with_non_nullable_id : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-
-    public string_id_document_operations_with_non_nullable_id()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed23";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public void Dispose()
-    {
-        theStore?.Dispose();
-        theSession?.Dispose();
-    }
-
-    private IDocumentSession theSession;
-
-    public async ValueTask DisposeAsync()
-    {
-        if (theStore != null)
-        {
-            await theStore.DisposeAsync();
-        }
-    }
 
     [Fact]
     public async Task store_a_document_smoke_test()

--- a/src/ValueTypeTests/VogenIds/duplicated_value_type_field_operations.cs
+++ b/src/ValueTypeTests/VogenIds/duplicated_value_type_field_operations.cs
@@ -9,37 +9,15 @@ using Vogen;
 
 namespace ValueTypeTests.VogenIds;
 
-public class duplicated_value_type_field_operations : IDisposable, IAsyncDisposable
+public class duplicated_value_type_field_operations : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-    private IDocumentSession theSession;
-
     public duplicated_value_type_field_operations()
     {
-        theStore = DocumentStore.For(opts =>
+        StoreOptions(opts =>
         {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "duplicated_value_type_field2";
-
             opts.RegisterValueType<DuplicateValueType>();
             opts.Schema.For<DuplicateValueTypeDoc>().Duplicate(x => x.DuplicateValueType);
         });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public void Dispose()
-    {
-        theStore?.Dispose();
-        theSession?.Dispose();
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (theStore != null)
-        {
-            await theStore.DisposeAsync();
-        }
     }
 
     [Fact]

--- a/src/ValueTypeTests/VogenIds/guid_based_document_operations.cs
+++ b/src/ValueTypeTests/VogenIds/guid_based_document_operations.cs
@@ -11,36 +11,8 @@ using Vogen;
 
 namespace ValueTypeTests.VogenIds;
 
-public class guid_id_document_operations : IDisposable, IAsyncDisposable
+public class guid_id_document_operations : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-
-    public guid_id_document_operations()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed5";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public void Dispose()
-    {
-        theStore?.Dispose();
-        theSession?.Dispose();
-    }
-
-    private IDocumentSession theSession;
-
-    public async ValueTask DisposeAsync()
-    {
-        if (theStore != null)
-        {
-            await theStore.DisposeAsync();
-        }
-    }
 
     [Fact]
     public void store_document_will_assign_the_identity()

--- a/src/ValueTypeTests/VogenIds/int_based_document_operations.cs
+++ b/src/ValueTypeTests/VogenIds/int_based_document_operations.cs
@@ -9,33 +9,8 @@ using Vogen;
 
 namespace ValueTypeTests.VogenIds;
 
-public class int_based_document_operations : IAsyncLifetime
+public class int_based_document_operations : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-
-    public int_based_document_operations()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed6";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Order));
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await theStore.DisposeAsync();
-        theSession?.Dispose();
-    }
-
-    private IDocumentSession theSession;
 
     [Fact]
     public void store_document_will_assign_the_identity()

--- a/src/ValueTypeTests/VogenIds/long_based_document_operations.cs
+++ b/src/ValueTypeTests/VogenIds/long_based_document_operations.cs
@@ -9,33 +9,8 @@ using Vogen;
 
 namespace ValueTypeTests.VogenIds;
 
-public class long_based_document_operations : IAsyncLifetime
+public class long_based_document_operations : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-
-    public long_based_document_operations()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed7";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Issue));
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await theStore.DisposeAsync();
-        theSession?.Dispose();
-    }
-
-    private IDocumentSession theSession;
 
     [Fact]
     public void store_document_will_assign_the_identity()

--- a/src/ValueTypeTests/VogenIds/string_id_document_operations.cs
+++ b/src/ValueTypeTests/VogenIds/string_id_document_operations.cs
@@ -10,36 +10,8 @@ using Vogen;
 
 namespace ValueTypeTests.VogenIds;
 
-public class string_id_document_operations : IDisposable, IAsyncDisposable
+public class string_id_document_operations : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-
-    public string_id_document_operations()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed8";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public void Dispose()
-    {
-        theStore?.Dispose();
-        theSession?.Dispose();
-    }
-
-    private IDocumentSession theSession;
-
-    public async ValueTask DisposeAsync()
-    {
-        if (theStore != null)
-        {
-            await theStore.DisposeAsync();
-        }
-    }
 
     [Fact]
     public async Task store_a_document_smoke_test()

--- a/src/ValueTypeTests/include_usage.cs
+++ b/src/ValueTypeTests/include_usage.cs
@@ -10,30 +10,8 @@ using Vogen;
 
 namespace ValueTypeTests;
 
-public class include_usage : IAsyncDisposable
+public class include_usage : OneOffConfigurationsContext
 {
-    private readonly DocumentStore theStore;
-    private IDocumentSession theSession;
-
-    public include_usage()
-    {
-        theStore = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "strong_typed24";
-        });
-
-        theSession = theStore.LightweightSession();
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (theStore != null)
-        {
-            await theStore.DisposeAsync();
-        }
-    }
-
     #region sample_include_a_single_reference_with_strong_identifier
 
     [Fact]


### PR DESCRIPTION
Phase-2 test-harness standardization, first non-event-sourcing hotspot (companion to #5104). Net **−444 lines**.

16 test classes across 13 ValueTypeTests files each hand-rolled a `DocumentStore` in the constructor, with **three inconsistent disposal variants** — `IDisposable`+`IAsyncDisposable` (the async path leaked the session), `IAsyncDisposable` alone, and `IAsyncLifetime` with per-test `DeleteDocumentsByTypeAsync` cleanup — and hand-numbered schema literals (`strong_typed1..24`, `duplicated_value_type_field1/2`, `strong_typed_exists`, `strong_typed_fsharp`).

All 16 classes now derive from `OneOffConfigurationsContext`:

- per-class schema names replace the hand-numbered literals
- the schema is dropped per test instance, so the `IAsyncLifetime` variants' per-test document cleanup is retired (each test now starts pristine)
- disposal is owned by the base — no more session leaks on the async path
- the three classes with real configuration (`duplicated_value_type_field_operations` ×2, the F# discriminated-union STJ setup) keep a constructor calling `StoreOptions(...)`; the other 13 need no constructor at all

Untouched: `registration.cs` / `applicability_of_identity_types.cs` (pure unit tests, no store), the three classes already on `OneOffConfigurationsContext`, and the two `BugIntegrationContext` bug tests.

## Verification

net9.0 local: full ValueTypeTests suite **340/340** (20s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U99pVx6kXwiGmaBUGLv7jB