### PR TITLE
Derive the StreamOne ETag from the numeric revision for revisioned documents

### DIFF
--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -466,9 +466,29 @@ still current:
   document), formatted as a quoted GUID, e.g. `"3f2504e0-4f89-11d3-9a0c-0305e82c3301"`.
   The `mt_version` value is read **inline with the document in the same single
   database round trip** (piggy-backed onto the streaming query), so enabling the
-  ETag adds no extra query. Document types whose version metadata is disabled (no
-  `mt_version` column) simply emit no ETag. Because the document is streamed in that
-  one round trip, a `304` on `StreamOne<T>` saves response bandwidth but not the read.
+  ETag adds no extra query. Because the document is streamed in that one round
+  trip, a `304` on `StreamOne<T>` saves response bandwidth but not the read.
+- For documents using [numeric revisioning](/documents/concurrency) instead of the
+  Guid version — `IRevisioned`/`ILongVersioned` types, and every aggregate-projection
+  target (snapshots, single- and multi-stream projections), since Marten forces
+  numeric revisions on those — the `StreamOne<T>` ETag is the numeric `mt_version`,
+  formatted as a quoted integer, e.g. `"3"`. Documents written by an
+  `EventProjection` are not forced into numeric revisions and emit no ETag unless
+  they opt into a versioning flavor themselves. For a `SingleStreamProjection`
+  target the revision is the source stream's version, so serving the read model
+  through `StreamOne<T>` produces the same ETag that `StreamAggregate<T>` would
+  serve for the stream itself; for an Inline-lifecycle projection, clients can
+  switch between the two read styles without invalidating their caches (an
+  Async-lifecycle document can lag the stream head, so the two styles may briefly
+  disagree). Multi-stream and `ILongVersioned` targets emit their own monotonic
+  per-document revision, which is a valid ETag but not a stream version. Note that
+  revision-derived ETags are deterministic: a projection-logic change plus rebuild
+  that does not advance the stream does not invalidate previously cached responses
+  (bumping `ProjectionVersion` does not reset the revision either), matching the
+  `StreamAggregate<T>` semantics. The compiled-query overload
+  (`StreamOne<TDoc, TOut>`) does not participate in ETag/`304` handling. Document
+  types with neither version flavor enabled (no `mt_version` column) simply emit
+  no ETag.
 - For `StreamAggregate<T>`, the ETag is derived from the event stream's
   version (a `long`), formatted as a quoted integer, e.g. `"42"`. The version
   is looked up before the aggregate is folded, so a cache hit (`304`) skips

--- a/src/EventSourcingTests/Bugs/optimistic_concurrency_on_projection_target_fails_fast.cs
+++ b/src/EventSourcingTests/Bugs/optimistic_concurrency_on_projection_target_fails_fast.cs
@@ -1,0 +1,52 @@
+using EventSourcingTests.Aggregation;
+using JasperFx.Events.Projections;
+using Marten.Exceptions;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+/// <summary>
+/// Companion guard to Bug_2978: the Guid version column and the numeric revision column are
+/// two flavors of the same physical <c>mt_version</c> column, so a mapping that ends up with
+/// both enabled used to surface as a raw duplicate-key <c>ArgumentException</c> (or invalid
+/// DDL with two <c>mt_version</c> columns) instead of an actionable configuration error.
+/// </summary>
+public class optimistic_concurrency_on_projection_target_fails_fast: BugIntegrationContext
+{
+    [Fact]
+    public void use_optimistic_concurrency_on_projected_document_throws_invalid_document_exception()
+    {
+        // ProjectionDocumentPolicy forces MyAggregate onto numeric revisions, then the fluent
+        // override runs after the policies and re-enables the Guid version — leaving both
+        // flavors on. That combination can never work and must fail fast — here already at
+        // store bootstrap, because the projection's ValidateConfiguration materializes the
+        // aggregate mapping.
+        var ex = Should.Throw<InvalidDocumentException>(() => StoreOptions(opts =>
+        {
+            opts.Projections.Add<AllGood>(ProjectionLifecycle.Inline);
+            opts.Schema.For<MyAggregate>().UseOptimisticConcurrency(true);
+        }));
+
+        ex.Message.ShouldContain("UseOptimisticConcurrency");
+        ex.Message.ShouldContain("UseNumericRevisions");
+        ex.Message.ShouldContain(nameof(MyAggregate));
+    }
+
+    [Fact]
+    public void switching_a_plain_document_from_numeric_revisions_to_optimistic_concurrency_also_fails_fast()
+    {
+        // Without any projection involved, stacking the two fluent calls leaves the revision
+        // metadata enabled from the first call while the second re-enables the Guid version.
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>().UseNumericRevisions(true);
+            opts.Schema.For<Target>().UseOptimisticConcurrency(true);
+        });
+
+        Should.Throw<InvalidDocumentException>(
+            () => theStore.Options.Storage.MappingFor(typeof(Target)));
+    }
+}

--- a/src/IssueService/StreamingMinimalEndpoints.cs
+++ b/src/IssueService/StreamingMinimalEndpoints.cs
@@ -56,6 +56,18 @@ public static class StreamingMinimalEndpoints
             (Guid id, IQuerySession session)
                 => new StreamOne<VersionlessDoc>(session.Query<VersionlessDoc>().Where(x => x.Id == id)));
 
+        // Projection-target document (numeric revisions forced by ProjectionDocumentPolicy) —
+        // served through StreamOne instead of StreamAggregate, the ETag is the numeric revision,
+        // which for a single-stream projection equals the source stream's version.
+        app.MapGet("/minimal/order-doc/{id:guid}",
+            (Guid id, IQuerySession session)
+                => new StreamOne<Order>(session.Query<Order>().Where(x => x.Id == id)));
+
+        // Plain document using numeric revisions via IRevisioned — no projection involved.
+        app.MapGet("/minimal/revisioned/{id:guid}",
+            (Guid id, IQuerySession session)
+                => new StreamOne<RevisionedIssueNote>(session.Query<RevisionedIssueNote>().Where(x => x.Id == id)));
+
         // --- StreamMany<T> ---
 
         app.MapGet("/minimal/issues/open",
@@ -173,11 +185,24 @@ public static class StreamingMinimalEndpoints
 }
 
 /// <summary>
-/// A document type registered with version metadata disabled (no <c>mt_version</c> column),
-/// used to prove <see cref="StreamOne{T}"/> emits no ETag for versionless documents.
+/// A document type registered with version metadata disabled (no <c>mt_version</c> column of
+/// either flavor — Guid version or numeric revision), used to prove <see cref="StreamOne{T}"/>
+/// emits no ETag for versionless documents.
 /// </summary>
 public class VersionlessDoc
 {
     public Guid Id { get; set; }
     public string Name { get; set; }
+}
+
+/// <summary>
+/// A plain (non-projection) document using numeric revisions via
+/// <see cref="IRevisioned"/>, used to prove <see cref="StreamOne{T}"/>
+/// derives its ETag from the numeric revision.
+/// </summary>
+public class RevisionedIssueNote: IRevisioned
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public int Version { get; set; }
 }

--- a/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
+++ b/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
@@ -216,9 +216,11 @@ public class streaming_result_types_tests: IntegrationContext
     [Fact]
     public async Task stream_one_emits_no_etag_when_version_metadata_disabled()
     {
-        // VersionlessDoc is registered with Metadata.Version.Enabled = false, so there is no
-        // mt_version column to derive an ETag from. EmitETag defaults to true, but the inline
-        // version read comes back null and no ETag (and no false 304) is produced.
+        // VersionlessDoc is registered with Metadata.Version.Enabled = false and carries no
+        // numeric revision metadata either (not a projection target, not IRevisioned), so there
+        // is no mt_version column of either flavor to derive an ETag from. EmitETag defaults to
+        // true, but the inline version read comes back null and no ETag (and no false 304) is
+        // produced.
         var doc = new VersionlessDoc { Id = Guid.NewGuid(), Name = "no version column" };
         await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
         {
@@ -299,6 +301,124 @@ public class streaming_result_types_tests: IntegrationContext
         public void RecordSavedChanges(Marten.IDocumentSession session, Marten.Services.IChangeSet commit) { }
         public void OnBeforeExecute(Npgsql.NpgsqlCommand command) => Count++;
         public void OnBeforeExecute(Npgsql.NpgsqlBatch batch) => Count++;
+    }
+
+    // ──────────────── StreamOne<T> ETag — numeric-revision documents ────────────────
+
+    [Fact]
+    public async Task stream_one_emits_stream_version_etag_for_projection_target_document()
+    {
+        // Order is the target of an inline single-stream projection (Projections.Snapshot<Order>),
+        // so ProjectionDocumentPolicy forces numeric revisions and the projection writes the source
+        // stream's version into mt_version. Serving the projected document through StreamOne emits
+        // that revision as the ETag — the same value StreamAggregate derives for the same stream.
+        var orderId = Guid.NewGuid();
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Events.StartStream<Order>(orderId, new OrderPlaced("Projected Book", 12.50m));
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order-doc/{orderId}");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        result.Context.Response.Headers["ETag"].ToString().ShouldBe("\"1\"");
+
+        var order = result.ReadAsJson<Order>();
+        order.Id.ShouldBe(orderId);
+        order.Description.ShouldBe("Projected Book");
+    }
+
+    [Fact]
+    public async Task stream_one_returns_304_when_if_none_match_matches_projection_revision()
+    {
+        var orderId = Guid.NewGuid();
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Events.StartStream<Order>(orderId, new OrderPlaced("Cached Projection", 3.00m));
+            await session.SaveChangesAsync();
+        }
+
+        var second = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order-doc/{orderId}");
+            s.WithRequestHeader("If-None-Match", "\"1\"");
+            s.StatusCodeShouldBe(304);
+        });
+
+        second.Context.Response.Headers["ETag"].ToString().ShouldBe("\"1\"");
+        second.ReadAsText().ShouldBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task stream_one_projection_etag_changes_when_the_stream_advances()
+    {
+        var orderId = Guid.NewGuid();
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Events.StartStream<Order>(orderId, new OrderPlaced("Evolving Book", 8.00m));
+            await session.SaveChangesAsync();
+        }
+
+        var first = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order-doc/{orderId}");
+            s.StatusCodeShouldBe(200);
+        });
+        first.Context.Response.Headers["ETag"].ToString().ShouldBe("\"1\"");
+
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Events.Append(orderId, new OrderShipped());
+            await session.SaveChangesAsync();
+        }
+
+        // The previously-cached ETag is now stale: full body again, with the new revision.
+        var second = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order-doc/{orderId}");
+            s.WithRequestHeader("If-None-Match", "\"1\"");
+            s.StatusCodeShouldBe(200);
+        });
+
+        second.Context.Response.Headers["ETag"].ToString().ShouldBe("\"2\"");
+
+        var order = second.ReadAsJson<Order>();
+        order.Shipped.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task stream_one_emits_revision_etag_for_plain_revisioned_document()
+    {
+        // Not a projection target: RevisionedIssueNote opts into numeric revisions by
+        // implementing IRevisioned, which also gives its mt_version column the narrower
+        // integer width (#4614) — proving the revision read handles both column widths.
+        var note = new RevisionedIssueNote { Id = Guid.NewGuid(), Name = "rev one" };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(note);
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/revisioned/{note.Id}");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        result.Context.Response.Headers["ETag"].ToString().ShouldBe("\"1\"");
+
+        await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/revisioned/{note.Id}");
+            s.WithRequestHeader("If-None-Match", "\"1\"");
+            s.StatusCodeShouldBe(304);
+        });
     }
 
     // ───────────────────────── StreamMany<T> ─────────────────────────

--- a/src/Marten.AspNetCore/QueryableExtensions.cs
+++ b/src/Marten.AspNetCore/QueryableExtensions.cs
@@ -19,9 +19,12 @@ public static class QueryableExtensions
     /// When <paramref name="emitETag"/> is true (the default), the document's <c>mt_version</c>
     /// is read <b>inline with the document in the same single round trip</b> (piggy-backed onto the
     /// streaming query, analogous to the <c>count(*) OVER()</c> stats column) and written as a quoted
-    /// <c>ETag</c> response header. If the incoming request's <c>If-None-Match</c> header matches that
-    /// version, a <c>304 Not Modified</c> is written instead, with an empty body. Document types with
-    /// version metadata disabled (no <c>mt_version</c> column) emit no ETag.
+    /// <c>ETag</c> response header — a quoted GUID under Guid optimistic concurrency, or a quoted
+    /// integer for numeric-revision documents (projection targets, <c>IRevisioned</c> types), where
+    /// a <c>SingleStreamProjection</c> target's revision is the source stream's version. If the
+    /// incoming request's <c>If-None-Match</c> header matches that value, a <c>304 Not Modified</c>
+    /// is written instead, with an empty body. Document types with neither version nor revision
+    /// metadata enabled (no <c>mt_version</c> column) emit no ETag.
     /// </para>
     /// </summary>
     /// <param name="queryable"></param>
@@ -68,10 +71,14 @@ public static class QueryableExtensions
             return;
         }
 
-        if (result.Version.HasValue)
-        {
-            var etag = ETagHelpers.Format(result.Version.Value);
+        var etag = result.Version.HasValue
+            ? ETagHelpers.Format(result.Version.Value)
+            : result.Revision.HasValue
+                ? ETagHelpers.Format(result.Revision.Value)
+                : null;
 
+        if (etag != null)
+        {
             if (ETagHelpers.IfNoneMatchMatches(context, etag))
             {
                 context.Response.StatusCode = StatusCodes.Status304NotModified;

--- a/src/Marten.AspNetCore/StreamOne.cs
+++ b/src/Marten.AspNetCore/StreamOne.cs
@@ -53,10 +53,11 @@ public sealed class StreamOne<T> : IResult, IEndpointMetadataProvider
 
     /// <summary>
     /// Whether to emit an <c>ETag</c> response header derived from the document's
-    /// <c>mt_version</c>, and honor an incoming <c>If-None-Match</c> request header by
-    /// responding <c>304 Not Modified</c> with an empty body when it matches. Defaults to
-    /// <c>true</c>. Set to <c>false</c> to opt out if a consumer's contract cannot tolerate
-    /// the extra header.
+    /// <c>mt_version</c> (a quoted GUID under Guid optimistic concurrency, a quoted integer
+    /// for numeric-revision documents such as projection targets), and honor an incoming
+    /// <c>If-None-Match</c> request header by responding <c>304 Not Modified</c> with an
+    /// empty body when it matches. Defaults to <c>true</c>. Set to <c>false</c> to opt out
+    /// if a consumer's contract cannot tolerate the extra header.
     /// </summary>
     public bool EmitETag { get; init; } = true;
 

--- a/src/Marten/Internal/Sessions/QuerySession.Execution.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Execution.cs
@@ -102,6 +102,21 @@ public partial class QuerySession
         }
     }
 
+    internal async Task<(bool found, long? revision)> StreamOneWithRevision(DbCommand command, Stream stream,
+        CancellationToken token)
+    {
+        await using var reader = await ExecuteReaderAsync(command, token).ConfigureAwait(false);
+
+        try
+        {
+            return await reader.StreamOneWithRevision(stream, token).ConfigureAwait(false);
+        }
+        finally
+        {
+            await reader.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
     internal async Task<int> StreamMany(DbCommand command, Stream stream, CancellationToken token)
     {
         await using var reader = await ExecuteReaderAsync(command, token).ConfigureAwait(false);

--- a/src/Marten/Linq/MartenLinqQueryProvider.cs
+++ b/src/Marten/Linq/MartenLinqQueryProvider.cs
@@ -25,11 +25,14 @@ internal record WaitForAggregate(TimeSpan Timeout, NonStaleDataTimeoutMode Timeo
 
 /// <summary>
 /// Outcome of a single-document JSON stream that also read the document's <c>mt_version</c>
-/// inline. <see cref="Found"/> is false when the query matched no row; <see cref="Version"/>
-/// is null when the document type has no <c>mt_version</c> column (version metadata disabled)
-/// or the value was SQL NULL — in which case no ETag should be emitted.
+/// inline. <see cref="Found"/> is false when the query matched no row. At most one of
+/// <see cref="Version"/> (Guid optimistic-concurrency mode) or <see cref="Revision"/>
+/// (numeric revision mode — projection-target documents and <c>IRevisioned</c>/<c>ILongVersioned</c>
+/// types) carries a value; both are null when the document type has no <c>mt_version</c> column
+/// (neither metadata flavor enabled) or the value was SQL NULL — in which case no ETag
+/// should be emitted.
 /// </summary>
-internal readonly record struct StreamOneJsonResult(bool Found, Guid? Version);
+internal readonly record struct StreamOneJsonResult(bool Found, Guid? Version, long? Revision);
 
 internal class MartenLinqQueryProvider: IQueryProvider
 {
@@ -272,9 +275,12 @@ internal class MartenLinqQueryProvider: IQueryProvider
     /// round trip — the version column is piggy-backed onto the streaming query via
     /// <see cref="VersionSelectClause{T}"/> (analogous to the <c>count(*) OVER()</c> stats column),
     /// so the ASP.NET Core <c>StreamOne</c> ETag support no longer needs a follow-up metadata query.
-    /// When the document type <typeparamref name="T"/> has no <c>mt_version</c> column (version
-    /// metadata disabled), the version column is not appended and <see cref="StreamOneJsonResult.Version"/>
-    /// comes back null so the caller emits no ETag.
+    /// The column is read as a Guid when the mapping uses Guid optimistic concurrency, and as a
+    /// numeric revision when the mapping uses numeric revisioning (projection-target documents,
+    /// <c>IRevisioned</c>/<c>ILongVersioned</c> types) — same physical column, different flavor.
+    /// When the document type <typeparamref name="T"/> has no <c>mt_version</c> column (neither
+    /// metadata flavor enabled), the column is not appended and the result carries neither a
+    /// version nor a revision so the caller emits no ETag.
     /// </summary>
     public async Task<StreamOneJsonResult> StreamOneWithVersion<T>(Expression expression, Stream destination,
         CancellationToken token) where T : notnull
@@ -288,24 +294,37 @@ internal class MartenLinqQueryProvider: IQueryProvider
         var main = statements.MainSelector;
         main.Limit = 1;
 
-        var versionEnabled = _session.Options.Storage.FindMapping(typeof(T)) is DocumentMapping
-        {
-            Metadata.Version.Enabled: true
-        };
+        var mapping = _session.Options.Storage.FindMapping(typeof(T)) as DocumentMapping;
 
-        if (!versionEnabled)
+        if (mapping is { Metadata.Version.Enabled: true })
         {
-            var plainCommand = statement.BuildCommand(_session);
-            var found = await _session.StreamOne(plainCommand, destination, token).ConfigureAwait(false);
-            return new StreamOneJsonResult(found, null);
+            main.SelectClause = new VersionSelectClause<T>(main.SelectClause);
+
+            var command = statement.BuildCommand(_session);
+            var (streamed, version) = await _session.StreamOneWithVersion(command, destination, token)
+                .ConfigureAwait(false);
+
+            return new StreamOneJsonResult(streamed, version, null);
         }
 
-        main.SelectClause = new VersionSelectClause<T>(main.SelectClause);
+        // Numeric-revision documents keep their revision in the same physical mt_version column,
+        // so the identical piggy-backed select serves them — the value just reads back as a
+        // number rather than a uuid. For a SingleStreamProjection target the revision *is* the
+        // source stream's version, making the resulting ETag byte-for-byte the one StreamAggregate
+        // serves for the same stream.
+        if (mapping is { Metadata.Revision.Enabled: true })
+        {
+            main.SelectClause = new VersionSelectClause<T>(main.SelectClause);
 
-        var command = statement.BuildCommand(_session);
-        var (streamed, version) = await _session.StreamOneWithVersion(command, destination, token)
-            .ConfigureAwait(false);
+            var command = statement.BuildCommand(_session);
+            var (streamed, revision) = await _session.StreamOneWithRevision(command, destination, token)
+                .ConfigureAwait(false);
 
-        return new StreamOneJsonResult(streamed, version);
+            return new StreamOneJsonResult(streamed, null, revision);
+        }
+
+        var plainCommand = statement.BuildCommand(_session);
+        var found = await _session.StreamOne(plainCommand, destination, token).ConfigureAwait(false);
+        return new StreamOneJsonResult(found, null, null);
     }
 }

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -898,6 +898,19 @@ public partial class DocumentMapping: IDocumentMapping, IDocumentType
                 $"{DocumentType.FullNameInCode()} cannot be configured with UseNumericRevision and UseOptimisticConcurrency. Choose one or the other");
         }
 
+        // The check above only sees the two mode flags, but the metadata Enabled bits are what
+        // actually emit columns — and the Guid version and numeric revision flavors compete for
+        // the same physical mt_version column, so both enabled means a duplicate column: a raw
+        // duplicate-key ArgumentException from projection storage or invalid DDL at migration
+        // time. The usual route here is Schema.For<T>().UseOptimisticConcurrency(true) on a
+        // projection-target document that ProjectionDocumentPolicy already forced onto numeric
+        // revisions (fluent overrides run after the policies). Fail fast with the fix instead.
+        if (Metadata.Version.Enabled && Metadata.Revision.Enabled)
+        {
+            throw new InvalidDocumentException(
+                $"{DocumentType.FullNameInCode()} has both the Guid version metadata (Metadata.Version, from UseOptimisticConcurrency) and the numeric revision metadata (Metadata.Revision, from UseNumericRevisions) enabled, but they map to the same mt_version column. Choose one or the other — fluent configuration calls accumulate rather than override each other, so remove the call for the mode you do not want. Note that projection-target documents always use numeric revisions and cannot opt into UseOptimisticConcurrency.");
+        }
+
         IQueryableMember idField;
         if (IdStrategy is ValueTypeIdGeneration st)
         {

--- a/src/Marten/Services/JsonStreamingExtensions.cs
+++ b/src/Marten/Services/JsonStreamingExtensions.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -58,6 +59,34 @@ internal static class JsonStreamingExtensions
             : await reader.GetFieldValueAsync<Guid>(versionOrdinal, token).ConfigureAwait(false);
 
         return (true, version);
+    }
+
+    /// <summary>
+    /// Numeric-revision counterpart of <see cref="StreamOneWithVersion"/>: streams the first
+    /// row's <c>data</c> column and reads the piggy-backed numeric <c>mt_version</c> value.
+    /// The column is <c>bigint</c> by default but <c>integer</c> for <c>IRevisioned</c>-backed
+    /// documents (#4614), so the value is materialized at whatever width came back and widened
+    /// to long rather than read through a single generic accessor.
+    /// </summary>
+    internal static async Task<(bool found, long? revision)> StreamOneWithRevision(this DbDataReader reader,
+        Stream stream, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            return (false, null);
+        }
+
+        var dataOrdinal = reader.GetOrdinal("data");
+        await reader.WriteJsonValueAsync(dataOrdinal, stream, token).ConfigureAwait(false);
+
+        var revisionOrdinal = reader.GetOrdinal(Marten.Linq.SqlGeneration.VersionSelectClause.VersionAlias);
+        long? revision = await reader.IsDBNullAsync(revisionOrdinal, token).ConfigureAwait(false)
+            ? null
+            : Convert.ToInt64(
+                await reader.GetFieldValueAsync<object>(revisionOrdinal, token).ConfigureAwait(false),
+                CultureInfo.InvariantCulture);
+
+        return (true, revision);
     }
 
     internal static ValueTask WriteBytes(this Stream stream, byte[] bytes, CancellationToken token)


### PR DESCRIPTION
Addresses #5120.

## What

`StreamOne<T>`'s ETag gate only reads the Guid `mt_version` flavor — which projection-target documents are *forbidden* from having (numeric revisions are forced by `ProjectionDocumentPolicy`, by design per #2978/#3057/#3097). 

Net effect: the common CQRS read-model shape (a `SingleStreamProjection` document served by `StreamOne<T>`) can never emit an ETag, even though its `mt_version` already holds the source stream's version — the exact value `StreamAggregate<T>` serves as its ETag.

**Commit 1** teaches the ETag path numeric revisions: `StreamOneJsonResult` widens to carry either flavor, revision mode piggy-backs the same `VersionSelectClause`/`mt_etag_version` select (no new SQL machinery; column read robustly at either width per #4614), and `WriteSingle` formats via the existing `ETagHelpers.Format(long)` — the `If-None-Match`/304 branch is shared code, so behavior is identical to the Guid path by construction. For a single-stream target the ETag equals what `StreamAggregate` serves for the same stream, so the two read styles are cache-compatible (Inline lifecycle; an Async-lifecycle document can lag the stream head).

**Commit 2 (separable — say the word and we split it into its own PR referencing #2978)**: `CompileAndValidate` now throws an actionable `InvalidDocumentException` when both `Metadata.Version.Enabled` and `Metadata.Revision.Enabled` are set. Today that state surfaces as a raw duplicate-key `ArgumentException` from projection storage, or invalid DDL with two `mt_version` columns — `DocumentStorageDescriptorBuilder` already documents the never-both assumption. The only fluent sequence newly rejected is `UseNumericRevisions(true)` followed by `UseOptimisticConcurrency(true)` on one store, which never worked (duplicate-column DDL). We deliberately did **not** make `UseOptimisticConcurrency(true)` clear `Revision.Enabled`: that would route a projection target past the guard into the Guid-only mapping that breaks on the second inline apply (`ConcurrencyException` — the projection path binds `DBNull` as the expected version), a silent runtime failure instead of a bootstrap error. We also considered and rejected moving `ProjectionDocumentPolicy` to post-policies — it would silently override explicit user configuration and reorder `ConfigureAggregateMapping`.

## Known non-goals / scope notes

- The compiled-query overload (`StreamOne<TDoc, TOut>`) does not participate in ETag/304 handling (pre-existing; the same `VersionSelectClause` piggy-back would extend it later if wanted).
- Revision-derived ETags are deterministic: a projection-logic change + rebuild that doesn't advance the stream won't invalidate cached responses (`ProjectionVersion` bumps don't reset the revision) — matching shipped `StreamAggregate` semantics; documented.
- Multi-stream/`ILongVersioned` targets emit their own monotonic per-document revision — a valid ETag, but not a stream version; documented.
- Malformed `If-None-Match` tokens behave exactly as on the Guid path (never match → 200) — inherited, unchanged.
- `EventProjection` outputs are not forced into revisioning and emit no ETag unless they opt in; documented.

## Tests

4 new tests beside the existing ETag pins in `Marten.AspNetCore.Testing` (projection-target emits `"1"`, honors 304, advances to `"2"` with stale-tag 200; plain `IRevisioned` document emits its revision), 2 failing-first guard tests beside `Bug_2978_*`, and the existing no-ETag pin extended to state the full negative condition (its subject has neither flavor).

Suites (net10.0 locally; net9 deferred to CI — no local runtime): Marten.AspNetCore.Testing 101/101 · DocumentDbTests 1089/0 · EventSourcingTests 1604/0 · DaemonTests 260/0 · LinqTests 1421/0 · CoreTests 515 passed with 4 failures, all triaged as not-ours: `Bug_4185_codegen_conflict…` and `rolling_range_partitioning…` reproduce identically on clean master (pre-existing), and `Bug_4187_ancillary…` + `divergent_application_assembly…` pass in isolation on this branch (full-suite interference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)