### PR TITLE
Bump Weasel 9.23.0 → 9.23.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -239,7 +239,7 @@
     <PackageVersion Include="Vogen" Version="7.0.0" />
     <!-- 9.16.2: the hold at 9.2.1 (were newer builds actually being published?) is resolved —
          Weasel.EntityFrameworkCore is on nuget.org, so it tracks the rest of the Weasel line. -->
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.23.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.23.1" />
     <!-- Weasel.Postgresql 9.1.x: managed LIST partitions under multi-database (sharded) apply.
          9.1.2 (marten#4706): managed-partition tables are no longer destructively rebuilt — the
          out-of-band AddPartitionToAllTables path creates partitions while the generic schema diff
@@ -325,9 +325,13 @@
          than resolving transitively.
          9.23.0 (weasel#416): AssertValidIdentifier now rejects a quote or semicolon outright. This is
          the belt to 9.21.1's braces — 9.21.1 made partition bound VALUES escape correctly, and this
-         closes the identifier side of the same surface. -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.23.0" />
-    <PackageVersion Include="Weasel.Storage" Version="9.23.0" />
+         closes the identifier side of the same surface.
+         9.23.1 (weasel#420/#422): the same weasel#416 identifier validation extended to the other
+         provider migrators (SQL Server previously validated nothing at all; Oracle, MySQL and Sqlite
+         each missed their own quoting characters), with the PostgreSQL check folded onto the shared
+         Weasel.Core helper so the providers cannot drift apart again. -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.23.1" />
+    <PackageVersion Include="Weasel.Storage" Version="9.23.1" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <!-- The whole test suite is on xunit v3. VSTest stays the execution mode, so the
          Nuke targets and the GitHub workflows are unaffected. -->


### PR DESCRIPTION
Rolls Weasel forward to [9.23.1](https://github.com/JasperFx/weasel/releases/tag/V9.23.1) — `Weasel.Postgresql`, `Weasel.Storage`, `Weasel.EntityFrameworkCore`.

## What's in it

weasel#420 + weasel#422: the identifier validation added for weasel#416 now covers **every** provider migrator instead of PostgreSQL alone, and PostgreSQL's own copy is folded onto the shared `Weasel.Core` helper so the providers cannot drift apart again. SQL Server previously validated nothing at all; Oracle, MySQL and Sqlite each missed their own quoting characters.

Marten only consumes the PostgreSQL side, so **this is a hardening roll-forward, not a fix for a Marten-reachable hole**: 9.23.0 already carried the PostgreSQL check that the GHSA-3vp4-34pf-2rcw class needs, and 9.21.1 carries the partition-bound `VALUES` escaping. Worth taking anyway to stay on the current line.

## Why it's a separate PR

A Weasel bump has form for landing outside the area it looks like it touches. Weasel 9.18–9.20.1 broke `Bug_4614` through `MatchesForDelta` bypassing a subclass `Equals(object)` — nowhere near anything in the release notes. Keeping it off #5123 means a bisect lands on one changed line.

## Verification

net9.0, against the published package, on this history (no other changes):

| Project | Result | Why this one |
|---|---|---|
| CoreTests | 519 / 0 / 1 | the project that caught the 9.18–9.20.1 regression |
| DocumentDbTests | 1089 / 0 / 1 | document storage + schema delta |
| EventSourcingTests | 1613 / 0 / 7 | event store schema |
| TenantPartitionedEventsTests | 238 / 0 / 2 | identifier validation sits closest to the partition naming paths |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde