### PR TITLE
Adopt JasperFx 2.37.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -174,21 +174,31 @@
          jasperfx#595 (BatchingChannel could deliver its trailing batch twice on shutdown) and #597.
          JasperFx 2.37.2: compliance wave 2 (marten#5118) — four more shared suites plus the seam
          members they need. Nothing outside JasperFx.Events.ComplianceTests changed; the other
-         packages move only because the line versions together. -->
-    <PackageVersion Include="JasperFx" Version="2.37.2" />
-    <PackageVersion Include="JasperFx.Events" Version="2.37.2" />
+         packages move only because the line versions together.
+         JasperFx 2.37.3: jasperfx#611 — JasperFx.Events.SourceGenerator now discovers an
+         EventProjection's published document types SEMANTICALLY. Discovery used to match only
+         GenericNameSyntax, so an explicit ApplyAsync override writing `ops.Store<Doc>(x)` registered
+         Doc while the equally valid `ops.Store(x)` registered nothing at all, silently (storage is
+         still provisioned on demand, so only schema-ahead-of-time, AllKnownDocumentTypes and rebuild
+         teardown came up short). Binding the invocation gives the same answer for both spellings.
+         Also stops `Store<object>(...)` registering `object` itself as a document type: registrability
+         is now a SpecialType/TypeKind question, because object/string render through ToDisplayString()
+         as C# keywords and slipped past the old name-prefix check. New JFXEVT005 (Info) flags a call
+         that binds to the projection's session but whose document type cannot be named. -->
+    <PackageVersion Include="JasperFx" Version="2.37.3" />
+    <PackageVersion Include="JasperFx.Events" Version="2.37.3" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.37.2" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.37.2">
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.37.3" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.37.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.37.2" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.37.3" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Picks up JasperFx/jasperfx#611, which is the reason 2.37.3 exists.

## What changes for Marten users

`JasperFx.Events.SourceGenerator` now discovers an EventProjection's published document types **semantically** rather than syntactically. Discovery used to match only `GenericNameSyntax`, so inside an explicit `ApplyAsync` override:

```csharp
operations.Store<AuditRecord>(record);   // registered AuditRecord
operations.Store(record);                // registered NOTHING
```

Nothing at the call site says so, and nothing fails at runtime — storage is provisioned on demand — so only the ahead-of-time surfaces came up short: schema creation, `AllKnownDocumentTypes()`, rebuild teardown. Same #4166 behaviour, now correct for both spellings.

**This is behaviour-changing, in the good direction, and belongs in the release notes.** A projection using the non-generic spelling will start registering document types it silently skipped before. The visible effects are that those types now appear in `AllKnownDocumentTypes()` and get their storage created up front.

Also carried:

- `Store<object>(...)` no longer registers `object` itself as a document type. `object` and `string` render through `ToDisplayString()` as their C# keywords, not `System.Object`/`System.String`, so they slipped past the old name-prefix check; registrability is now a `SpecialType`/`TypeKind` question.
- New **JFXEVT005** (Info) for a call that binds to the projection's own session but whose document type cannot be named — `object`, `dynamic`, an open type parameter. Info rather than Warning so it cannot break a `TreatWarningsAsErrors` build over a legitimate call.

## Verification

net9.0, against the published packages:

- `EventSourcingTests` **1614 / 0 / 7**
- `DaemonTests` **260 / 0 / 0**

One transient `DaemonTests` failure appeared on the first of three runs and I could not identify it — the run output was not captured, and two subsequent full runs were clean at 260/0/0. Recording it rather than omitting it; I have no evidence tying it to this bump, and a registration change would present deterministically rather than intermittently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde