### PR TITLE
Commit the events queued by a ProjectionScenario's final step

### DIFF
--- a/src/DaemonTests/EventProjections/scenario_trailing_action_tests.cs
+++ b/src/DaemonTests/EventProjections/scenario_trailing_action_tests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.EventProjections;
+
+// #5126: a ScenarioAction only flushed when the NEXT queued step was an assertion, so anything a
+// trailing action appended was still in the session when Execute's finally disposed it. The events
+// were silently dropped, and an arrange-only scenario was a no-op that passed.
+public class scenario_trailing_action_tests: OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task trailing_append_is_committed()
+    {
+        StoreOptions(opts => opts.Projections.Add(new UserProjection(), ProjectionLifecycle.Inline));
+
+        var flushed = Guid.NewGuid();
+        var trailing = Guid.NewGuid();
+
+        await theStore.Advanced.EventProjectionScenario(scenario =>
+        {
+            // An assertion follows this one, so it flushes through the pre-existing path.
+            scenario.Append(Guid.NewGuid(), new CreateUser { UserId = flushed, UserName = "Flushed" });
+            scenario.DocumentShouldExist<User>(flushed);
+
+            // Nothing follows this one.
+            scenario.Append(Guid.NewGuid(), new CreateUser { UserId = trailing, UserName = "Trailing" });
+        });
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<User>(trailing)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task arrange_only_scenario_actually_writes()
+    {
+        StoreOptions(opts => opts.Projections.Add(new UserProjection(), ProjectionLifecycle.Inline));
+
+        var id = Guid.NewGuid();
+
+        // No assertions at all -- every step is an action, so nothing used to be committed.
+        await theStore.Advanced.EventProjectionScenario(scenario =>
+        {
+            scenario.Append(Guid.NewGuid(), new CreateUser { UserId = id, UserName = "Arranged" });
+        });
+
+        await using var query = theStore.QuerySession();
+        var user = await query.LoadAsync<User>(id);
+        user.ShouldNotBeNull();
+        user.UserName.ShouldBe("Arranged");
+    }
+}

--- a/src/Marten/Events/TestSupport/ProjectionScenario.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenario.cs
@@ -107,6 +107,25 @@ public partial class ProjectionScenario: IEventOperations
                 }
             }
 
+            // A ScenarioAction only flushes when the step AFTER it is an assertion, so whatever a
+            // trailing action queued is still sitting in the session -- and the finally below disposes
+            // that session without committing. An append with no assertion after it is still an append,
+            // and an arrange-only scenario should not be a silent no-op that passes. See #5126.
+            //
+            // Unconditional on purpose: SaveChangesAsync returns immediately when the unit of work is
+            // empty, and WaitForNonStaleData is already a no-op when no daemon is running.
+            try
+            {
+                await Session.SaveChangesAsync(ct).ConfigureAwait(false);
+                await WaitForNonStaleData().ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                descriptions.Add($"FAILED: committing the events queued by the final step");
+                descriptions.Add(e.ToString());
+                exceptions.Add(e);
+            }
+
             if (exceptions.Any())
             {
                 throw new ProjectionScenarioException(descriptions, exceptions);


### PR DESCRIPTION
Closes #5126

## The bug

`ScenarioAction` only flushes the session when the step **after** it is an assertion:

```csharp
_action(scenario.Session.Events);
if (scenario.NextStep is ScenarioAssertion)   // null for the last step
{
    await scenario.Session.SaveChangesAsync(ct);
    await scenario.WaitForNonStaleData();
}
```

`NextStep` peeks the queue *after* the current step was dequeued, so it is null on the final step and the branch never runs. `Execute`'s `finally` then disposes the session, and Marten's dispose does not commit.

Consequences: a scenario ending in an append silently loses those events, and **an arrange-only scenario is a complete no-op that passes**.

## The fix

Flush once more after the step loop. Unconditional on purpose — `SaveChangesAsync` returns immediately when the unit of work is empty (`DocumentSessionBase.SaveChangesAsync` checks `HasOutstandingWork` before doing anything) and `WaitForNonStaleData` is already a no-op when no daemon is running, so scenarios that already flushed pay nothing for it.

The flush sits inside the `try` and aggregates into `ProjectionScenarioException` like any other step, so a failing commit is reported as a scenario failure with the rest rather than escaping raw.

## Tests

Two regression tests, **both verified to fail on master before the fix**:

- `trailing_append_is_committed` — an append after an assertion, with nothing following it
- `arrange_only_scenario_actually_writes` — a scenario with no assertions at all

None of the eight existing tests covered this, because every one of them happens to end with an assertion.

net9.0: `DaemonTests` **262 / 0 / 0**.

## Not addressed here

The same `NextStep is ScenarioAssertion` rule means consecutive actions batch into a single transaction, so a scenario cannot express "two separate commits" — which is what you would want for optimistic concurrency or per-batch projection behaviour. That is a design decision rather than a defect, and it is called out in #5126 and #5127 rather than changed silently here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde