### PR TITLE
ProjectionScenario ergonomics and quality pass

### DIFF
--- a/docs/events/projections/testing.md
+++ b/docs/events/projections/testing.md
@@ -299,6 +299,93 @@ In the version above, we can just be using a shared `IHost` and the async daemon
 new events, then force the test harness to "wait" for the underlying async daemon to be completely caught up before proceeding
 to test the expected documents persisted in the database by the projection. 
 
+## Scripted Scenarios with EventProjectionScenario
+
+For a more declarative way to test a projection end to end, Marten has a built-in scenario runner on
+`IDocumentStore.Advanced` that scripts a sequence of event appends and document assertions, then executes
+the whole sequence for you:
+
+<!-- snippet: sample_using_event_projection_scenario -->
+<a id='snippet-sample_using_event_projection_scenario'></a>
+```cs
+[Fact]
+public async Task happy_path_test_with_inline_projection()
+{
+    StoreOptions(opts =>
+    {
+        opts.Projections.Add(new UserProjection(), ProjectionLifecycle.Inline);
+    });
+
+    await theStore.Advanced.EventProjectionScenario(scenario =>
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        var id3 = Guid.NewGuid();
+
+        scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id1, UserName = "Kareem"});
+        scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id2, UserName = "Magic"});
+        scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id3, UserName = "James"});
+
+        scenario.DocumentShouldExist<User>(id1);
+        scenario.DocumentShouldExist<User>(id2);
+        scenario.DocumentShouldExist<User>(id3, user => user.UserName.ShouldBe("James"));
+
+        scenario.Append(Guid.NewGuid(), new DeleteUser {UserId = id2});
+
+        scenario.DocumentShouldExist<User>(id1);
+        scenario.DocumentShouldNotExist<User>(id2);
+        scenario.DocumentShouldExist<User>(id3);
+
+    }, TestContext.Current.CancellationToken);
+}
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/EventProjections/event_projection_scenario_tests.cs#L17-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_event_projection_scenario' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The scenario works with any projection lifecycle. If the store has any asynchronous projections registered, the
+scenario quietly spins up a projection daemon, waits for it to catch up after each batch of appended events, and
+shuts it down afterward — your test code looks identical either way.
+
+A few things to know about how a scenario executes:
+
+- The `Append()` / `StartStream()` / `AppendEvents()` calls **queue** work — nothing touches the database until the
+  scenario executes. The `StartStream()` overloads that generate their own stream id return that `Guid` so you can
+  capture it for later assertions.
+- Consecutive appends are batched into a single commit; the pending work is saved whenever the next step is an
+  assertion, and once more at the end of the scenario.
+- Assertion steps run against a query session after the projected data is up to date. `DocumentShouldExist<T>()`
+  and `DocumentShouldNotExist<T>()` cover the common cases, and `AssertAgainstProjectedData()` is the general
+  purpose hook for anything else.
+- If an *action* step fails, the scenario stops immediately — the remaining steps would be running against a state
+  nobody intended. Failed *assertions* accumulate instead, and everything is reported at the end in a single
+  `ProjectionScenarioException` that lists each step and what went wrong. Assertion failures inside the aggregate
+  are typed as `ProjectionScenarioAssertionException` so tooling can tell them apart from infrastructure failures.
+
+::: warning
+By default the scenario **deletes all event data plus the storage for every registered projection** before it runs,
+so each scenario starts from a clean slate. Only use this feature against a test database! To run a scenario on top
+of existing data instead, set `scenario.DeleteExistingData = false`.
+:::
+
+The scenario object exposes a few knobs:
+
+```cs
+await theStore.Advanced.EventProjectionScenario(scenario =>
+{
+    // Keep any existing event/projection data (the default is to wipe it)
+    scenario.DeleteExistingData = false;
+
+    // Apply the whole scenario to one tenant when using multi-tenancy
+    scenario.TenantId = "tenant1";
+
+    // Maximum time to wait for async projections to catch up
+    // after each batch of events. The default is 30 seconds
+    scenario.Timeout = 5.Seconds();
+
+    // ... queue up appends and assertions
+});
+```
+
 ## What about System Time?!?
 
 ::: info

--- a/src/DaemonTests/EventProjections/event_projection_scenario_tests.cs
+++ b/src/DaemonTests/EventProjections/event_projection_scenario_tests.cs
@@ -14,6 +14,8 @@ namespace DaemonTests.EventProjections;
 
 public class event_projection_scenario_tests : OneOffConfigurationsContext
 {
+    #region sample_using_event_projection_scenario
+
     [Fact]
     public async Task happy_path_test_with_inline_projection()
     {
@@ -44,6 +46,9 @@ public class event_projection_scenario_tests : OneOffConfigurationsContext
 
         }, TestContext.Current.CancellationToken);
     }
+
+    #endregion
+
     [Fact]
     public async Task happy_path_test_with_inline_projection_multi_tenanted()
     {

--- a/src/DaemonTests/EventProjections/projection_scenario_quality_tests.cs
+++ b/src/DaemonTests/EventProjections/projection_scenario_quality_tests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Marten.Events.TestSupport;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.EventProjections;
+
+public class projection_scenario_quality_tests: OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task failed_assertions_surface_as_typed_assertion_exceptions()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Add(new UserProjection(), ProjectionLifecycle.Inline);
+        });
+
+        var ex = await Should.ThrowAsync<ProjectionScenarioException>(async () =>
+        {
+            await theStore.Advanced.EventProjectionScenario(scenario =>
+            {
+                var id = Guid.NewGuid();
+                scenario.Append(Guid.NewGuid(), new CreateUser { UserId = id, UserName = "Kareem" });
+
+                // Fails: the user document DOES exist
+                scenario.DocumentShouldNotExist<User>(id);
+            }, TestContext.Current.CancellationToken);
+        });
+
+        ex.InnerExceptions.Single().ShouldBeOfType<ProjectionScenarioAssertionException>();
+    }
+
+    [Fact]
+    public async Task a_failed_action_stops_the_scenario_and_skips_the_remaining_steps()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Add(new UserProjection(), ProjectionLifecycle.Inline);
+        });
+
+        var ex = await Should.ThrowAsync<ProjectionScenarioException>(async () =>
+        {
+            await theStore.Advanced.EventProjectionScenario(scenario =>
+            {
+                scenario.AppendEvents("An action that blows up", _ => throw new DivideByZeroException("boom"));
+
+                // Neither of these should run -- the second one would fail loudly if it did
+                scenario.DocumentShouldNotExist<User>(Guid.NewGuid());
+                scenario.DocumentShouldExist<User>(Guid.NewGuid());
+            }, TestContext.Current.CancellationToken);
+        });
+
+        ex.InnerExceptions.Single().ShouldBeOfType<DivideByZeroException>();
+        ex.Message.ShouldContain("Skipped the remaining 2 step(s)");
+    }
+
+    [Fact]
+    public async Task start_stream_returns_the_generated_stream_id()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Add(new UserProjection(), ProjectionLifecycle.Inline);
+        });
+
+        var userId = Guid.NewGuid();
+        var streamId = Guid.Empty;
+
+        await theStore.Advanced.EventProjectionScenario(scenario =>
+        {
+            streamId = scenario.StartStream(new CreateUser { UserId = userId, UserName = "Oscar" });
+            scenario.DocumentShouldExist<User>(userId);
+        }, TestContext.Current.CancellationToken);
+
+        streamId.ShouldNotBe(Guid.Empty);
+
+        var events = await theSession.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(1);
+        events.Single().Data.ShouldBeOfType<CreateUser>().UserId.ShouldBe(userId);
+    }
+
+    [Fact]
+    public async Task a_scenario_cannot_be_executed_twice()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Add(new UserProjection(), ProjectionLifecycle.Inline);
+        });
+
+        var scenario = new ProjectionScenario(theStore);
+        scenario.Append(Guid.NewGuid(), new CreateUser { UserId = Guid.NewGuid(), UserName = "Once" });
+
+        await scenario.Execute(TestContext.Current.CancellationToken);
+
+        // The steps were consumed by the first run, so a second run would be a silent no-op.
+        // It should be a loud failure instead.
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            await scenario.Execute(TestContext.Current.CancellationToken);
+        });
+    }
+
+    [Fact]
+    public async Task opting_out_of_deleting_existing_data_retains_prior_events_and_documents()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Add(new UserProjection(), ProjectionLifecycle.Inline);
+        });
+
+        var existingId = Guid.NewGuid();
+        theSession.Events.StartStream(Guid.NewGuid(),
+            new CreateUser { UserId = existingId, UserName = "Existing" });
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await theStore.Advanced.EventProjectionScenario(scenario =>
+        {
+            scenario.DeleteExistingData = false;
+
+            // Still here because the scenario did not wipe the store
+            scenario.DocumentShouldExist<User>(existingId, u => u.UserName.ShouldBe("Existing"));
+        }, TestContext.Current.CancellationToken);
+    }
+}

--- a/src/Marten/AdvancedOperations.cs
+++ b/src/Marten/AdvancedOperations.cs
@@ -289,7 +289,8 @@ public class AdvancedOperations
 
     /// <summary>
     ///     Marten's built in test support for event projections. Only use this in testing as
-    ///     it will delete existing event and projected aggregate data
+    ///     it will delete existing event and projected aggregate data by default (opt out
+    ///     with ProjectionScenario.DeleteExistingData = false)
     /// </summary>
     /// <param name="configuration"></param>
     /// <returns></returns>

--- a/src/Marten/Events/TestSupport/ProjectionScenario.Assertions.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenario.Assertions.cs
@@ -25,16 +25,7 @@ public partial class ProjectionScenario
     /// <typeparam name="T">The document type</typeparam>
     public void DocumentShouldExist<T>(string id, Action<T>? assertions = null) where T : notnull
     {
-        assertion(async (session, ct) =>
-        {
-            var document = await session.LoadAsync<T>(id, ct).ConfigureAwait(false);
-            if (document == null)
-            {
-                throw new Exception($"Document {typeof(T).FullNameInCode()} with id '{id}' does not exist");
-            }
-
-            assertions?.Invoke(document);
-        }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should exist";
+        documentShouldExist(id, (session, ct) => session.LoadAsync<T>(id, ct), assertions);
     }
 
     /// <summary>
@@ -45,16 +36,7 @@ public partial class ProjectionScenario
     /// <typeparam name="T">The document type</typeparam>
     public void DocumentShouldExist<T>(long id, Action<T>? assertions = null) where T : notnull
     {
-        assertion(async (session, ct) =>
-        {
-            var document = await session.LoadAsync<T>(id, ct).ConfigureAwait(false);
-            if (document == null)
-            {
-                throw new Exception($"Document {typeof(T).FullNameInCode()} with id '{id}' does not exist");
-            }
-
-            assertions?.Invoke(document);
-        }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should exist";
+        documentShouldExist(id, (session, ct) => session.LoadAsync<T>(id, ct), assertions);
     }
 
     /// <summary>
@@ -65,16 +47,7 @@ public partial class ProjectionScenario
     /// <typeparam name="T">The document type</typeparam>
     public void DocumentShouldExist<T>(int id, Action<T>? assertions = null) where T : notnull
     {
-        assertion(async (session, ct) =>
-        {
-            var document = await session.LoadAsync<T>(id, ct).ConfigureAwait(false);
-            if (document == null)
-            {
-                throw new Exception($"Document {typeof(T).FullNameInCode()} with id '{id}' does not exist");
-            }
-
-            assertions?.Invoke(document);
-        }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should exist";
+        documentShouldExist(id, (session, ct) => session.LoadAsync<T>(id, ct), assertions);
     }
 
     /// <summary>
@@ -85,16 +58,7 @@ public partial class ProjectionScenario
     /// <typeparam name="T">The document type</typeparam>
     public void DocumentShouldExist<T>(Guid id, Action<T>? assertions = null) where T : notnull
     {
-        assertion(async (session, ct) =>
-        {
-            var document = await session.LoadAsync<T>(id, ct).ConfigureAwait(false);
-            if (document == null)
-            {
-                throw new Exception($"Document {typeof(T).FullNameInCode()} with id '{id}' does not exist");
-            }
-
-            assertions?.Invoke(document);
-        }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should exist";
+        documentShouldExist(id, (session, ct) => session.LoadAsync<T>(id, ct), assertions);
     }
 
     /// <summary>
@@ -104,15 +68,7 @@ public partial class ProjectionScenario
     /// <typeparam name="T">The document type</typeparam>
     public void DocumentShouldNotExist<T>(string id) where T : notnull
     {
-        assertion(async (session, ct) =>
-        {
-            var document = await session.LoadAsync<T>(id, ct).ConfigureAwait(false);
-            if (document != null)
-            {
-                throw new Exception(
-                    $"Document {typeof(T).FullNameInCode()} with id '{id}' exists, but should not.");
-            }
-        }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should not exist or be deleted";
+        documentShouldNotExist(id, (session, ct) => session.LoadAsync<T>(id, ct));
     }
 
     /// <summary>
@@ -122,15 +78,7 @@ public partial class ProjectionScenario
     /// <typeparam name="T">The document type</typeparam>
     public void DocumentShouldNotExist<T>(long id) where T : notnull
     {
-        assertion(async (session, ct) =>
-        {
-            var document = await session.LoadAsync<T>(id, ct).ConfigureAwait(false);
-            if (document != null)
-            {
-                throw new Exception(
-                    $"Document {typeof(T).FullNameInCode()} with id '{id}' exists, but should not.");
-            }
-        }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should not exist or be deleted";
+        documentShouldNotExist(id, (session, ct) => session.LoadAsync<T>(id, ct));
     }
 
     /// <summary>
@@ -140,15 +88,7 @@ public partial class ProjectionScenario
     /// <typeparam name="T">The document type</typeparam>
     public void DocumentShouldNotExist<T>(int id) where T : notnull
     {
-        assertion(async (session, ct) =>
-        {
-            var document = await session.LoadAsync<T>(id, ct).ConfigureAwait(false);
-            if (document != null)
-            {
-                throw new Exception(
-                    $"Document {typeof(T).FullNameInCode()} with id '{id}' exists, but should not.");
-            }
-        }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should not exist or be deleted";
+        documentShouldNotExist(id, (session, ct) => session.LoadAsync<T>(id, ct));
     }
 
     /// <summary>
@@ -158,12 +98,34 @@ public partial class ProjectionScenario
     /// <typeparam name="T">The document type</typeparam>
     public void DocumentShouldNotExist<T>(Guid id) where T : notnull
     {
+        documentShouldNotExist(id, (session, ct) => session.LoadAsync<T>(id, ct));
+    }
+
+    private void documentShouldExist<T>(object id, Func<IQuerySession, CancellationToken, Task<T?>> load,
+        Action<T>? assertions) where T : notnull
+    {
         assertion(async (session, ct) =>
         {
-            var document = await session.LoadAsync<T>(id, ct).ConfigureAwait(false);
+            var document = await load(session, ct).ConfigureAwait(false);
+            if (document == null)
+            {
+                throw new ProjectionScenarioAssertionException(
+                    $"Document {typeof(T).FullNameInCode()} with id '{id}' does not exist");
+            }
+
+            assertions?.Invoke(document);
+        }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should exist";
+    }
+
+    private void documentShouldNotExist<T>(object id, Func<IQuerySession, CancellationToken, Task<T?>> load)
+        where T : notnull
+    {
+        assertion(async (session, ct) =>
+        {
+            var document = await load(session, ct).ConfigureAwait(false);
             if (document != null)
             {
-                throw new Exception(
+                throw new ProjectionScenarioAssertionException(
                     $"Document {typeof(T).FullNameInCode()} with id '{id}' exists, but should not.");
             }
         }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should not exist or be deleted";

--- a/src/Marten/Events/TestSupport/ProjectionScenario.EventOperations.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenario.EventOperations.cs
@@ -1,395 +1,300 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Events;
-using JasperFx.Events.Protected;
 
 namespace Marten.Events.TestSupport;
 
 public partial class ProjectionScenario
 {
-    public StreamAction Append(Guid stream, IEnumerable<object> events)
+    private static string describe(object[] events)
     {
-        var step = action(e => e.Append(stream, events));
-        if (events.Count() > 3)
-        {
-            step.Description = $"Append({stream}, events)";
-        }
-        else
-        {
-            step.Description = $"Append({stream}, {events.Select(x => x.ToString()).Join(", ")})";
-        }
-
-        return StreamAction.Append(_store.Events, stream, events);
+        return events.Length > 3 ? "events" : events.Select(x => x.ToString()).Join(", ");
     }
 
-    public StreamAction Append(Guid stream, params object[] events)
+    /// <summary>
+    ///     Queue appending events to an existing event stream in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream id</param>
+    /// <param name="events">The events to append</param>
+    public void Append(Guid stream, IEnumerable<object> events)
     {
-        var step = action(e => e.Append(stream, events));
-        if (events.Length > 3)
-        {
-            step.Description = $"Append({stream}, events)";
-        }
-        else
-        {
-            step.Description = $"Append({stream}, {events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Append(_store.Events, stream, events);
+        Append(stream, events as object[] ?? events.ToArray());
     }
 
-    public StreamAction Append(string stream, IEnumerable<object> events)
+    /// <summary>
+    ///     Queue appending events to an existing event stream in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream id</param>
+    /// <param name="events">The events to append</param>
+    public void Append(Guid stream, params object[] events)
     {
-        var step = action(e => e.Append(stream, events));
-        if (events.Count() > 3)
-        {
-            step.Description = $"Append('{stream}', events)";
-        }
-        else
-        {
-            step.Description = $"Append('{stream}', {events.Select(x => x.ToString()).Join(", ")})";
-        }
-
-        return StreamAction.Append(_store.Events, stream, events);
+        action(e => e.Append(stream, events)).Description = $"Append({stream}, {describe(events)})";
     }
 
-    public StreamAction Append(string stream, params object[] events)
+    /// <summary>
+    ///     Queue appending events to an existing event stream in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream key</param>
+    /// <param name="events">The events to append</param>
+    public void Append(string stream, IEnumerable<object> events)
     {
-        var step = action(e => e.Append(stream, events));
-        if (events.Length > 3)
-        {
-            step.Description = $"Append('{stream}', events)";
-        }
-        else
-        {
-            step.Description = $"Append('{stream}', {events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Append(_store.Events, stream, events);
+        Append(stream, events as object[] ?? events.ToArray());
     }
 
-    public StreamAction Append(Guid stream, long expectedVersion, params object[] events)
+    /// <summary>
+    ///     Queue appending events to an existing event stream in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream key</param>
+    /// <param name="events">The events to append</param>
+    public void Append(string stream, params object[] events)
     {
-        var step = action(e => e.Append(stream, expectedVersion, events));
-        if (events.Length > 3)
-        {
-            step.Description = $"Append({stream}, {expectedVersion}, events)";
-        }
-        else
-        {
-            step.Description =
-                $"Append({stream}, {expectedVersion}, {events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Append(_store.Events, stream, events);
+        action(e => e.Append(stream, events)).Description = $"Append(\"{stream}\", {describe(events)})";
     }
 
-    public StreamAction Append(string stream, long expectedVersion, IEnumerable<object> events)
+    /// <summary>
+    ///     Queue appending events to an existing event stream with an expected version
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream id</param>
+    /// <param name="expectedVersion">The expected stream version after appending</param>
+    /// <param name="events">The events to append</param>
+    public void Append(Guid stream, long expectedVersion, params object[] events)
     {
-        var step = action(e => e.Append(stream, expectedVersion, events));
-        if (events.Count() > 3)
-        {
-            step.Description = $"Append(\"{stream}\", {expectedVersion}, events)";
-        }
-        else
-        {
-            step.Description =
-                $"Append(\"{stream}\", {expectedVersion}, {events.Select(x => x.ToString()).Join(", ")})";
-        }
-
-        return StreamAction.Append(_store.Events, stream, events);
+        action(e => e.Append(stream, expectedVersion, events)).Description =
+            $"Append({stream}, {expectedVersion}, {describe(events)})";
     }
 
-    public StreamAction Append(string stream, long expectedVersion, params object[] events)
+    /// <summary>
+    ///     Queue appending events to an existing event stream with an expected version
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream key</param>
+    /// <param name="expectedVersion">The expected stream version after appending</param>
+    /// <param name="events">The events to append</param>
+    public void Append(string stream, long expectedVersion, IEnumerable<object> events)
     {
-        var step = action(e => e.Append(stream, expectedVersion, events));
-        if (events.Length > 3)
-        {
-            step.Description = $"Append(\"{stream}\", {expectedVersion}, events)";
-        }
-        else
-        {
-            step.Description =
-                $"Append(\"{stream}\", {expectedVersion}, {events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Append(_store.Events, stream, events);
+        Append(stream, expectedVersion, events as object[] ?? events.ToArray());
     }
 
-    public StreamAction StartStream<TAggregate>(Guid id, params object[] events) where TAggregate : class
+    /// <summary>
+    ///     Queue appending events to an existing event stream with an expected version
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream key</param>
+    /// <param name="expectedVersion">The expected stream version after appending</param>
+    /// <param name="events">The events to append</param>
+    public void Append(string stream, long expectedVersion, params object[] events)
     {
-        var step = action(e => e.StartStream<TAggregate>(id, events));
-        if (events.Length > 3)
-        {
-            step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>({id}, events)";
-        }
-        else
-        {
-            step.Description =
-                $"StartStream<{typeof(TAggregate).FullNameInCode()}>({id}, {events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, id, events);
+        action(e => e.Append(stream, expectedVersion, events)).Description =
+            $"Append(\"{stream}\", {expectedVersion}, {describe(events)})";
     }
 
-    public StreamAction StartStream(Type aggregateType, Guid id, IEnumerable<object> events)
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="id">The stream id</param>
+    /// <param name="events">The initial events</param>
+    /// <typeparam name="TAggregate">The aggregate type for the new stream</typeparam>
+    public void StartStream<TAggregate>(Guid id, params object[] events) where TAggregate : class
     {
-        var step = action(e => e.StartStream(aggregateType, id, events));
-        if (events.Count() > 3)
-        {
-            step.Description = $"StartStream({aggregateType.FullNameInCode()}>({id}, events)";
-        }
-        else
-        {
-            step.Description =
-                $"StartStream({aggregateType.FullNameInCode()}, {id}, {events.Select(x => x.ToString()).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, id, events);
+        action(e => e.StartStream<TAggregate>(id, events)).Description =
+            $"StartStream<{typeof(TAggregate).FullNameInCode()}>({id}, {describe(events)})";
     }
 
-    public StreamAction StartStream(Type aggregateType, Guid id, params object[] events)
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="aggregateType">The aggregate type for the new stream</param>
+    /// <param name="id">The stream id</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(Type aggregateType, Guid id, IEnumerable<object> events)
     {
-        var step = action(e => e.StartStream(aggregateType, id, events));
-        if (events.Length > 3)
-        {
-            step.Description = $"StartStream({aggregateType.FullNameInCode()}>({id}, events)";
-        }
-        else
-        {
-            step.Description =
-                $"StartStream({aggregateType.FullNameInCode()}, {id}, {events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, id, events);
+        StartStream(aggregateType, id, (events as object[] ?? events.ToArray()));
     }
 
-    public StreamAction StartStream<TAggregate>(string streamKey, IEnumerable<object> events)
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="aggregateType">The aggregate type for the new stream</param>
+    /// <param name="id">The stream id</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(Type aggregateType, Guid id, params object[] events)
+    {
+        action(e => e.StartStream(aggregateType, id, events)).Description =
+            $"StartStream({aggregateType.FullNameInCode()}, {id}, {describe(events)})";
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="streamKey">The stream key</param>
+    /// <param name="events">The initial events</param>
+    /// <typeparam name="TAggregate">The aggregate type for the new stream</typeparam>
+    public void StartStream<TAggregate>(string streamKey, IEnumerable<object> events)
         where TAggregate : class
     {
-        var step = action(e => e.StartStream<TAggregate>(streamKey, events));
-        if (events.Count() > 3)
-        {
-            step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>(\"{streamKey}\", events)";
-        }
-        else
-        {
-            step.Description =
-                $"StartStream<{typeof(TAggregate).FullNameInCode()}>(\"{streamKey}\", {events.Select(x => x.ToString()).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, streamKey, events);
+        StartStream<TAggregate>(streamKey, events as object[] ?? events.ToArray());
     }
 
-    public StreamAction StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="streamKey">The stream key</param>
+    /// <param name="events">The initial events</param>
+    /// <typeparam name="TAggregate">The aggregate type for the new stream</typeparam>
+    public void StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class
     {
-        var step = action(e => e.StartStream<TAggregate>(streamKey, events));
-        if (events.Length > 3)
-        {
-            step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>(\"{streamKey}\", events)";
-        }
-        else
-        {
-            step.Description =
-                $"StartStream<{typeof(TAggregate).FullNameInCode()}>(\"{streamKey}\", {events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, streamKey, events);
+        action(e => e.StartStream<TAggregate>(streamKey, events)).Description =
+            $"StartStream<{typeof(TAggregate).FullNameInCode()}>(\"{streamKey}\", {describe(events)})";
     }
 
-    public StreamAction StartStream(Type aggregateType, string streamKey, IEnumerable<object> events)
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="aggregateType">The aggregate type for the new stream</param>
+    /// <param name="streamKey">The stream key</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(Type aggregateType, string streamKey, IEnumerable<object> events)
     {
-        var step = action(e => e.StartStream(aggregateType, streamKey, events));
-        if (events.Count() > 3)
-        {
-            step.Description = $"StartStream({aggregateType.FullNameInCode()}>(\"{streamKey}\", events)";
-        }
-        else
-        {
-            step.Description =
-                $"StartStream({aggregateType.FullNameInCode()}, \"{streamKey}\", {events.Select(x => x.ToString()).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, streamKey, events);
+        StartStream(aggregateType, streamKey, events as object[] ?? events.ToArray());
     }
 
-    public StreamAction StartStream(Type aggregateType, string streamKey, params object[] events)
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="aggregateType">The aggregate type for the new stream</param>
+    /// <param name="streamKey">The stream key</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(Type aggregateType, string streamKey, params object[] events)
     {
-        var step = action(e => e.StartStream(aggregateType, streamKey, events));
-        if (events.Length > 3)
-        {
-            step.Description = $"StartStream({aggregateType.FullNameInCode()}>(\"{streamKey}\", events)";
-        }
-        else
-        {
-            step.Description =
-                $"StartStream({aggregateType.FullNameInCode()}, \"{streamKey}\", {events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, streamKey, events);
+        action(e => e.StartStream(aggregateType, streamKey, events)).Description =
+            $"StartStream({aggregateType.FullNameInCode()}, \"{streamKey}\", {describe(events)})";
     }
 
-    public StreamAction StartStream(Guid id, IEnumerable<object> events)
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="id">The stream id</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(Guid id, IEnumerable<object> events)
     {
-        var step = action(e => e.StartStream(id, events));
-        if (events.Count() > 3)
-        {
-            step.Description = $"StartStream({id}, events)";
-        }
-        else
-        {
-            step.Description = $"StartStream({id}, {events.Select(x => x.ToString()).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, id, events);
+        StartStream(id, events as object[] ?? events.ToArray());
     }
 
-    public StreamAction StartStream(Guid id, params object[] events)
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="id">The stream id</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(Guid id, params object[] events)
     {
-        var step = action(e => e.StartStream(id, events));
-        if (events.Length > 3)
-        {
-            step.Description = $"StartStream({id}, events)";
-        }
-        else
-        {
-            step.Description = $"StartStream({id}, {events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, id, events);
+        action(e => e.StartStream(id, events)).Description = $"StartStream({id}, {describe(events)})";
     }
 
-    public StreamAction StartStream(string streamKey, IEnumerable<object> events)
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="streamKey">The stream key</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(string streamKey, IEnumerable<object> events)
     {
-        var step = action(e => e.StartStream(streamKey, events));
-        if (events.Count() > 3)
-        {
-            step.Description = $"StartStream(\"{streamKey}\", events)";
-        }
-        else
-        {
-            step.Description = $"StartStream(\"{streamKey}\", {events.Select(x => x.ToString()).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, streamKey, events);
+        StartStream(streamKey, events as object[] ?? events.ToArray());
     }
 
-    public StreamAction StartStream(string streamKey, params object[] events)
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="streamKey">The stream key</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(string streamKey, params object[] events)
     {
-        var step = action(e => e.StartStream(streamKey, events));
-        if (events.Length > 3)
-        {
-            step.Description = $"StartStream(\"{streamKey}\", events)";
-        }
-        else
-        {
-            step.Description = $"StartStream(\"{streamKey}\", {events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, streamKey, events);
+        action(e => e.StartStream(streamKey, events)).Description =
+            $"StartStream(\"{streamKey}\", {describe(events)})";
     }
 
-    public StreamAction StartStream<TAggregate>(IEnumerable<object> events) where TAggregate : class
+    /// <summary>
+    ///     Queue starting a new event stream with a newly generated stream id
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="events">The initial events</param>
+    /// <typeparam name="TAggregate">The aggregate type for the new stream</typeparam>
+    /// <returns>The generated id of the new stream</returns>
+    public Guid StartStream<TAggregate>(IEnumerable<object> events) where TAggregate : class
+    {
+        return StartStream<TAggregate>(events as object[] ?? events.ToArray());
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream with a newly generated stream id
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="events">The initial events</param>
+    /// <typeparam name="TAggregate">The aggregate type for the new stream</typeparam>
+    /// <returns>The generated id of the new stream</returns>
+    public Guid StartStream<TAggregate>(params object[] events) where TAggregate : class
     {
         var streamId = Guid.NewGuid();
-        var step = action(e => e.StartStream<TAggregate>(streamId, events));
-        if (events.Count() > 3)
-        {
-            step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>(events)";
-        }
-        else
-        {
-            step.Description =
-                $"StartStream<{typeof(TAggregate).FullNameInCode()}>({events.Select(x => x.ToString()).Join(", ")})";
-        }
+        action(e => e.StartStream<TAggregate>(streamId, events)).Description =
+            $"StartStream<{typeof(TAggregate).FullNameInCode()}>({streamId}, {describe(events)})";
 
-        return StreamAction.Start(_store.Events, streamId, events);
+        return streamId;
     }
 
-    public StreamAction StartStream<TAggregate>(params object[] events) where TAggregate : class
+    /// <summary>
+    ///     Queue starting a new event stream with a newly generated stream id
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="aggregateType">The aggregate type for the new stream</param>
+    /// <param name="events">The initial events</param>
+    /// <returns>The generated id of the new stream</returns>
+    public Guid StartStream(Type aggregateType, IEnumerable<object> events)
     {
-        var streamId = Guid.NewGuid();
-        var step = action(e => e.StartStream<TAggregate>(streamId, events));
-        if (events.Length > 3)
-        {
-            step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>(events)";
-        }
-        else
-        {
-            step.Description =
-                $"StartStream<{typeof(TAggregate).FullNameInCode()}>({events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, streamId, events);
+        return StartStream(aggregateType, events as object[] ?? events.ToArray());
     }
 
-    public StreamAction StartStream(Type aggregateType, IEnumerable<object> events)
+    /// <summary>
+    ///     Queue starting a new event stream with a newly generated stream id
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="aggregateType">The aggregate type for the new stream</param>
+    /// <param name="events">The initial events</param>
+    /// <returns>The generated id of the new stream</returns>
+    public Guid StartStream(Type aggregateType, params object[] events)
     {
         var streamId = Guid.NewGuid();
-        var step = action(e => e.StartStream(aggregateType, streamId, events));
-        if (events.Count() > 3)
-        {
-            step.Description = $"StartStream({aggregateType.FullNameInCode()}>(events)";
-        }
-        else
-        {
-            step.Description =
-                $"StartStream({aggregateType.FullNameInCode()}, {events.Select(x => x.ToString()!).Join(", ")})";
-        }
+        action(e => e.StartStream(aggregateType, streamId, events)).Description =
+            $"StartStream({aggregateType.FullNameInCode()}, {streamId}, {describe(events)})";
 
-        return StreamAction.Start(_store.Events, streamId, events);
+        return streamId;
     }
 
-    public StreamAction StartStream(Type aggregateType, params object[] events)
+    /// <summary>
+    ///     Queue starting a new event stream with a newly generated stream id
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="events">The initial events</param>
+    /// <returns>The generated id of the new stream</returns>
+    public Guid StartStream(IEnumerable<object> events)
     {
-        var streamId = Guid.NewGuid();
-        var step = action(e => e.StartStream(aggregateType, streamId, events));
-        if (events.Length > 3)
-        {
-            step.Description = $"StartStream({aggregateType.FullNameInCode()}>(events)";
-        }
-        else
-        {
-            step.Description =
-                $"StartStream({aggregateType.FullNameInCode()}, {events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, streamId, events);
+        return StartStream(events as object[] ?? events.ToArray());
     }
 
-    public StreamAction StartStream(IEnumerable<object> events)
+    /// <summary>
+    ///     Queue starting a new event stream with a newly generated stream id
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="events">The initial events</param>
+    /// <returns>The generated id of the new stream</returns>
+    public Guid StartStream(params object[] events)
     {
         var streamId = Guid.NewGuid();
-        var step = action(e => e.StartStream(streamId, events));
-        if (events.Count() > 3)
-        {
-            step.Description = "StartStream(events)";
-        }
-        else
-        {
-            step.Description = $"StartStream({events.Select(x => x.ToString()!).Join(", ")})";
-        }
+        action(e => e.StartStream(streamId, events)).Description =
+            $"StartStream({streamId}, {describe(events)})";
 
-        return StreamAction.Start(_store.Events, streamId, events);
-    }
-
-    public StreamAction StartStream(params object[] events)
-    {
-        var streamId = Guid.NewGuid();
-        var step = action(e => e.StartStream(streamId, events));
-        if (events.Length > 3)
-        {
-            step.Description = "StartStream(events)";
-        }
-        else
-        {
-            step.Description = $"StartStream({events.Select(x => x.ToString()!).Join(", ")})";
-        }
-
-        return StreamAction.Start(_store.Events, streamId, events);
+        return streamId;
     }
 
     /// <summary>
@@ -409,17 +314,5 @@ public partial class ProjectionScenario
     public void AppendEvents(Action<IEventOperations> appendAction)
     {
         AppendEvents("Appending events...", appendAction);
-    }
-
-    public Task CompactStreamAsync<T>(string streamKey, Action<StreamCompactingRequest<T>>? configure = null)
-        where T : class
-    {
-        throw new NotSupportedException();
-    }
-
-    public Task CompactStreamAsync<T>(Guid streamId, Action<StreamCompactingRequest<T>>? configure = null)
-        where T : class
-    {
-        throw new NotSupportedException();
     }
 }

--- a/src/Marten/Events/TestSupport/ProjectionScenario.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenario.cs
@@ -9,43 +9,50 @@ using Marten.Events.Daemon;
 
 namespace Marten.Events.TestSupport;
 
-public partial class ProjectionScenario: IEventOperations
+public partial class ProjectionScenario
 {
     private readonly Queue<ScenarioStep> _steps = new();
     private readonly DocumentStore _store;
+    private bool _hasExecuted;
 
-
-    public ProjectionScenario(DocumentStore store)
+    internal ProjectionScenario(DocumentStore store)
     {
         _store = store;
     }
 
-    internal IProjectionDaemon Daemon { get; private set; }
+    internal IProjectionDaemon? Daemon { get; private set; }
 
     internal ScenarioStep? NextStep => _steps.Count != 0 ? _steps.Peek() : null;
 
-    internal IDocumentSession Session { get; private set; }
+    internal IDocumentSession? Session { get; private set; }
 
     /// <summary>
-    ///     Disable the scenario from "cleaning" out any existing
-    ///     event and projected document data before running the scenario
+    ///     The scenario deletes all existing event data plus the storage for every
+    ///     registered projection before running. Set this to false to run the
+    ///     scenario on top of whatever data already exists
     /// </summary>
-    public bool DoNotDeleteExistingData { get; set; }
+    public bool DeleteExistingData { get; set; } = true;
 
     /// <summary>
     ///     Opt into applying this scenario to a specific tenant id in the
     ///     case of using multi-tenancy of any kind
     /// </summary>
-    public string TenantId { get; set; }
+    public string? TenantId { get; set; }
 
-    internal Task WaitForNonStaleData()
+    /// <summary>
+    ///     Maximum time the scenario waits for any asynchronous projections to
+    ///     catch up after each batch of appended events. Default is 30 seconds
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = 30.Seconds();
+
+    internal Task WaitForNonStaleData(CancellationToken ct = default)
     {
         if (Daemon == null)
         {
             return Task.CompletedTask;
         }
 
-        return Daemon.WaitForNonStaleData(30.Seconds());
+        return Daemon.WaitForNonStaleData(Timeout).WaitAsync(ct);
     }
 
 
@@ -67,7 +74,15 @@ public partial class ProjectionScenario: IEventOperations
 
     internal async Task Execute(CancellationToken ct = default)
     {
-        if (!DoNotDeleteExistingData)
+        if (_hasExecuted)
+        {
+            throw new InvalidOperationException(
+                "This ProjectionScenario has already been executed and its steps have been consumed. Build and run a new scenario with DocumentStore.Advanced.EventProjectionScenario() instead");
+        }
+
+        _hasExecuted = true;
+
+        if (DeleteExistingData)
         {
             await _store.Advanced.Clean.DeleteAllEventDataAsync(ct).ConfigureAwait(false);
             foreach (var storageType in
@@ -88,6 +103,7 @@ public partial class ProjectionScenario: IEventOperations
             var exceptions = new List<Exception>();
             var number = 0;
             var descriptions = new List<string>();
+            var actionFailed = false;
 
             while (_steps.Any())
             {
@@ -104,6 +120,22 @@ public partial class ProjectionScenario: IEventOperations
                     descriptions.Add($"FAILED: {number.ToString().PadLeft(3)}. {step.Description}");
                     descriptions.Add(e.ToString());
                     exceptions.Add(e);
+
+                    // A failed action means every later step would run against a state nobody
+                    // intended, so stop right here instead of piling up cascading noise. Failed
+                    // assertions keep accumulating -- the state is still the intended one.
+                    if (step is ScenarioAction)
+                    {
+                        actionFailed = true;
+                        if (_steps.Count != 0)
+                        {
+                            descriptions.Add(
+                                $"Skipped the remaining {_steps.Count} step(s) after the failed action");
+                            _steps.Clear();
+                        }
+
+                        break;
+                    }
                 }
             }
 
@@ -113,17 +145,21 @@ public partial class ProjectionScenario: IEventOperations
             // and an arrange-only scenario should not be a silent no-op that passes. See #5126.
             //
             // Unconditional on purpose: SaveChangesAsync returns immediately when the unit of work is
-            // empty, and WaitForNonStaleData is already a no-op when no daemon is running.
-            try
+            // empty, and WaitForNonStaleData is already a no-op when no daemon is running. Skipped when
+            // an action failed -- the session may hold a partially built unit of work at that point.
+            if (!actionFailed)
             {
-                await Session.SaveChangesAsync(ct).ConfigureAwait(false);
-                await WaitForNonStaleData().ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                descriptions.Add($"FAILED: committing the events queued by the final step");
-                descriptions.Add(e.ToString());
-                exceptions.Add(e);
+                try
+                {
+                    await Session.SaveChangesAsync(ct).ConfigureAwait(false);
+                    await WaitForNonStaleData(ct).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    descriptions.Add("FAILED: committing the events queued by the final step");
+                    descriptions.Add(e.ToString());
+                    exceptions.Add(e);
+                }
             }
 
             if (exceptions.Any())

--- a/src/Marten/Events/TestSupport/ProjectionScenarioAssertionException.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenarioAssertionException.cs
@@ -1,0 +1,15 @@
+using Marten.Exceptions;
+
+namespace Marten.Events.TestSupport;
+
+/// <summary>
+///     Thrown when a single ProjectionScenario assertion fails, e.g. a document that should
+///     exist does not. Lets test code and tooling distinguish scenario assertion failures
+///     from infrastructure failures inside the aggregated ProjectionScenarioException
+/// </summary>
+public class ProjectionScenarioAssertionException: MartenException
+{
+    public ProjectionScenarioAssertionException(string message): base(message)
+    {
+    }
+}

--- a/src/Marten/Events/TestSupport/ScenarioAction.cs
+++ b/src/Marten/Events/TestSupport/ScenarioAction.cs
@@ -15,12 +15,12 @@ internal class ScenarioAction: ScenarioStep
 
     public override async Task Execute(ProjectionScenario scenario, CancellationToken ct = default)
     {
-        _action(scenario.Session.Events);
+        _action(scenario.Session!.Events);
 
         if (scenario.NextStep is ScenarioAssertion)
         {
-            await scenario.Session.SaveChangesAsync(ct).ConfigureAwait(false);
-            await scenario.WaitForNonStaleData().ConfigureAwait(false);
+            await scenario.Session!.SaveChangesAsync(ct).ConfigureAwait(false);
+            await scenario.WaitForNonStaleData(ct).ConfigureAwait(false);
         }
     }
 }

--- a/src/Marten/Events/TestSupport/ScenarioAssertion.cs
+++ b/src/Marten/Events/TestSupport/ScenarioAssertion.cs
@@ -15,6 +15,6 @@ internal class ScenarioAssertion: ScenarioStep
 
     public override Task Execute(ProjectionScenario scenario, CancellationToken ct = default)
     {
-        return _check(scenario.Session, ct);
+        return _check(scenario.Session!, ct);
     }
 }

--- a/src/Marten/Events/TestSupport/ScenarioStep.cs
+++ b/src/Marten/Events/TestSupport/ScenarioStep.cs
@@ -5,7 +5,7 @@ namespace Marten.Events.TestSupport;
 
 internal abstract class ScenarioStep
 {
-    public string Description { get; set; }
+    public string Description { get; set; } = string.Empty;
 
     public abstract Task Execute(ProjectionScenario scenario, CancellationToken ct = default);
 }


### PR DESCRIPTION
Closes #5127

Full quality pass over `Marten.Events.TestSupport` per the findings in #5127, done ahead of the planned cross-store lift into JasperFx.Events so the shared surface starts from the fixed shape. Breaking changes were explicitly authorized — the feature has near-zero external use.

## API changes (breaking)

- **`ProjectionScenario` no longer implements `IEventOperations`** (finding 1). The `Append`/`StartStream` methods only ever queued a closure; the `StreamAction` they returned was a disconnected throwaway. They now return `void` — except the `StartStream` overloads that generate their own stream id, which return that `Guid` so tests can capture it for later assertions. The two never-implemented `CompactStreamAsync` stubs disappear with the interface.
- **`DoNotDeleteExistingData` → `DeleteExistingData` (default `true`)** (finding 3). No more double negative on an API that wipes the database by default.
- **The constructor is now `internal`** (finding 5). `DocumentStore.Advanced.EventProjectionScenario()` was always the intended entry point; a directly-constructed scenario could be configured but never run.
- **Nullability** (finding 9): `TenantId` is `string?`; the internal `Daemon`/`Session` properties are nullable.

## Behavior changes

- **Typed assertion failures** (finding 2): `DocumentShouldExist`/`DocumentShouldNotExist` throw the new `ProjectionScenarioAssertionException` (derives from `MartenException`, satisfying the CoreTests exception convention) instead of bare `Exception`.
- **Fail-fast on actions, accumulate on assertions** (finding 11): a failed action step stops the scenario and reports how many steps were skipped, instead of running every later step against a state nobody intended. Failed assertions still accumulate into one `ProjectionScenarioException`.
- **Re-execution guard** (finding 10): running a scenario twice throws `InvalidOperationException` instead of silently doing nothing.
- **Configurable wait** (finding 8): new `Timeout` property (default 30s) replaces the hard-coded `WaitForNonStaleData` timeout, and the scenario's `CancellationToken` now applies to that wait.

## Internal cleanup

- The eight copy-pasted assertion bodies collapse into two private helpers over `object id` (finding 6) — the same shape the JasperFx.Events compliance tests use, which should make the lift mechanical.
- `IEnumerable<object>` overloads materialize the sequence once instead of walking it up to three times (finding 7); the 24 append/start-stream overloads now share single-line bodies with a common description helper.

## Docs (finding 4)

New "Scripted Scenarios with EventProjectionScenario" section on [Testing Projections](https://martendb.io/events/projections/testing.html), with a snippet region added around the canonical happy-path test. The feature was previously undocumented. markdownlint + cspell pass locally with CI args.

## Tests

Five new tests in `projection_scenario_quality_tests.cs`: typed assertion exception, action fail-fast + skip reporting, returned generated stream id, re-execute guard, and `DeleteExistingData = false`. Scenario suite (8 existing + 2 from #5126 + 5 new) is 15/15 on net9.0; full `Marten.slnx` builds clean.

## Relationship to other work

- Builds on the #5126 fix (#5130), already on master.
- JasperFx/polecat#404 — recommend **not** porting the missing overloads to Polecat now; the collapsed shape here is what the JasperFx.Events lift should mirror, and that lift supersedes both ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)