### PR TITLE
Container-scoped projections work with live aggregation and are validated

### DIFF
--- a/src/ContainerScopedProjectionTests/Bug_5095_scoped_projection_live_aggregation.cs
+++ b/src/ContainerScopedProjectionTests/Bug_5095_scoped_projection_live_aggregation.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Exceptions;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace ContainerScopedProjectionTests;
+
+/// <summary>
+/// Repro for https://github.com/JasperFx/marten/issues/5095.
+///
+/// A projection registered through <c>AddProjectionWithServices</c> with a Scoped or
+/// Transient lifetime is wrapped in <c>ScopedAggregationWrapper</c>. That wrapper does
+/// not implement <c>IAggregatorSource&lt;TQuerySession&gt;</c>, so
+/// <c>ProjectionGraph.AggregatorFor&lt;T&gt;()</c> never finds it: the lookup falls
+/// through <c>tryFindProjectionSourceForAggregateType</c> to the conventional
+/// aggregation built off the aggregate type itself. Every native aggregation path --
+/// <c>AggregateStreamAsync</c>, <c>RebuildSingleStreamAsync</c>, <c>AggregateToAsync</c>
+/// -- therefore silently ignores the projection's own logic. Registering the same
+/// projection as a Singleton exposes the real projection and everything works.
+///
+/// Separately, <c>ProjectionSourceWrapperBase</c>'s constructor copies name/version/
+/// options off the resolved source but never calls <c>AssembleAndAssertValidity()</c>
+/// on it, so an invalid projection that a Singleton registration rejects at startup is
+/// silently accepted when registered Scoped.
+///
+/// The aggregates here deliberately have NO conventional Create/Apply methods, so the
+/// conventional fallback cannot accidentally produce a correct-looking answer -- the
+/// projection's Evolve override is the only thing that can build them.
+/// </summary>
+[Collection("ioc")]
+public class Bug_5095_scoped_projection_live_aggregation
+{
+    [Theory]
+    [InlineData(ServiceLifetime.Singleton)]
+    [InlineData(ServiceLifetime.Scoped)]
+    [InlineData(ServiceLifetime.Transient)]
+    public async Task live_aggregation_uses_the_registered_projection(ServiceLifetime lifetime)
+    {
+        var streamId = Guid.NewGuid();
+        using var host = await startHost<TallyProjection>($"b5095_live_{suffix(lifetime)}", lifetime);
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Tally>(streamId, new Incremented(2), new Incremented(3));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        var tally = await query.Events.AggregateStreamAsync<Tally>(streamId);
+
+        tally.ShouldNotBeNull();
+        // The projection multiplies by the injected factor of 10; conventional
+        // aggregation off Tally would have no way to produce this (or anything).
+        tally.Total.ShouldBe(50);
+    }
+
+    [Theory]
+    [InlineData(ServiceLifetime.Singleton)]
+    [InlineData(ServiceLifetime.Scoped)]
+    [InlineData(ServiceLifetime.Transient)]
+    public async Task rebuild_single_stream_uses_the_registered_projection(ServiceLifetime lifetime)
+    {
+        var streamId = Guid.NewGuid();
+        using var host = await startHost<TallyProjection>($"b5095_rebuild_{suffix(lifetime)}", lifetime);
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Tally>(streamId, new Incremented(2), new Incremented(3));
+            await session.SaveChangesAsync();
+        }
+
+        await store.Advanced.RebuildSingleStreamAsync<Tally>(streamId);
+
+        await using var query = store.QuerySession();
+        var tally = await query.LoadAsync<Tally>(streamId);
+
+        tally.ShouldNotBeNull();
+        tally.Total.ShouldBe(50);
+    }
+
+    [Theory]
+    [InlineData(ServiceLifetime.Singleton)]
+    [InlineData(ServiceLifetime.Scoped)]
+    [InlineData(ServiceLifetime.Transient)]
+    public async Task invalid_projection_is_rejected_at_configuration_regardless_of_lifetime(
+        ServiceLifetime lifetime)
+    {
+        // InvalidTally has a public constructor taking an event -- a conventional
+        // aggregate handler -- while InvalidTallyProjection overrides EvolveAsync.
+        // Mixing the two is a configuration error Marten rejects for a Singleton.
+        await Should.ThrowAsync<InvalidProjectionException>(async () =>
+        {
+            using var host = await startHost<InvalidTallyProjection>(
+                $"b5095_invalid_{suffix(lifetime)}", lifetime);
+
+            // Building the store is what runs validation
+            var store = host.Services.GetRequiredService<IDocumentStore>();
+            await using var session = store.LightweightSession();
+            await session.SaveChangesAsync();
+        });
+    }
+
+    private static string suffix(ServiceLifetime lifetime) => lifetime.ToString().ToLowerInvariant();
+
+    private static async Task<IHost> startHost<TProjection>(string schema, ServiceLifetime lifetime)
+        where TProjection : class, IMartenRegistrable
+    {
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync(schema);
+            await conn.CloseAsync();
+        }
+
+        return await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IMultiplier>(new Multiplier(10));
+
+                services.AddMarten(opts =>
+                    {
+                        opts.Connection(ConnectionSource.ConnectionString);
+                        opts.DatabaseSchemaName = schema;
+                    })
+                    .AddProjectionWithServices<TProjection>(ProjectionLifecycle.Inline, lifetime);
+            })
+            .StartAsync();
+    }
+}
+
+public interface IMultiplier
+{
+    int Factor { get; }
+}
+
+public class Multiplier: IMultiplier
+{
+    public Multiplier(int factor) => Factor = factor;
+    public int Factor { get; }
+}
+
+public record Incremented(int Amount);
+
+/// <summary>
+/// Deliberately has no conventional Create/Apply methods -- only the projection can build it.
+/// </summary>
+public class Tally
+{
+    public Guid Id { get; set; }
+    public int Total { get; set; }
+}
+
+public class TallyProjection: SingleStreamProjection<Tally, Guid>
+{
+    private readonly IMultiplier _multiplier;
+
+    public TallyProjection(IMultiplier multiplier)
+    {
+        _multiplier = multiplier;
+    }
+
+    public override Tally? Evolve(Tally? snapshot, Guid id, IEvent e)
+    {
+        snapshot ??= new Tally { Id = id };
+
+        if (e.Data is Incremented incremented)
+        {
+            snapshot.Total += incremented.Amount * _multiplier.Factor;
+        }
+
+        return snapshot;
+    }
+}
+
+/// <summary>
+/// Invalid on purpose: a public constructor taking an event is a conventional aggregate
+/// handler, and the projection also overrides EvolveAsync.
+/// </summary>
+public class InvalidTally
+{
+    public InvalidTally()
+    {
+    }
+
+    public InvalidTally(Incremented incremented)
+    {
+        Total = incremented.Amount;
+    }
+
+    public Guid Id { get; set; }
+    public int Total { get; set; }
+}
+
+public class InvalidTallyProjection: SingleStreamProjection<InvalidTally, Guid>
+{
+    private readonly IMultiplier _multiplier;
+
+    public InvalidTallyProjection(IMultiplier multiplier)
+    {
+        _multiplier = multiplier;
+    }
+
+    public override ValueTask<InvalidTally?> EvolveAsync(InvalidTally? snapshot, Guid id, IQuerySession session,
+        IEvent e, System.Threading.CancellationToken cancellation)
+    {
+        snapshot ??= new InvalidTally { Id = id };
+
+        if (e.Data is Incremented incremented)
+        {
+            snapshot.Total += incremented.Amount * _multiplier.Factor;
+        }
+
+        return new ValueTask<InvalidTally?>(snapshot);
+    }
+}

--- a/src/Marten/Events/Aggregation/SingleStreamProjection.cs
+++ b/src/Marten/Events/Aggregation/SingleStreamProjection.cs
@@ -78,11 +78,9 @@ public class SingleStreamProjection<TDoc, TId>:
                 services.AddScoped<TConcrete>();
                 services.ConfigureMarten((s, opts) =>
                 {
-                    var wrapper =
-                        typeof(ScopedAggregationWrapper<,,,,>)
-                            .CloseAndBuildAs<ProjectionBase>(s,
-                                typeof(TConcrete), typeof(TDoc), typeof(TId), typeof(IDocumentOperations),
-                                typeof(IQuerySession));
+                    var wrapper = ScopedAggregationWrapper.Build(s,
+                        typeof(TConcrete), typeof(TDoc), typeof(TId), typeof(IDocumentOperations),
+                        typeof(IQuerySession));
 
                     wrapper.Lifecycle = lifecycle;
                     configure?.Invoke(wrapper);
@@ -113,11 +111,9 @@ public class SingleStreamProjection<TDoc, TId>:
                 services.AddScoped<TConcrete>();
                 services.ConfigureMarten<TStore>((s, opts) =>
                 {
-                    var wrapper =
-                        typeof(ScopedAggregationWrapper<,,,,>)
-                            .CloseAndBuildAs<ProjectionBase>(s,
-                                typeof(TConcrete), typeof(TDoc), typeof(TId), typeof(IDocumentOperations),
-                                typeof(IQuerySession));
+                    var wrapper = ScopedAggregationWrapper.Build(s,
+                        typeof(TConcrete), typeof(TDoc), typeof(TId), typeof(IDocumentOperations),
+                        typeof(IQuerySession));
 
                     wrapper.Lifecycle = lifecycle;
                     configure?.Invoke(wrapper);

--- a/src/Marten/Events/Projections/CompositeProjection.cs
+++ b/src/Marten/Events/Projections/CompositeProjection.cs
@@ -239,9 +239,8 @@ internal class CompositeProjectionWithServicesSource<TProjection> :
         else if (_aggregateType != null && _identityType != null)
         {
             var projectionServices = new ProjectionActivatingServiceProvider<TProjection>(services);
-            source = typeof(ScopedAggregationWrapper<,,,,>)
-                .CloseAndBuildAs<ProjectionBase>(projectionServices, typeof(TProjection), _aggregateType, _identityType,
-                    typeof(IDocumentOperations), typeof(IQuerySession))
+            source = ScopedAggregationWrapper.Build(projectionServices, typeof(TProjection), _aggregateType,
+                    _identityType, typeof(IDocumentOperations), typeof(IQuerySession))
                 .As<IProjectionSource<IDocumentOperations, IQuerySession>>();
         }
         else

--- a/src/Marten/Events/Projections/MultiStreamProjection.cs
+++ b/src/Marten/Events/Projections/MultiStreamProjection.cs
@@ -96,11 +96,9 @@ public abstract class MultiStreamProjection<TDoc, TId>: JasperFxMultiStreamProje
                 services.AddScoped<TConcrete>();
                 services.ConfigureMarten((s, opts) =>
                 {
-                    var wrapper =
-                        typeof(ScopedAggregationWrapper<,,,,>)
-                            .CloseAndBuildAs<ProjectionBase>(s,
-                                typeof(TConcrete), typeof(TDoc), typeof(TId), typeof(IDocumentOperations),
-                                typeof(IQuerySession));
+                    var wrapper = ScopedAggregationWrapper.Build(s,
+                        typeof(TConcrete), typeof(TDoc), typeof(TId), typeof(IDocumentOperations),
+                        typeof(IQuerySession));
 
                     wrapper.Lifecycle = lifecycle;
                     configure?.Invoke(wrapper);
@@ -132,11 +130,9 @@ public abstract class MultiStreamProjection<TDoc, TId>: JasperFxMultiStreamProje
                 services.AddScoped<TConcrete>();
                 services.ConfigureMarten<TStore>((s, opts) =>
                 {
-                    var wrapper =
-                        typeof(ScopedAggregationWrapper<,,,,>)
-                            .CloseAndBuildAs<ProjectionBase>(s,
-                                typeof(TConcrete), typeof(TDoc), typeof(TId), typeof(IDocumentOperations),
-                                typeof(IQuerySession));
+                    var wrapper = ScopedAggregationWrapper.Build(s,
+                        typeof(TConcrete), typeof(TDoc), typeof(TId), typeof(IDocumentOperations),
+                        typeof(IQuerySession));
 
                     wrapper.Lifecycle = lifecycle;
                     configure?.Invoke(wrapper);


### PR DESCRIPTION
Closes #5095. Consumes JasperFx/jasperfx#617.

> [!IMPORTANT]
> **Draft: blocked on JasperFx.Events 2.38.0.** The pin here is the *intended* published version; jasperfx#617 is open, not published. Everything below was verified against a local pack of that branch and needs re-verification against the real package before this leaves draft.

## The bug

A projection registered through `AddProjectionWithServices` with a **Scoped or Transient** lifetime is wrapped in `ScopedAggregationWrapper`, and two things went wrong as a result.

**Native aggregation silently ran the wrong thing.** The wrapper doesn't implement `IAggregatorSource`, so `AggregatorFor<T>()` never found it and fell through to conventional aggregation built off the aggregate type. `AggregateStreamAsync<T>` and `RebuildSingleStreamAsync<T>` therefore ignored the registered projection's logic entirely — no error, just a different answer. Registering the same projection as a Singleton worked, which is the asymmetry the reporter hit.

**Validation was hidden.** The wrapper's base constructor copied name/version/options off the resolved projection but never called `AssembleAndAssertValidity()` on it — only the wrapper was validated. A projection that a Singleton registration rejects at startup was silently accepted when registered Scoped, so switching lifetime later would surface a configuration error that had been there all along.

## What changed in Marten

Small — the real work is in jasperfx#617. The four `Register` overloads in `SingleStreamProjection` / `MultiStreamProjection`, plus `CompositeProjection`, now call `ScopedAggregationWrapper.Build(...)` instead of closing `typeof(ScopedAggregationWrapper<,,,,>)` themselves. That helper picks the single-stream wrapper (which can serve live aggregation) or the general one, and unwraps the reflection `TargetInvocationException` so a configuration error surfaces as the real `InvalidProjectionException` instead of a reflection wrapper.

Multi-stream deliberately keeps the general wrapper: only single-stream projections implement `IAggregator`, and exposing multi-stream to `AggregatorFor` would be new behavior the Singleton path doesn't have.

## Test

`Bug_5095_scoped_projection_live_aggregation` is a 3×3 matrix — {live aggregation, single stream rebuild, invalid-projection validation} × {Singleton, Scoped, Transient}.

The aggregate deliberately has **no** conventional `Create`/`Apply` methods, so the conventional fallback can't accidentally produce a correct-looking answer; the projection's `Evolve` (which multiplies by an injected factor) is the only thing that can build it.

| | before | after |
|---|---|---|
| Repro matrix | 3 passed / 6 failed | **9 passed** |

Every pre-fix failure was Scoped or Transient; every Singleton case passed throughout.

## Regression sweep (net9.0)

`ContainerScopedProjectionTests` 80/80 · `EventSourcingTests` 1614/1614 · `DaemonTests` 267/267 · full `Marten.slnx` builds clean. `AggregatorFor` is on the hot path for all live aggregation, so the two large suites are the meaningful signal here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)