### PR TITLE
Bump JasperFx to 2.38.0 and Weasel to 9.23.2, adopt compliance wave 3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -184,21 +184,31 @@
          Also stops `Store<object>(...)` registering `object` itself as a document type: registrability
          is now a SpecialType/TypeKind question, because object/string render through ToDisplayString()
          as C# keywords and slipped past the old name-prefix check. New JFXEVT005 (Info) flags a call
-         that binds to the projection's session but whose document type cannot be named. -->
-    <PackageVersion Include="JasperFx" Version="2.37.3" />
-    <PackageVersion Include="JasperFx.Events" Version="2.37.3" />
+         that binds to the projection's session but whose document type cannot be named.
+         JasperFx 2.38.0: two changes Marten consumes directly.
+         jasperfx#616 (marten#5127) — the ProjectionScenario test harness is lifted into a new
+         JasperFx.Events.TestSupport namespace so Marten and Polecat share one implementation
+         instead of maintaining parallel ports.
+         jasperfx#617 (marten#5095) — a projection registered through AddProjectionWithServices with
+         a Scoped/Transient lifetime is now reachable from AggregatorFor, so live aggregation and
+         single stream rebuilds run the actual projection instead of silently falling through to
+         conventional aggregation off the aggregate type; and the projection a scoped wrapper wraps
+         is validated rather than only the wrapper, so an invalid configuration fails at startup for
+         every lifetime instead of only Singleton. -->
+    <PackageVersion Include="JasperFx" Version="2.38.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.38.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.37.3" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.37.3">
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.38.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.38.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.37.3" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.38.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
@@ -249,7 +259,7 @@
     <PackageVersion Include="Vogen" Version="7.0.0" />
     <!-- 9.16.2: the hold at 9.2.1 (were newer builds actually being published?) is resolved —
          Weasel.EntityFrameworkCore is on nuget.org, so it tracks the rest of the Weasel line. -->
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.23.1" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.23.2" />
     <!-- Weasel.Postgresql 9.1.x: managed LIST partitions under multi-database (sharded) apply.
          9.1.2 (marten#4706): managed-partition tables are no longer destructively rebuilt — the
          out-of-band AddPartitionToAllTables path creates partitions while the generic schema diff
@@ -339,9 +349,12 @@
          9.23.1 (weasel#420/#422): the same weasel#416 identifier validation extended to the other
          provider migrators (SQL Server previously validated nothing at all; Oracle, MySQL and Sqlite
          each missed their own quoting characters), with the PostgreSQL check folded onto the shared
-         Weasel.Core helper so the providers cannot drift apart again. -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.23.1" />
-    <PackageVersion Include="Weasel.Storage" Version="9.23.1" />
+         Weasel.Core helper so the providers cannot drift apart again.
+         9.23.2 (weasel#424/#425): Sqlite and MySql implement the non-generic
+         Weasel.Core.ICommandBuilder (weasel#423), and the JasperFx line moves to 2.38.0 so this
+         matrix stays coherent with the JasperFx pins above rather than resolving transitively. -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.23.2" />
+    <PackageVersion Include="Weasel.Storage" Version="9.23.2" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <!-- The whole test suite is on xunit v3. VSTest stays the execution mode, so the
          Nuke targets and the GitHub workflows are unaffected. -->

--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance.cs
@@ -34,3 +34,9 @@ public class event_projection_enrichment_compliance
 
 public class rebuild_concurrency_cap_compliance
     : RebuildConcurrencyCapCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+public class activity_correlation_compliance
+    : ActivityCorrelationCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+public class string_identity_single_stream_compliance
+    : StringIdentitySingleStreamCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;

--- a/src/Marten.Testing/Harness/ComplianceQuerySessionAlias.cs
+++ b/src/Marten.Testing/Harness/ComplianceQuerySessionAlias.cs
@@ -8,3 +8,10 @@ global using ComplianceQuerySession = Marten.IQuerySession;
 // they cannot reach the <TOperations, TQuerySession> pair their suite class is generic over.
 global using ComplianceOperations = Marten.IDocumentOperations;
 global using ComplianceEventProjection = Marten.Events.Projections.EventProjection;
+
+// The string stream identity suite (JasperFx compliance wave 3) declares a custom single stream
+// projection at file scope, so it cannot reach its suite class's <TOperations, TQuerySession>
+// generics either. Each product subclasses JasperFxSingleStreamProjectionBase under its own name,
+// so the base type comes in through this alias.
+global using ComplianceStringPartyProjectionBase =
+    Marten.Events.Aggregation.SingleStreamProjection<JasperFx.Events.ComplianceTests.StringQuestParty, string>;

--- a/src/Marten.Testing/Harness/MartenComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenComplianceFixture.cs
@@ -39,6 +39,17 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
             options.Projections.MaxConcurrentRebuildsPerDatabase = config.MaxConcurrentRebuildsPerDatabase;
         }
 
+        if (config.StreamIdentity.HasValue)
+        {
+            options.Events.StreamIdentity = config.StreamIdentity.Value;
+        }
+
+        if (config.EnableCorrelationTracking)
+        {
+            options.Events.MetadataConfig.CorrelationIdEnabled = true;
+            options.Events.MetadataConfig.CausationIdEnabled = true;
+        }
+
         config.ApplyTo(new MartenComplianceRegistrar(options));
 
         _store = new DocumentStore(options);
@@ -84,6 +95,15 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
     public override void StoreDocument<T>(IDocumentOperations session, T document) => session.Store(document);
 
     public override JasperFx.Events.IEventStoreOperations EventsFor(IDocumentOperations session) => session.Events;
+
+    // Session-scoped correlation/causation is shared behavior that no shared interface declares:
+    // in Marten the pair hangs off IQuerySession, which every session from OpenSession() is.
+    public override string? CorrelationIdFor(IDocumentOperations session) => ((IQuerySession)session).CorrelationId;
+
+    public override string? CausationIdFor(IDocumentOperations session) => ((IQuerySession)session).CausationId;
+
+    public override void SetCorrelationId(IDocumentOperations session, string? correlationId)
+        => ((IQuerySession)session).CorrelationId = correlationId;
 
     public override IEventStore EventStore => _store;
 


### PR DESCRIPTION
Moves both dependency lines forward together and adopts the compliance suites that came with them.

## The bumps

**JasperFx 2.38.0** (all five packages) brings jasperfx#616 — the `ProjectionScenario` test harness lifted into `JasperFx.Events.TestSupport` (#5127) — and jasperfx#617 — the #5095 fix making Scoped/Transient projections reachable from `AggregatorFor` and validating the projection a scoped wrapper wraps.

**Weasel 9.23.2** (all three packages) carries weasel#424, the non-generic `Weasel.Core.ICommandBuilder` on Sqlite and MySql, plus Weasel's own move to JasperFx 2.38.0 — so the two lines stay coherent here rather than resolving transitively.

## This is not a pure version bump

2.38.0 also carries **JasperFx compliance wave 3** (jasperfx#613), which adds two shared suites and the seam members they need. Without adopting them the solution does not compile, so that work is in this PR:

- **`MartenComplianceFixture` implements `CorrelationIdFor` / `CausationIdFor` / `SetCorrelationId`.** Session-scoped correlation is shared behavior no shared interface declares; in Marten the pair hangs off `IQuerySession`.
- **`BuildStoreAsync` honors the two new `ComplianceStoreConfig` knobs.** `StreamIdentity` — the string-identity suite needs `AsString`, or the store rejects a string-keyed aggregate against Guid stream identity. `EnableCorrelationTracking` — mapped onto `MetadataConfig.CorrelationIdEnabled` / `CausationIdEnabled` so the metadata is actually persisted.
- **New `ComplianceStringPartyProjectionBase` global alias**, using the same per-consumer alias mechanism already there for `ComplianceQuerySession` and friends: the suite declares its projection at file scope and cannot reach its own generics, so each product supplies its `SingleStreamProjection<TDoc, TId>` base by alias.
- **Both suites enrolled** in `marten_event_store_compliance`.

Shared compliance tests go **55 → 65**, all passing. Catching this mattered: enrolling the suites without honoring the config knobs compiled fine but failed 7 of the 10 new tests.

## Verification (net9.0)

| Suite | Result |
|---|---|
| Compliance (incl. wave 3) | **65 / 65** |
| EventSourcingTests | **1624 / 1624** |
| DocumentDbTests | **1089 / 1089** |
| `Marten.slnx` build | clean |

`CoreTests` shows 4 failures — one **fewer** than the **5** an unbumped `master` baseline produces in the same environment (`Bug_4185`, `Bug_4187`, `rolling_range` host-startup, assembly-reuse-warning). I ran that baseline specifically to check attribution: these are pre-existing and environmental, not from this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)