### PR TITLE
Alias the StreamOne payload column so Select() projections keep their ETag

### DIFF
--- a/src/IssueService/StreamingMinimalEndpoints.cs
+++ b/src/IssueService/StreamingMinimalEndpoints.cs
@@ -53,6 +53,13 @@ public static class StreamingMinimalEndpoints
                     EmitETag = false
                 });
 
+        // StreamOne over a Select() projection (#5158). The ETag still describes the source
+        // document, since the projection is a pure function of it.
+        app.MapGet("/minimal/issue/{id:guid}/summary",
+            (Guid id, IQuerySession session)
+                => new StreamOne<IssueSummary>(session.Query<Issue>().Where(x => x.Id == id)
+                    .Select(x => new IssueSummary { Description = x.Description })));
+
         // Document type whose version metadata is disabled — no mt_version column, so
         // EmitETag = true (the default) must still emit NO ETag rather than a constant zero-Guid.
         app.MapGet("/minimal/versionless/{id:guid}",
@@ -220,6 +227,15 @@ public class VersionlessDoc
 {
     public Guid Id { get; set; }
     public string Name { get; set; }
+}
+
+/// <summary>
+/// Projection shape for the <c>Select()</c>-over-<see cref="Issue"/> endpoint (#5158). Not a
+/// registered document type — it only ever exists as the output of a LINQ projection.
+/// </summary>
+public class IssueSummary
+{
+    public string Description { get; set; }
 }
 
 /// <summary>

--- a/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
+++ b/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
@@ -586,6 +586,227 @@ public class streaming_result_types_tests: IntegrationContext
         body.Length.ShouldBe(0);
     }
 
+    [Fact]
+    public async Task stream_one_and_stream_aggregate_serve_the_same_etag_for_the_same_stream()
+    {
+        // The cache-coherence claim #5120 rests on, and the reason serving a read model through
+        // StreamOne rather than StreamAggregate is safe: for an Inline SingleStreamProjection the
+        // document's revision IS the source stream's version, so a client can switch between the
+        // two read styles without invalidating what it has cached. Asserted rather than assumed —
+        // both endpoints are hit for the same stream and their ETags compared, at two different
+        // stream versions so a coincidental match at "1" cannot pass.
+        var orderId = Guid.NewGuid();
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Events.StartStream<Order>(orderId, new OrderPlaced("coherent", 9.00m));
+            await session.SaveChangesAsync();
+        }
+
+        var one = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order-doc/{orderId}");
+            s.StatusCodeShouldBe(200);
+        });
+        var aggregate = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var etag = one.Context.Response.Headers["ETag"].ToString();
+        etag.ShouldBe("\"1\"");
+        aggregate.Context.Response.Headers["ETag"].ToString().ShouldBe(etag);
+
+        // Advance the stream and confirm the two stay in step rather than agreeing only at 1.
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Events.Append(orderId, new OrderShipped());
+            await session.SaveChangesAsync();
+        }
+
+        var oneAgain = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order-doc/{orderId}");
+            s.StatusCodeShouldBe(200);
+        });
+        var aggregateAgain = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}");
+            s.StatusCodeShouldBe(200);
+        });
+
+        oneAgain.Context.Response.Headers["ETag"].ToString().ShouldBe("\"2\"");
+        aggregateAgain.Context.Response.Headers["ETag"].ToString().ShouldBe("\"2\"");
+
+        // And a tag minted by one style is honored by the other.
+        await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}");
+            s.WithRequestHeader("If-None-Match", oneAgain.Context.Response.Headers["ETag"].ToString());
+            s.StatusCodeShouldBe(304);
+        });
+        await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order-doc/{orderId}");
+            s.WithRequestHeader("If-None-Match", aggregateAgain.Context.Response.Headers["ETag"].ToString());
+            s.StatusCodeShouldBe(304);
+        });
+    }
+
+    // ──────────────── StreamOne<T> ETag — Select() projections (#5158) ────────────────
+
+    [Fact]
+    public async Task stream_one_over_a_select_projection_serves_the_projection_and_the_document_etag()
+    {
+        // #5158: VersionSelectClause rebuilds the select list from the inner clause's SelectFields()
+        // rather than delegating to its Apply, which dropped the `as data` alias that
+        // SelectDataSelectClause emits — so the reader's GetOrdinal("data") threw
+        // IndexOutOfRangeException. The plain path only worked because its field is the literal
+        // `d.data`, which Postgres happens to name `data`.
+        var issue = new Issue { Description = "projected", Open = true };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        var full = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}");
+            s.StatusCodeShouldBe(200);
+        });
+        var etag = full.Context.Response.Headers["ETag"].ToString();
+        etag.ShouldNotBeNullOrEmpty();
+
+        var projected = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}/summary");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        projected.ReadAsJson<IssueSummary>().Description.ShouldBe("projected");
+
+        // The projection is a pure function of the document, so it validates against the same
+        // version — a client can cache either representation off the same ETag.
+        projected.Context.Response.Headers["ETag"].ToString().ShouldBe(etag);
+
+        var cached = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}/summary");
+            s.WithRequestHeader("If-None-Match", etag);
+            s.StatusCodeShouldBe(304);
+        });
+        cached.ReadAsText().ShouldBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task stream_one_over_an_anonymous_type_projection_emits_the_document_etag()
+    {
+        // The anonymous-type shape from the #5158 report. It cannot go through an endpoint (the
+        // result type has to be nameable), so it is exercised against WriteSingle directly.
+        var store = theHost.Services.GetRequiredService<IDocumentStore>();
+        var issue = new Issue { Description = "anonymous", Open = true };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        await query.Query<Issue>().Where(x => x.Id == issue.Id)
+            .Select(x => new { x.Description })
+            .WriteSingle(context, emitETag: true);
+
+        context.Response.StatusCode.ShouldBe(200);
+        context.Response.Headers["ETag"].ToString().ShouldNotBeNullOrEmpty();
+
+        context.Response.Body.Position = 0;
+        (await new StreamReader(context.Response.Body).ReadToEndAsync())
+            .ShouldContain("anonymous");
+    }
+
+    [Fact]
+    public async Task stream_one_over_a_scalar_projection_emits_the_document_etag()
+    {
+        // The second #5158 failure mode: for a scalar projection T is a primitive, and looking up
+        // a document mapping for it threw ArgumentOutOfRangeException ("This type cannot be used as
+        // a Marten document") before any SQL was even built. The flavor now comes from the source
+        // document type instead.
+        var store = theHost.Services.GetRequiredService<IDocumentStore>();
+        var issue = new Issue { Description = "scalar projection", Open = true };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        await query.Query<Issue>().Where(x => x.Id == issue.Id)
+            .Select(x => x.Description)
+            .WriteSingle(context, emitETag: true);
+
+        context.Response.StatusCode.ShouldBe(200);
+        context.Response.Headers["ETag"].ToString().ShouldNotBeNullOrEmpty();
+
+        context.Response.Body.Position = 0;
+        (await new StreamReader(context.Response.Body).ReadToEndAsync())
+            .ShouldBe("\"scalar projection\"");
+    }
+
+    [Fact]
+    public async Task stream_one_over_a_select_projection_of_a_revisioned_document_emits_the_revision()
+    {
+        // The projection path on the numeric-revision flavor: the ETag is still the source
+        // document's revision, which for a single-stream projection target is the stream version.
+        var store = theHost.Services.GetRequiredService<IDocumentStore>();
+        var orderId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Order>(orderId, new OrderPlaced("projected order", 4.00m));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        await query.Query<Order>().Where(x => x.Id == orderId)
+            .Select(x => new { x.Description })
+            .WriteSingle(context, emitETag: true);
+
+        context.Response.StatusCode.ShouldBe(200);
+        context.Response.Headers["ETag"].ToString().ShouldBe("\"1\"");
+    }
+
+    [Fact]
+    public async Task stream_one_over_a_select_projection_of_a_versionless_document_emits_no_etag()
+    {
+        // The source document type decides the flavor, so a projection over a type with no
+        // mt_version column must still emit no ETag rather than picking up a default from the
+        // projected type.
+        var store = theHost.Services.GetRequiredService<IDocumentStore>();
+        var doc = new VersionlessDoc { Id = Guid.NewGuid(), Name = "no version" };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        await query.Query<VersionlessDoc>().Where(x => x.Id == doc.Id)
+            .Select(x => new { x.Name })
+            .WriteSingle(context, emitETag: true);
+
+        context.Response.StatusCode.ShouldBe(200);
+        context.Response.Headers.ContainsKey("ETag").ShouldBeFalse();
+    }
+
     // ───────────────────────── StreamMany<T> ─────────────────────────
 
     [Fact]

--- a/src/Marten/Linq/MartenLinqQueryProvider.cs
+++ b/src/Marten/Linq/MartenLinqQueryProvider.cs
@@ -305,7 +305,16 @@ internal class MartenLinqQueryProvider: IQueryProvider
         var main = statements.MainSelector;
         main.Limit = 1;
 
-        var mapping = _session.Options.Storage.FindMapping(typeof(T)) as DocumentMapping;
+        // Resolve the mapping from the SOURCE document type, not from T. Under a Select()
+        // projection T is the projected type — an anonymous type, a DTO, or a scalar like string —
+        // and asking StorageFeatures for a mapping of that either invents one whose version
+        // metadata defaults to enabled (so a version column got appended to a projected select) or
+        // throws outright for a primitive (#5158). The version being read is the source document's
+        // either way, so the source document type is what decides the flavor.
+        var documentType = parser.DocumentTypes().FirstOrDefault();
+        var mapping = documentType == null
+            ? null
+            : _session.Options.Storage.FindMapping(documentType) as DocumentMapping;
 
         // Both flavors keep their value in the same physical mt_version column, so one
         // piggy-backed select serves them; only the CLR type read back differs. For a

--- a/src/Marten/Linq/SqlGeneration/VersionSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/VersionSelectClause.cs
@@ -22,6 +22,17 @@ namespace Marten.Linq.SqlGeneration;
 /// so it never collides with an <c>mt_version</c> column the inner clause may already
 /// select (e.g. under optimistic concurrency).
 /// </para>
+/// <para>
+/// The payload column is aliased to <see cref="DataAlias"/>. This decorator rebuilds the
+/// <c>select</c> list from <see cref="ISelectClause.SelectFields"/> rather than delegating to the
+/// inner clause's own <c>Apply</c>, which means any aliasing that <c>Apply</c> would have done is
+/// lost — and the JSON streaming reader looks the payload up by the name <c>data</c>. For
+/// <c>DataSelectClause</c> the name happened to survive because its field is the literal
+/// <c>d.data</c>; for a <c>Select()</c> projection (<c>SelectDataSelectClause</c>, whose field is a
+/// <c>jsonb_build_object(...)</c> expression) it did not, and the read failed with
+/// <c>Field not found in row: data</c> (#5158). Aliasing explicitly makes the name intentional for
+/// every inner clause instead of incidental for one.
+/// </para>
 /// </summary>
 internal static class VersionSelectClause
 {
@@ -29,6 +40,12 @@ internal static class VersionSelectClause
     /// Result-set alias under which the piggy-backed <c>mt_version</c> value is returned.
     /// </summary>
     public const string VersionAlias = "mt_etag_version";
+
+    /// <summary>
+    /// Result-set alias under which the document payload is returned, matching the column name the
+    /// JSON streaming reader looks for.
+    /// </summary>
+    public const string DataAlias = "data";
 }
 
 internal class VersionSelectClause<T>: ISelectClause, IModifyableFromObject where T : notnull
@@ -48,10 +65,25 @@ internal class VersionSelectClause<T>: ISelectClause, IModifyableFromObject wher
 
     public string FromObject { get; set; }
 
+    /// <summary>
+    /// The inner clause's fields with the payload explicitly aliased to <c>data</c> — see the
+    /// remarks on <see cref="VersionSelectClause"/> for why the alias cannot be left implicit.
+    /// <c>DocumentTable.SelectColumns</c> guarantees the payload is the first selected field
+    /// ("the order of the selection is data, id, everything else"), so the remaining fields —
+    /// e.g. the <c>mt_version</c> a revisioned document's storage already selects — pass through
+    /// untouched and keep their own names.
+    /// </summary>
+    private string[] innerFields()
+    {
+        var fields = Inner.SelectFields().ToArray();
+        fields[0] = $"{fields[0]} as {VersionSelectClause.DataAlias}";
+        return fields;
+    }
+
     public void Apply(ICommandBuilder sql)
     {
         sql.Append("select ");
-        sql.Append(Inner.SelectFields().Join(", "));
+        sql.Append(innerFields().Join(", "));
         sql.Append(", ");
         sql.Append(VersionColumn);
         sql.Append(" from ");
@@ -61,7 +93,7 @@ internal class VersionSelectClause<T>: ISelectClause, IModifyableFromObject wher
 
     public string[] SelectFields()
     {
-        return Inner.SelectFields().Concat(new[] { VersionColumn }).ToArray();
+        return innerFields().Concat(new[] { VersionColumn }).ToArray();
     }
 
     public ISelector BuildSelector(IStorageSession session)


### PR DESCRIPTION
Fixes #5158. Also closes out the last untested claim behind #5120.

## The defect

`WriteSingle` / `StreamOne<T>` threw at runtime whenever the queryable carried a `Select()` projection and `emitETag` was on (the default). Regression from #5027 / PR #5030 (`44f9b44a2`), shipped in 9.18.0.

Dumping the generated SQL for three shapes of the same query showed **two** distinct failure modes, not the one reported:

```text
plain   OK      select d.data, d.mt_version as mt_etag_version from ... mt_doc_issue as d where d.id = :p0 LIMIT :p1;
anon    THREW   select  jsonb_build_object('Description', d.data ->> 'Description') , d.mt_version as mt_etag_version from ...
scalar  THREW   (no SQL — threw before the command was built)
```

**Mode 1 — the lost `data` alias.** `VersionSelectClause.Apply` rebuilds the select list from `Inner.SelectFields()` instead of delegating to the inner clause's own `Apply`, so any aliasing `Apply` would have emitted is dropped. `DataSelectClause`'s field is the literal `d.data`, so Postgres names the column `data` anyway and the plain path worked *by luck*. `SelectDataSelectClause`'s field is a `jsonb_build_object(...)` expression, so rebuilt without the alias the column came back named `jsonb_build_object` and the reader's `GetOrdinal("data")` threw `IndexOutOfRangeException`.

**Mode 2 — scalar projections.** `Select(x => x.Description)` makes `T` a primitive, and `FindMapping(typeof(string))` throws `ArgumentOutOfRangeException: This type cannot be used as a Marten document` before any SQL is built.

## The fix

1. **`VersionSelectClause` aliases the payload explicitly** to `data`, making the name intentional for every inner clause rather than incidental for one. `DocumentTable.SelectColumns` guarantees the payload is the first selected field — *"the order of the selection is data, id, everything else"* — so only field 0 is aliased and the remaining fields pass through untouched, keeping their own names. That matters: a revisioned document's storage already selects `d.data, d.mt_version`, and aliasing more than the payload would have broken it.
2. **`MartenLinqQueryProvider.StreamOneWithVersion<T>` resolves the mapping from the source document type** (`parser.DocumentTypes().First()`) rather than from `T`. Under a projection `T` is the projected type, and asking `StorageFeatures` for a mapping of it either invents one whose version metadata defaults to enabled or throws for a primitive. The version being read is the source document's either way.

Net effect: projections **keep** their ETag rather than merely not crashing. The projection is a pure function of the document, so it validates against the same version — a client can cache either representation off the same tag.

## Tests

- `stream_one_over_a_select_projection_serves_the_projection_and_the_document_etag` — Alba e2e over a new `/minimal/issue/{id}/summary` endpoint: the projected body is served, its ETag equals the full document's, and that tag drives a 304.
- `stream_one_over_an_anonymous_type_projection_emits_the_document_etag` — the exact shape from the report. Cannot go through an endpoint (the result type must be nameable), so it runs against `WriteSingle` directly.
- `stream_one_over_a_scalar_projection_emits_the_document_etag` — mode 2.
- `stream_one_over_a_select_projection_of_a_revisioned_document_emits_the_revision` — the projection path on the numeric-revision flavor.
- `stream_one_over_a_select_projection_of_a_versionless_document_emits_no_etag` — the source type still decides, so a projection over a versionless document must not pick up a default from the projected type.

## Closing out #5120

#5120's proposal shipped in full in #5121, but one load-bearing claim in it was asserted in a code comment and never tested:

> For a `SingleStreamProjection` target the resulting ETag is semantically identical to `StreamAggregate`'s (both are the stream version), so the two read styles stay cache-coherent.

That is the entire justification for the feature. `stream_one_and_stream_aggregate_serve_the_same_etag_for_the_same_stream` now hits both endpoints for the same stream, compares their ETags at version 1 **and** version 2 (so a coincidental match at `"1"` cannot pass), and confirms a tag minted by either style is honored by the other with a 304. With that pinned, #5120 can be closed.

## Verified locally (net10.0)

Marten.AspNetCore.Testing · LinqTests 1421/1421 · DocumentDbTests 1089 passed (1 pre-existing skip) · CompiledQueryTests 9/9 · EventSourcingTests.

Worth noting one course-correction during development: a first attempt guarded with `CanCarryVersion` (skip the version column for multi-field select clauses) and silently dropped the ETag for `IRevisioned`/`ILongVersioned` documents, whose storage selects `data` *and* `mt_version`. Two existing tests caught it, and it was replaced with the narrower first-field aliasing above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
