### PR TITLE
Stop the high water mark stalling forever behind idle advisory-lock sessions (#5108, #5125)

### DIFF
--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -104,16 +104,64 @@ means the session holding it keeps a transaction open for as long as it is the l
 `options.Events.UseAdvisoryLockTransaction` to false to use a session-scoped lock instead, which holds
 no open transaction.
 
+::: tip
+Marten's gap detection recognizes its own leadership lock connections and never counts them as
+possible appenders, so a transaction-scoped lock — whether currently held or leaked from a host that
+has already been torn down — does not stall the high water mark. Before 9.23 it could: one such
+session was enough to pin the mark for every later daemon in that process, surfacing as
+`WaitForNonStaleProjectionDataAsync` timing out and a repeating
+`Daemon high water detection is holding before the sequence gap` log. If you are on an older version
+and see that, `UseAdvisoryLockTransaction = false` is the workaround, since a session-scoped lock
+holds no transaction to be seen.
+:::
+
+## Sequence Gaps and the High Water Mark <Badge type="tip" text="9.23" />
+
+The high water mark is the point below which the daemon knows every event is committed and safely
+ordered. It advances contiguously, so it stops under any hole in the event sequence.
+
+Most holes fill in within milliseconds — they are simply appends that have drawn a sequence number and
+not yet committed. Some never fill: a rolled-back `SaveChangesAsync`, or an optimistic-concurrency
+loser, burns its sequence numbers permanently, because PostgreSQL sequences are non-transactional.
+The daemon cannot tell those two apart by looking at the hole, so it asks a different question: is any
+transaction still running that could have reserved it? While the answer is yes, the mark holds. Once
+no such transaction remains, the gap is proven dead and the daemon skips the entire dead span in one
+step, recording it in `mt_high_water_skips`.
+
+This is why the daemon holds rather than guessing, and why it never skips past events that later
+commit. It also means an open transaction that will never commit is the thing that can stall it. That
+covers sessions parked `idle in transaction` — the daemon rules out any session that has provably
+executed nothing since before the gap's sequence numbers were handed out, and its own leadership lock
+connections regardless. The evidence supporting that reasoning is durable, so it survives daemon
+restarts, deploys and shard rebalancing.
+
+If you want a bounded escape hatch anyway — against, say, a leaked application session that holds an
+open transaction forever — set a cap:
+
+```cs
+// Skip a stale gap once it has been stuck this long even if a transaction that
+// could still fill it appears to be alive. Null (the default) never knowingly
+// skips past a live appender.
+opts.Projections.SkipStaleGapsDespiteLiveTransactionsAfter = 5.Minutes();
+```
+
+Use it deliberately: past the cap the daemon skips on a *suspicion* of deadness, so an append that
+commits inside the skipped range will never be projected. PostgreSQL's own
+`idle_in_transaction_session_timeout` is usually the better backstop, since it removes the cause
+rather than working around it. Note that it will also kill Wolverine's transaction-scoped listener
+locks if you use them.
+
+To recover a mark that is stuck for any other reason, `AdvanceHighWaterMarkToLatestAsync()` moves it
+to the highest committed sequence:
+
+```cs
+await store.Advanced.AdvanceHighWaterMarkToLatestAsync(CancellationToken.None);
+```
+
 ::: warning
-Prefer `UseAdvisoryLockTransaction = false` when a **single process starts more than one
-daemon-hosting `IHost` over its lifetime** — the usual shape of an xUnit integration suite that boots
-and tears down a host per test class. Should any leadership lock session outlive its host, a
-transaction-scoped lock leaves that session `idle in transaction` for the rest of the process, and the
-daemon's high-water gap detection has to treat any transaction older than a sequence gap as a
-potential in-flight append it must not skip past. One such session is enough to pin the high water
-mark for every later daemon in that process, which surfaces as `WaitForNonStaleProjectionDataAsync`
-timing out and a repeating `Daemon high water detection is holding before the sequence gap` log. A
-session-scoped lock cannot cause that, because it holds no transaction to be seen.
+`AdvanceHighWaterMarkToLatestAsync()` is a manual override. Anything still in flight below the new
+mark will never be projected, so reach for it when you have established that a gap is genuinely dead
+and not as routine maintenance.
 :::
 
 ## Projection Distribution

--- a/src/DaemonTests.ManualOnly/Coordination/high_water_advances_past_dead_gaps_with_slow_transactions.cs
+++ b/src/DaemonTests.ManualOnly/Coordination/high_water_advances_past_dead_gaps_with_slow_transactions.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Core;
+using Marten.Events.Daemon;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace DaemonTests.ManualOnly.Coordination;
+
+/// <summary>
+/// End-to-end proof for #5108 and #5125: a real HotCold daemon, real advisory locks, and deliberately
+/// slow (permanently idle-in-transaction) sessions, against a store carrying a genuinely dead sequence
+/// gap. These run against real wall-clock daemon polling rather than driving the detector directly,
+/// which is the whole point — the reports are about what the running daemon does, and both of them
+/// end with "the mark never advances again".
+///
+/// The gap-liveness probe (#4953/#4977) refuses to skip a gap while any transaction that could still
+/// fill it looks alive, and its second clause counts ANY client backend whose transaction started
+/// before the gap was observed. A session parked idle-in-transaction on an advisory lock — Wolverine's
+/// exclusive listeners, or the daemon's OWN transaction-scoped leadership lock — trips that clause
+/// forever, because it never commits. #5057's allocation fence rules such sessions out by proof, but
+/// only while the detector instance that watched the sequence cross the mark is still alive.
+///
+/// Slow by construction (multi-second daemon polling and settle windows), so these live in
+/// ManualOnly rather than the CI daemon suite.
+/// </summary>
+public class high_water_advances_past_dead_gaps_with_slow_transactions: DaemonContext
+{
+    public high_water_advances_past_dead_gaps_with_slow_transactions(ITestOutputHelper output): base(output)
+    {
+    }
+
+    private string Schema => theStore.Events.DatabaseSchemaName;
+
+    private readonly List<NpgsqlConnection> _slowSessions = new();
+
+    #region helpers
+
+    private async Task<NpgsqlConnection> openConnection()
+    {
+        var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    /// <summary>
+    /// A purposefully slow transaction: grabs a transaction-scoped advisory lock and then sits
+    /// idle-in-transaction indefinitely without running another statement. This is exactly the shape
+    /// of Wolverine's exclusive listener sessions — the fleet in #5108 had 57 of them — and of the
+    /// daemon's own leadership lock in #5125.
+    /// </summary>
+    private async Task startSlowAdvisoryLockSession(long advisoryKey)
+    {
+        var conn = await openConnection();
+        await conn.BeginTransactionAsync();
+        await conn.CreateCommand($"select pg_advisory_xact_lock({advisoryKey})")
+            .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        _slowSessions.Add(conn);
+    }
+
+    private async Task closeSlowSessions()
+    {
+        foreach (var conn in _slowSessions)
+        {
+            await conn.DisposeAsync();
+        }
+
+        _slowSessions.Clear();
+    }
+
+    /// <summary>
+    /// Burn a sequence number and roll it back — a rolled-back SaveChanges, which is how the reporters'
+    /// optimistic-concurrency losers produce their gaps — then commit more events above the hole so the
+    /// mark is genuinely pinned under a permanently dead sequence number.
+    /// </summary>
+    private async Task<long> createDeadGapAsync()
+    {
+        long seq;
+        await using (var conn = await openConnection())
+        {
+            var tx = await conn.BeginTransactionAsync(TestContext.Current.CancellationToken);
+            seq = (long)(await conn.CreateCommand($"select nextval('{Schema}.mt_events_sequence')")
+                .ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+
+            // An in-flight append that holds the row but never commits
+            await conn.CreateCommand($@"
+insert into {Schema}.mt_events(seq_id, id, stream_id, version, data, type, timestamp, tenant_id, mt_dotnet_type, is_archived)
+select {seq}, gen_random_uuid(), stream_id, 100000 + {seq}, data, type, now(), tenant_id, mt_dotnet_type, false
+from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+
+            await tx.RollbackAsync(TestContext.Current.CancellationToken);
+        }
+
+        return seq;
+    }
+
+    /// <summary>
+    /// Commit event rows straight through SQL rather than through <c>theStore</c>. The restart test
+    /// has to keep writing after the first host is disposed, and disposing a host tears down the
+    /// pooled data source that the context's own store is still holding (see #4874) — going direct
+    /// keeps this test measuring high-water behavior instead of that disposal ordering.
+    /// </summary>
+    private async Task commitEventsDirectlyAsync(int count)
+    {
+        await using var conn = await openConnection();
+        for (var i = 0; i < count; i++)
+        {
+            await conn.CreateCommand($@"
+insert into {Schema}.mt_events(seq_id, id, stream_id, version, data, type, timestamp, tenant_id, mt_dotnet_type, is_archived)
+select nextval('{Schema}.mt_events_sequence'), gen_random_uuid(), stream_id, 200000 + {i}, data, type, now(), tenant_id, mt_dotnet_type, false
+from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    private async Task<long> currentHighWaterMarkAsync()
+    {
+        await using var conn = await openConnection();
+        var raw = await conn
+            .CreateCommand(
+                $"select coalesce(max(last_seq_id), 0) from {Schema}.mt_event_progression where name = 'HighWaterMark'")
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        return raw is long l ? l : Convert.ToInt64(raw ?? 0L);
+    }
+
+    private async Task<long> highestCommittedSequenceAsync()
+    {
+        await using var conn = await openConnection();
+        var raw = await conn.CreateCommand($"select coalesce(max(seq_id), 0) from {Schema}.mt_events")
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        return raw is long l ? l : Convert.ToInt64(raw ?? 0L);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// #5108 §1 — the deploy / crash / shard-rebalance case. A daemon runs and catches up (which is
+    /// when the allocation fence is established), the process is replaced, and a dead gap is sitting
+    /// there when the replacement starts. On master the replacement detector has no in-memory
+    /// allocation history, the slow advisory-lock sessions read as live reservers, and the mark never
+    /// advances again.
+    /// </summary>
+    [Fact]
+    public async Task restarted_daemon_advances_past_a_dead_gap_with_slow_sessions_present()
+    {
+        // The Wolverine-listener fleet: open BEFORE anything else, so every one of them has an
+        // xact_start older than any gap the detector will ever observe
+        await startSlowAdvisoryLockSession(51080001);
+        await startSlowAdvisoryLockSession(51080002);
+        await startSlowAdvisoryLockSession(51080003);
+
+        try
+        {
+            NumberOfStreams = 5;
+            await PublishSingleThreaded();
+            var published = NumberOfEvents;
+
+            // First daemon generation: runs while the store is healthy and caught up. This is the only
+            // window in which anything can observe the sequence's allocated high still at or below the
+            // mark — i.e. the only chance to establish the fence.
+            var first = await StartDaemonInHotColdMode();
+            await first.Daemon().Tracker.WaitForHighWaterMark(published, 30.Seconds());
+            _output.WriteLine($"First daemon generation caught up at {published}");
+
+            // The deploy: the process holding that in-memory history goes away
+            await first.StopAsync(TestContext.Current.CancellationToken);
+            first.Dispose();
+
+            // ...and a dead gap forms while no daemon is running
+            var deadSeq = await createDeadGapAsync();
+            _output.WriteLine($"Dead sequence number: {deadSeq}");
+
+            await commitEventsDirectlyAsync(3);
+            var ceiling = await highestCommittedSequenceAsync();
+            _output.WriteLine($"Highest committed sequence above the gap: {ceiling}");
+
+            // The replacement node starts up against a store that was already gapped
+            using var second = await StartDaemonInHotColdMode();
+            await second.Daemon().Tracker.WaitForHighWaterMark(ceiling, 60.Seconds());
+
+            (await currentHighWaterMarkAsync()).ShouldBe(ceiling);
+        }
+        finally
+        {
+            await closeSlowSessions();
+        }
+    }
+
+    /// <summary>
+    /// #5125 — no restart and no third-party session needed. The store is already gapped before any
+    /// daemon has ever run (events appended then deleted; a rolled-back append leaves the same state),
+    /// so no fence can be established by construction. The only open transaction is the daemon's OWN
+    /// HotCold leadership lock, which is transaction-scoped by default and therefore sits
+    /// idle-in-transaction for its entire tenure — and gap detection counts it as a possible reserver
+    /// of the very gap it is trying to skip.
+    /// </summary>
+    [Fact]
+    public async Task daemon_advances_when_its_own_advisory_lock_is_the_only_open_transaction()
+    {
+        // Poison the sequence BEFORE any daemon exists: append, then delete the rows, leaving the
+        // sequence's allocated values above a high water mark that is still 0
+        NumberOfStreams = 3;
+        await PublishSingleThreaded();
+
+        await using (var conn = await openConnection())
+        {
+            await conn.CreateCommand($"delete from {Schema}.mt_events")
+                .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+            await conn.CreateCommand($"delete from {Schema}.mt_streams")
+                .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+            await conn.CreateCommand($"delete from {Schema}.mt_event_progression")
+                .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await currentHighWaterMarkAsync()).ShouldBe(0);
+
+        // Now real events land above the permanent hole
+        NumberOfStreams = 4;
+        await PublishSingleThreaded();
+        var ceiling = await highestCommittedSequenceAsync();
+        _output.WriteLine($"Highest committed sequence above the poisoned range: {ceiling}");
+
+        using var host = await StartDaemonInHotColdMode();
+        await host.Daemon().Tracker.WaitForHighWaterMark(ceiling, 60.Seconds());
+
+        (await currentHighWaterMarkAsync()).ShouldBe(ceiling);
+    }
+}

--- a/src/DaemonTests/Bugs/Bug_5108_dead_gap_span_clears_in_one_cycle.cs
+++ b/src/DaemonTests/Bugs/Bug_5108_dead_gap_span_clears_in_one_cycle.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Core;
+using JasperFx.Events;
+using Marten.Events.Daemon.HighWater;
+using Marten.Storage;
+using Marten.Testing;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace DaemonTests.Bugs;
+
+/// <summary>
+/// #5108 §2: recovery from a race-heavy field of dead gaps used to be a serial grind — the skip
+/// advanced to the next gap edge, so N gaps cost N detection cycles and each one re-paid
+/// StaleSequenceThreshold from a fresh observation. The reporter measured a mark crawling 38 → 426
+/// over 21 seconds against ~50 gaps in 489 sequences, with the cost growing linearly in write
+/// contention.
+///
+/// One liveness verdict already proves the whole span dead: every sequence number at or below the
+/// ceiling recorded when the gap was first observed was handed out at or before that moment (nextval
+/// runs inside the reserving transaction, so its xact_start cannot postdate it), and the probe
+/// establishes that no transaction from before the observation is still running.
+/// </summary>
+public class Bug_5108_dead_gap_span_clears_in_one_cycle: DaemonContext
+{
+    public Bug_5108_dead_gap_span_clears_in_one_cycle(ITestOutputHelper output): base(output)
+    {
+    }
+
+    private string Schema => theStore.Events.DatabaseSchemaName;
+
+    private async Task<NpgsqlConnection> openConnection()
+    {
+        var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    private async Task appendEvents(int count)
+    {
+        await using var session = theStore.LightweightSession();
+        for (var i = 0; i < count; i++)
+        {
+            session.Events.StartStream(Guid.NewGuid(), new Bug5108SpanEvent(i + 1));
+        }
+
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task execute(string sql)
+    {
+        await using var conn = await openConnection();
+        await conn.CreateCommand(sql).ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<long> scalar(string sql)
+    {
+        await using var conn = await openConnection();
+        var raw = await conn.CreateCommand(sql).ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        return raw is long l ? l : Convert.ToInt64(raw ?? 0L);
+    }
+
+    [Fact]
+    public async Task a_field_of_dead_gaps_is_cleared_by_a_single_skip()
+    {
+        StoreOptions(opts => opts.Projections.StaleSequenceThreshold = 500.Milliseconds());
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        await appendEvents(40);
+        // Park the mark directly under the first hole so the very first DetectInSafeZone call sees the
+        // gap pinned rather than spending a cycle on an ordinary contiguous advance
+        await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 6)");
+
+        // A race-heavy field: many rolled-back appends scattered above the mark. Deleting the rows
+        // leaves exactly what a rolled-back SaveChanges leaves behind — allocated sequence numbers
+        // that will never commit.
+        await execute($"delete from {Schema}.mt_events where seq_id in (7, 9, 12, 13, 18, 25, 26, 31, 37)");
+
+        var ceiling = await scalar($"select coalesce(max(seq_id), 0) from {Schema}.mt_events");
+        ceiling.ShouldBe(40);
+
+        var detector = new HighWaterDetector((MartenDatabase)theStore.Tenancy.Default.Database, theStore.Events,
+            NullLogger.Instance);
+
+        // First sighting holds — the gap has to be stuck past the threshold before anything is skipped
+        var held = await detector.DetectInSafeZone(CancellationToken.None);
+        held.CurrentMark.ShouldBe(6);
+
+        await Task.Delay(700, TestContext.Current.CancellationToken);
+
+        // ONE cycle clears all nine gaps, not one gap per cycle
+        var skipped = await detector.DetectInSafeZone(CancellationToken.None);
+        skipped.CurrentMark.ShouldBe(40);
+        skipped.IncludesSkipping.ShouldBeTrue();
+
+        (await scalar(
+                $"select coalesce(max(last_seq_id), 0) from {Schema}.mt_event_progression where name = 'HighWaterMark'"))
+            .ShouldBe(40);
+    }
+}
+
+public record Bug5108SpanEvent(int Number);

--- a/src/DaemonTests/Bugs/Bug_5108_durable_allocation_fence.cs
+++ b/src/DaemonTests/Bugs/Bug_5108_durable_allocation_fence.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Core;
+using JasperFx.Events;
+using Marten.Events.Daemon.HighWater;
+using Marten.Storage;
+using Marten.Testing;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace DaemonTests.Bugs;
+
+/// <summary>
+/// #5108 / #5125: the allocation fence that rules permanently-idle open transactions out as gap
+/// reservers (#5057) used to live only in the detector instance's memory, so a daemon that started or
+/// resumed AFTER a gap formed had none and the mark never advanced again. These pin the two things
+/// that make the default configuration recover: the fence is durable across detector generations, and
+/// the daemon's own advisory-lock connections are ruled out structurally.
+///
+/// The end-to-end versions — real HotCold daemons and real leadership locks — live in
+/// DaemonTests.ManualOnly.Coordination.high_water_advances_past_dead_gaps_with_slow_transactions.
+/// </summary>
+public class Bug_5108_durable_allocation_fence: DaemonContext
+{
+    private readonly ITestOutputHelper _output;
+
+    public Bug_5108_durable_allocation_fence(ITestOutputHelper output): base(output)
+    {
+        _output = output;
+    }
+
+    private string Schema => theStore.Events.DatabaseSchemaName;
+
+    #region helpers
+
+    private async Task<NpgsqlConnection> openConnection()
+    {
+        var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    private async Task<NpgsqlConnection> startIdleAdvisoryLockSession(long lockId)
+    {
+        var conn = await openConnection();
+        await conn.BeginTransactionAsync(TestContext.Current.CancellationToken);
+        await conn.CreateCommand($"select pg_advisory_xact_lock({lockId})")
+            .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        return conn;
+    }
+
+    private async Task appendEvents(int count)
+    {
+        await using var session = theStore.LightweightSession();
+        for (var i = 0; i < count; i++)
+        {
+            session.Events.StartStream(Guid.NewGuid(), new Bug5108FenceEvent(i + 1));
+        }
+
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task execute(string sql)
+    {
+        await using var conn = await openConnection();
+        await conn.CreateCommand(sql).ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<long> scalar(string sql)
+    {
+        await using var conn = await openConnection();
+        var raw = await conn.CreateCommand(sql).ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        return raw is long l ? l : Convert.ToInt64(raw ?? 0L);
+    }
+
+    private async Task<(NpgsqlConnection conn, NpgsqlTransaction tx, long seq)> startOutstandingAppend()
+    {
+        var conn = await openConnection();
+        var tx = await conn.BeginTransactionAsync(TestContext.Current.CancellationToken);
+        var seq = (long)(await conn.CreateCommand($"select nextval('{Schema}.mt_events_sequence')")
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+        await conn.CreateCommand($@"
+insert into {Schema}.mt_events(seq_id, id, stream_id, version, data, type, timestamp, tenant_id, mt_dotnet_type, is_archived)
+select {seq}, gen_random_uuid(), stream_id, 100000 + {seq}, data, type, now(), tenant_id, mt_dotnet_type, false
+from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        return (conn, tx, seq);
+    }
+
+    private HighWaterDetector buildDetector()
+    {
+        return new HighWaterDetector((MartenDatabase)theStore.Tenancy.Default.Database, theStore.Events,
+            NullLogger.Instance);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// The #5108 §1 shape: a daemon runs and catches up (establishing the fence), the process is
+    /// replaced, and a dead gap is already sitting there when the replacement starts. The replacement
+    /// detector has no in-memory history whatsoever and must still be able to prove the gap dead.
+    /// </summary>
+    [Fact]
+    public async Task a_fresh_detector_inherits_the_fence_its_predecessor_persisted()
+    {
+        StoreOptions(opts => opts.Projections.StaleSequenceThreshold = 500.Milliseconds());
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        var listener = await startIdleAdvisoryLockSession(5108101);
+        try
+        {
+            await appendEvents(8);
+            await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+            // Generation 1: polls while caught up, which is the only moment the sequence's allocated
+            // high is observably at or below the mark
+            var first = buildDetector();
+            (await first.Detect(CancellationToken.None)).CurrentMark.ShouldBe(8);
+
+            (await scalar(
+                    $"select coalesce(max(last_seq_id), -1) from {Schema}.mt_event_progression where name = '{HighWaterAllocationFence.ProgressionName}'"))
+                .ShouldBe(8);
+
+            // The gap forms after that generation is gone
+            var (conn, tx, seq) = await startOutstandingAppend();
+            try
+            {
+                seq.ShouldBe(9);
+                await appendEvents(3); // 10..12 committed
+                await tx.RollbackAsync(TestContext.Current.CancellationToken);
+            }
+            finally
+            {
+                await conn.DisposeAsync();
+            }
+
+            // Generation 2 — a brand new detector, exactly what a redeployed process gets
+            var second = buildDetector();
+            (await second.DetectInSafeZone(CancellationToken.None)).CurrentMark.ShouldBe(8);
+
+            await Task.Delay(700, TestContext.Current.CancellationToken);
+
+            var skipped = await second.DetectInSafeZone(CancellationToken.None);
+            _output.WriteLine($"Fresh detector past threshold: CurrentMark={skipped.CurrentMark}");
+            skipped.CurrentMark.ShouldBe(12);
+            skipped.IncludesSkipping.ShouldBeTrue();
+        }
+        finally
+        {
+            await listener.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// The safety counterpart: a persisted fence must not turn into a licence to skip past a
+    /// transaction that really is still holding the gap. The reserver ran its statements after the
+    /// fence was recorded, so it is never quiescent and the mark has to hold.
+    /// </summary>
+    [Fact]
+    public async Task a_persisted_fence_does_not_skip_past_a_genuinely_live_reserver()
+    {
+        StoreOptions(opts => opts.Projections.StaleSequenceThreshold = 500.Milliseconds());
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        var listener = await startIdleAdvisoryLockSession(5108102);
+        try
+        {
+            await appendEvents(8);
+            await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+            var first = buildDetector();
+            (await first.Detect(CancellationToken.None)).CurrentMark.ShouldBe(8);
+
+            var (conn, tx, seq) = await startOutstandingAppend();
+            try
+            {
+                seq.ShouldBe(9);
+                await appendEvents(3);
+
+                // A fresh detector with only the PERSISTED fence to go on, against a reserver that is
+                // still alive — it must hold, no matter how long it waits
+                var second = buildDetector();
+                (await second.DetectInSafeZone(CancellationToken.None)).CurrentMark.ShouldBe(8);
+
+                await Task.Delay(700, TestContext.Current.CancellationToken);
+                var stillHeld = await second.DetectInSafeZone(CancellationToken.None);
+                _output.WriteLine($"Live reserver, persisted fence only: CurrentMark={stillHeld.CurrentMark}");
+                stillHeld.CurrentMark.ShouldBe(8);
+
+                await tx.RollbackAsync(TestContext.Current.CancellationToken);
+            }
+            finally
+            {
+                await conn.DisposeAsync();
+            }
+        }
+        finally
+        {
+            await listener.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// #5125: no fence can exist at all here — the store was gapped before any detector ever polled —
+    /// and the only open transaction is one of the daemon's own leadership locks. That connection
+    /// exists solely to hold the lock and never appends, so it must not be counted as a reserver.
+    /// </summary>
+    [Fact]
+    public async Task the_daemons_own_advisory_lock_session_does_not_hold_a_dead_gap()
+    {
+        StoreOptions(opts => opts.Projections.StaleSequenceThreshold = 500.Milliseconds());
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        // DaemonContext gives every test class its own DaemonLockId, and the base id is always part of
+        // the set the detector derives — this is the same lock a HotCold coordinator would be holding
+        var daemonLock = await startIdleAdvisoryLockSession(theStore.Options.Projections.DaemonLockId);
+        try
+        {
+            await appendEvents(8);
+            await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+            // The gap forms before ANY detector poll, so no fence — in memory or persisted — can exist
+            var (conn, tx, seq) = await startOutstandingAppend();
+            try
+            {
+                seq.ShouldBe(9);
+                await appendEvents(3); // 10..12 committed
+                await tx.RollbackAsync(TestContext.Current.CancellationToken);
+            }
+            finally
+            {
+                await conn.DisposeAsync();
+            }
+
+            var detector = buildDetector();
+            (await detector.DetectInSafeZone(CancellationToken.None)).CurrentMark.ShouldBe(8);
+
+            (await scalar(
+                    $"select count(*) from {Schema}.mt_event_progression where name = '{HighWaterAllocationFence.ProgressionName}'"))
+                .ShouldBe(0);
+
+            await Task.Delay(700, TestContext.Current.CancellationToken);
+
+            var skipped = await detector.DetectInSafeZone(CancellationToken.None);
+            _output.WriteLine($"Own daemon lock, no fence available: CurrentMark={skipped.CurrentMark}");
+            skipped.CurrentMark.ShouldBe(12);
+            skipped.IncludesSkipping.ShouldBeTrue();
+        }
+        finally
+        {
+            await daemonLock.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// TryCorrectProgressInDatabaseAsync rewrites mt_event_progression with no WHERE clause. The fence
+    /// row records an OBSERVED sequence allocation, not projection progress — restamping it would have
+    /// it claim something that was never observed, and a fence dated later than the truth wrongly
+    /// excludes a live reserver.
+    /// </summary>
+    [Fact]
+    public async Task correcting_progress_leaves_the_fence_row_alone()
+    {
+        StoreOptions(opts => opts.Projections.StaleSequenceThreshold = 500.Milliseconds());
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        await appendEvents(8);
+        await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+        var detector = buildDetector();
+        (await detector.Detect(CancellationToken.None)).CurrentMark.ShouldBe(8);
+
+        var fenceBefore = await scalar(
+            $"select last_seq_id from {Schema}.mt_event_progression where name = '{HighWaterAllocationFence.ProgressionName}'");
+        fenceBefore.ShouldBe(8);
+
+        // Drive the mark above the sequence height so the correction actually fires
+        await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 999999)");
+        await detector.TryCorrectProgressInDatabaseAsync(CancellationToken.None);
+
+        (await scalar(
+                $"select last_seq_id from {Schema}.mt_event_progression where name = 'HighWaterMark'"))
+            .ShouldBe(8);
+
+        (await scalar(
+                $"select last_seq_id from {Schema}.mt_event_progression where name = '{HighWaterAllocationFence.ProgressionName}'"))
+            .ShouldBe(fenceBefore);
+    }
+
+    /// <summary>
+    /// The fence row is high-water bookkeeping, not a shard, and must never be reported as projection
+    /// progress.
+    /// </summary>
+    [Fact]
+    public async Task the_fence_row_is_not_reported_as_projection_progress()
+    {
+        StoreOptions(opts => opts.Projections.StaleSequenceThreshold = 500.Milliseconds());
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        await appendEvents(8);
+        await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+        var detector = buildDetector();
+        await detector.Detect(CancellationToken.None);
+
+        (await scalar(
+                $"select count(*) from {Schema}.mt_event_progression where name = '{HighWaterAllocationFence.ProgressionName}'"))
+            .ShouldBe(1);
+
+        var progress =
+            await theStore.Advanced.AllProjectionProgress(token: TestContext.Current.CancellationToken);
+        progress.ShouldNotContain(x => x.ShardName == HighWaterAllocationFence.ProgressionName);
+    }
+}
+
+public record Bug5108FenceEvent(int Number);

--- a/src/DaemonTests/Internals/detecting_the_high_water_mark.cs
+++ b/src/DaemonTests/Internals/detecting_the_high_water_mark.cs
@@ -131,7 +131,13 @@ public class HighWaterDetectorTests: DaemonContext
 
         var statistics2 = await theDetector.DetectInSafeZone(CancellationToken.None);
 
-        statistics2.CurrentMark.ShouldBe(NumberOfEvents - 96);
+        // #5108 §2: all four dead gaps clear in ONE cycle, not one gap per cycle. Every sequence
+        // number at or below the ceiling recorded at observation was handed out before that moment,
+        // and the liveness probe just established that no transaction from before it is still alive —
+        // so every one of these gaps is provably dead, not just the first. Previously each gap cost
+        // its own detection cycle plus a fresh StaleSequenceThreshold, which is what made recovery
+        // time grow linearly with the number of gaps.
+        statistics2.CurrentMark.ShouldBe(NumberOfEvents);
         statistics2.IncludesSkipping.ShouldBeTrue();
     }
 

--- a/src/Marten/Events/Daemon/HighWater/GapLivenessProbe.cs
+++ b/src/Marten/Events/Daemon/HighWater/GapLivenessProbe.cs
@@ -19,14 +19,14 @@ namespace Marten.Events.Daemon.HighWater;
 /// (e.g. Wolverine's idle-in-transaction advisory-lock listener sessions).
 /// </summary>
 internal record GapLiveness(long OldLockHolders, long OlderTransactions, long OlderWriteXids,
-    long QuiescentSessionsIgnored = 0)
+    long QuiescentSessionsIgnored = 0, long DaemonLockSessionsIgnored = 0)
 {
     public bool IndicatesLiveReserver => OldLockHolders > 0 || OlderTransactions > 0 || OlderWriteXids > 0;
 
     public override string ToString()
     {
         return
-            $"mt_events write locks held by transactions from before the gap: {OldLockHolders}, open transactions from before the gap: {OlderTransactions}, in-progress write transaction ids from before the gap: {OlderWriteXids}, idle-in-transaction sessions ruled out as reservers: {QuiescentSessionsIgnored}";
+            $"mt_events write locks held by transactions from before the gap: {OldLockHolders}, open transactions from before the gap: {OlderTransactions}, in-progress write transaction ids from before the gap: {OlderWriteXids}, idle-in-transaction sessions ruled out as reservers: {QuiescentSessionsIgnored}, daemon advisory-lock sessions ruled out as reservers: {DaemonLockSessionsIgnored}";
     }
 }
 
@@ -68,14 +68,16 @@ internal class GapLivenessProbe: ISingleQueryHandler<GapLiveness>
     private readonly DateTimeOffset _gapFirstObserved;
     private readonly long _xmaxAtObservation;
     private readonly DateTimeOffset? _allocationFence;
+    private readonly long[] _daemonLockIds;
 
     public GapLivenessProbe(EventGraph graph, DateTimeOffset gapFirstObserved, long xmaxAtObservation,
-        DateTimeOffset? allocationFence = null)
+        DateTimeOffset? allocationFence = null, long[]? daemonLockIds = null)
     {
         _graph = graph;
         _gapFirstObserved = gapFirstObserved;
         _xmaxAtObservation = xmaxAtObservation;
         _allocationFence = allocationFence;
+        _daemonLockIds = daemonLockIds ?? [];
     }
 
     public NpgsqlCommand BuildCommand()
@@ -93,6 +95,32 @@ with quiescent as (
    where a.pid <> pg_backend_pid()
      and a.state in ('idle in transaction', 'idle in transaction (aborted)')
      and a.state_change < :fence
+),
+-- #5125: the daemon's OWN HotCold leadership lock. With the default transaction-scoped advisory
+-- lock it sits 'idle in transaction' for the whole of its leadership tenure, so it satisfies the
+-- open-transaction clause forever — including on a store that was already gapped before any daemon
+-- ran, where no allocation fence can ever be established and the quiescent CTE above is therefore
+-- always empty. That connection is dedicated to holding the lock and never appends, so it can never
+-- be a gap's reserver. Matched on Marten's own deterministic lock ids (ProjectionLockIds.Compute
+-- over this store's schema, shards and DaemonLockId), and further restricted to sessions that have
+-- written nothing at all -- a backend that has actually appended has an xid and is never excluded.
+own_daemon_locks as (
+  select a.pid, a.backend_xid
+    from pg_locks l
+    join pg_stat_activity a on a.pid = l.pid
+   where l.locktype = 'advisory'
+     and l.granted
+     and l.pid <> pg_backend_pid()
+     and l.classid = 0
+     and l.objsubid = 1
+     and l.objid = any(:lock_ids)
+     and l.database = (select d.oid from pg_database d where d.datname = current_database())
+     and a.backend_xid is null
+),
+excluded as (
+  select pid, backend_xid from quiescent
+  union
+  select pid, backend_xid from own_daemon_locks
 )
 select
   (select count(*)
@@ -104,7 +132,7 @@ select
       and l.pid <> pg_backend_pid()
       and l.database = (select d.oid from pg_database d where d.datname = current_database())
       and a.xact_start <= :first_observed
-      and l.pid not in (select q.pid from quiescent q)
+      and l.pid not in (select e.pid from excluded e)
       and l.relation in (select c.oid
                            from pg_class c
                            join pg_namespace n on n.oid = c.relnamespace
@@ -118,12 +146,12 @@ select
       and a.backend_type = 'client backend'
       and a.xact_start is not null
       and a.xact_start <= :first_observed
-      and a.pid not in (select q.pid from quiescent q)) as older_transactions,
+      and a.pid not in (select e.pid from excluded e)) as older_transactions,
   (select count(*)
      from pg_snapshot_xip(pg_current_snapshot()) as xip(xid)
     where xip.xid::text::bigint < :xmax0
       and mod(xip.xid::text::bigint, 4294967296) not in
-          (select q.backend_xid::text::bigint from quiescent q where q.backend_xid is not null)) as older_write_xids,
+          (select e.backend_xid::text::bigint from excluded e where e.backend_xid is not null)) as older_write_xids,
   (select count(*)
      from pg_stat_activity a
     where a.datname = current_database()
@@ -131,7 +159,15 @@ select
       and a.backend_type = 'client backend'
       and a.xact_start is not null
       and a.xact_start <= :first_observed
-      and a.pid in (select q.pid from quiescent q)) as quiescent_ignored
+      and a.pid in (select q.pid from quiescent q)) as quiescent_ignored,
+  (select count(*)
+     from pg_stat_activity a
+    where a.datname = current_database()
+      and a.pid <> pg_backend_pid()
+      and a.backend_type = 'client backend'
+      and a.xact_start is not null
+      and a.xact_start <= :first_observed
+      and a.pid in (select o.pid from own_daemon_locks o)) as daemon_lock_ignored
 ".Trim();
 
         var command = new NpgsqlCommand(sql);
@@ -140,6 +176,8 @@ select
         command.AddNamedParameter("xmax0", _xmaxAtObservation);
         // No fence ⇒ nothing qualifies as quiescent ⇒ exactly the unfenced behavior
         command.AddNamedParameter("fence", _allocationFence ?? DateTimeOffset.MinValue);
+        // Empty ⇒ own_daemon_locks matches nothing ⇒ exactly the pre-#5125 behavior
+        command.AddNamedParameter("lock_ids", _daemonLockIds);
 
         return command;
     }
@@ -155,6 +193,7 @@ select
             await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false),
             await reader.GetFieldValueAsync<long>(1, token).ConfigureAwait(false),
             await reader.GetFieldValueAsync<long>(2, token).ConfigureAwait(false),
-            await reader.GetFieldValueAsync<long>(3, token).ConfigureAwait(false));
+            await reader.GetFieldValueAsync<long>(3, token).ConfigureAwait(false),
+            await reader.GetFieldValueAsync<long>(4, token).ConfigureAwait(false));
     }
 }

--- a/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
@@ -290,11 +290,26 @@ internal class HighWaterDetector: IHighWaterDetector
                 observed.Mark, liveness, age, cap);
         }
 
-        // Proven dead (or cap expired): walk past the gap, but never beyond the reserved ceiling
-        // recorded when the gap was first observed — sequence numbers reserved after that belong to
-        // newer transactions whose fate is not proven.
-        var walk = await runGapDetectorAsync(statistics.SafeStartMark + 1, false, token).ConfigureAwait(false);
-        var target = walk.HasValue ? Math.Min(walk.Value, observed.ReservedCeiling) : observed.ReservedCeiling;
+        // Proven dead (or cap expired): clear the WHOLE dead span in one move, but never beyond the
+        // reserved ceiling recorded when the gap was first observed — sequence numbers reserved after
+        // that belong to newer transactions whose fate is not proven.
+        //
+        // #5108 §2: this used to advance to the next gap edge, so a field of N dead gaps took N
+        // detection cycles and each one re-paid StaleSequenceThreshold from a fresh observation —
+        // reported as a mark grinding 38 → 426 over 21 seconds, with the cost growing linearly in
+        // write contention. The evidence already in hand covers the entire span: every sequence number
+        // at or below the ceiling was handed out at or before the observation (nextval runs inside the
+        // reserving transaction, so its xact_start cannot postdate it), and the probe above just
+        // established that no transaction from before the observation is still alive. So every one of
+        // those numbers is now either committed or permanently dead — the same argument that licensed
+        // skipping the first gap, applied to all of them at once.
+        // When nothing at all is committed ABOVE the mark, the dead span runs to the end of the
+        // reserved range — reserved-but-never-committed numbers with no live reserver — and the ceiling
+        // is the target, which is the long-standing GH-2681 behavior the null walk used to express.
+        var committed = await _runner.Query(new CommittedSequenceHandler(_graph), token).ConfigureAwait(false);
+        var target = committed > statistics.LastMark
+            ? Math.Min(committed, observed.ReservedCeiling)
+            : observed.ReservedCeiling;
         if (target <= statistics.LastMark)
         {
             return statistics;

--- a/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core;
+using JasperFx.Events.Daemon;
 using JasperFx.Events.Daemon.HighWater;
 using JasperFx.Events.Projections;
 using Marten.Events.Projections;
@@ -86,6 +87,40 @@ internal class HighWaterDetector: IHighWaterDetector
     private const int AllocationHistoryCapacity = 128;
 
     private sealed record AllocationObservation(DateTimeOffset Timestamp, long AllocatedHigh);
+
+    // #5125: the advisory lock ids this store's HotCold coordinator negotiates leadership with, so the
+    // liveness probe can rule out the daemon's own idle-in-transaction lock connections. Derived
+    // rather than plumbed: every input is known here, and ProjectionLockIds.Compute is the same
+    // formula the JasperFx distributors use, so no reference to the running coordinator is needed.
+    // SingleTenantProjectionDistributor computes one id per shard from the schema qualifier;
+    // MultiTenantedProjectionDistributor uses the base DaemonLockId as-is. Recomputed per probe (only
+    // while a gap is actually stuck) because the shard list moves at runtime under per-tenant
+    // expansion. Negative ids are dropped: those would encode into pg_locks with a non-zero classid
+    // and the probe's predicate deliberately only matches the classid = 0 space.
+    private long[] daemonAdvisoryLockIds()
+    {
+        try
+        {
+            var projections = _graph.Options.Projections;
+            var baseLockId = projections.DaemonLockId;
+
+            var ids = new HashSet<long> { baseLockId };
+            foreach (var shard in projections.AllShards())
+            {
+                ids.Add(ProjectionLockIds.Compute(_graph.DatabaseSchemaName, shard.Name, baseLockId));
+            }
+
+            return ids.Where(x => x >= 0).ToArray();
+        }
+        catch (Exception e)
+        {
+            // Never let lock-id derivation break gap detection — an empty set is exactly the
+            // pre-#5125 behavior (nothing excluded, the daemon holds).
+            _logger.LogDebug(e, "Unable to derive the daemon advisory lock ids for database {Database}",
+                DatabaseIdentity);
+            return [];
+        }
+    }
 
     public HighWaterDetector(MartenDatabase runner, EventGraph graph, ILogger logger)
     {
@@ -225,7 +260,9 @@ internal class HighWaterDetector: IHighWaterDetector
         }
 
         var liveness = await _runner
-            .Query(new GapLivenessProbe(_graph, observed.Since, observed.Xmax, observed.AllocationFence), token)
+            .Query(
+                new GapLivenessProbe(_graph, observed.Since, observed.Xmax, observed.AllocationFence,
+                    daemonAdvisoryLockIds()), token)
             .ConfigureAwait(false);
         if (liveness.IndicatesLiveReserver)
         {
@@ -370,7 +407,7 @@ internal class HighWaterDetector: IHighWaterDetector
                 statistics.Timestamp,
                 (statistics as MartenHighWaterStatistics)?.CurrentXmax ?? 0,
                 statistics.HighestSequence,
-                findAllocationFence(statistics.CurrentMark));
+                findAllocationFence(statistics, statistics.CurrentMark));
         }
     }
 
@@ -639,12 +676,17 @@ select coalesce(
         // No allocation fence here: the vectorized poll reads committed max(seq_id) per tenant, not
         // a reserved last_value, so there is no history to prove when the tenant's gap sequences
         // were allocated — quiescent sessions are NOT ruled out on this path (conservative).
+        // #5125: the daemon's own advisory-lock sessions ARE still ruled out. That exclusion is
+        // structural rather than fence-derived — those connections exist only to hold the leadership
+        // lock and never append — so it holds on this path too, where no fence can ever exist.
         if (_settings.UseTransactionEvidenceForGapSkipping
             && _tenantStaleSince.TryGetValue(statistics.TenantId!, out var observation))
         {
             var age = statistics.Timestamp.Subtract(observation.Since);
             var liveness = await _runner
-                .Query(new GapLivenessProbe(_graph, observation.Since, observation.Xmax), token)
+                .Query(
+                    new GapLivenessProbe(_graph, observation.Since, observation.Xmax, null,
+                        daemonAdvisoryLockIds()), token)
                 .ConfigureAwait(false);
             if (liveness.IndicatesLiveReserver)
             {
@@ -856,10 +898,15 @@ select coalesce(
         var statistics = await loadCurrentStatistics(token).ConfigureAwait(false);
         if (statistics.LastMark > statistics.HighestSequence)
         {
+            // #5108: every row EXCEPT the allocation fence. The fence row's last_seq_id is an observed
+            // sequence allocation, not projection progress — restamping it here would have it claim
+            // that nothing above an arbitrary sequence had been handed out at a moment when that was
+            // never observed, and a fence that is too late wrongly excludes a live reserver.
             await using var cmd =
                 new NpgsqlCommand(
-                        $"update {_graph.DatabaseSchemaName}.mt_event_progression set last_seq_id = :seq, last_updated = transaction_timestamp()")
-                    .With("seq", statistics.HighestSequence);
+                        $"update {_graph.DatabaseSchemaName}.mt_event_progression set last_seq_id = :seq, last_updated = transaction_timestamp() where name <> :fence")
+                    .With("seq", statistics.HighestSequence)
+                    .With("fence", HighWaterAllocationFence.ProgressionName);
 
             await _runner.SingleCommit(cmd, token).ConfigureAwait(false);
         }
@@ -874,7 +921,61 @@ select coalesce(
     {
         var statistics = await _runner.Query(_highWaterStatisticsDetector, token).ConfigureAwait(false);
         recordAllocationObservation(statistics);
+        await persistAllocationFenceAsync(statistics, token).ConfigureAwait(false);
         return statistics;
+    }
+
+    // #5108: the in-memory allocation history above dies with the detector instance, and a daemon that
+    // starts or resumes AFTER a gap formed therefore has no fence at all — the liveness probe falls
+    // back to counting every old open transaction as a possible reserver, so a permanently
+    // idle-in-transaction session (Wolverine's advisory-lock listeners, the daemon's own leadership
+    // lock) holds a dead gap forever. Persisting the fence hands the next detector generation what its
+    // predecessor observed.
+    //
+    // No history is needed in the database: findAllocationFence wants the NEWEST observation whose
+    // allocated high is at or below the mark, and both values only ever move forward, so a single row
+    // maintained incrementally is exactly equivalent. Promote while the store is caught up; the moment
+    // a gap opens, allocation passes the mark, promotion stops, and the row is frozen at the last
+    // moment nothing above the mark had been handed out — precisely the fence.
+    //
+    // Soundness does NOT rest on the mark used here. The row records "at time T, nothing above H had
+    // been allocated", which is true of the statement's own snapshot because the statement re-reads the
+    // sequence itself rather than trusting the reading from the poll above — a timestamp stamped
+    // against a stale allocation reading could sit LATER than the moment it claims, and a fence that is
+    // too late wrongly excludes a genuine reserver. The mark only decides WHEN to refresh; the
+    // read-back independently requires the stored high to be at or below the stuck mark.
+    private async Task persistAllocationFenceAsync(HighWaterStatistics statistics, CancellationToken token)
+    {
+        // Under per-tenant event partitioning tenants draw from their own sequences, so the
+        // store-global sequence says nothing about allocation — same reason AllocatedSequenceHigh is
+        // null there. No sound fence exists to persist.
+        if (_graph.UseTenantPartitionedEvents)
+        {
+            return;
+        }
+
+        try
+        {
+            await using var cmd = new NpgsqlCommand($@"
+insert into {_graph.DatabaseSchemaName}.mt_event_progression(name, last_seq_id, last_updated)
+select '{HighWaterAllocationFence.ProgressionName}', alloc.high, transaction_timestamp()
+from (select case when is_called then last_value else last_value - 1 end as high
+      from {_graph.DatabaseSchemaName}.mt_events_sequence) alloc
+where alloc.high <= :mark
+on conflict (name) do update
+   set last_seq_id = excluded.last_seq_id, last_updated = excluded.last_updated
+ where excluded.last_updated > {_graph.DatabaseSchemaName}.mt_event_progression.last_updated")
+                .With("mark", statistics.LastMark);
+
+            await _runner.SingleCommit(cmd, token).ConfigureAwait(false);
+        }
+        catch (Exception e) when (!token.IsCancellationRequested)
+        {
+            // The fence is an optimization on top of a conservative default: without it the detector
+            // simply holds, which is the pre-#5108 behavior. Never let recording it take down a poll.
+            _logger.LogDebug(e, "Unable to record the high water allocation fence for database {Database}",
+                DatabaseIdentity);
+        }
     }
 
     // #4953 follow-up: feed the allocation history from every statistics poll — see _allocationHistory
@@ -925,23 +1026,36 @@ select coalesce(
 
     // The latest server time at which the highest ALLOCATED sequence number was still at or below the
     // stuck mark — every sequence number above the mark was therefore handed out strictly after this
-    // moment. Null when no qualifying poll is in memory (detector started while the gap already
-    // existed). #5091: reading allocation rather than the reserved ceiling is what lets a gap stuck at
+    // moment. Null when neither this detector's own history nor the persisted row offers a qualifying
+    // reading. #5091: reading allocation rather than the reserved ceiling is what lets a gap stuck at
     // mark 0 be fenced at all, since a pristine sequence reserves 1 while having allocated nothing.
-    private DateTimeOffset? findAllocationFence(long mark)
+    // #5108: the persisted row is what carries a fence across detector restarts — see
+    // persistAllocationFenceAsync. Take the LATER of the two: both are sound, and a later fence rules
+    // out strictly more sessions.
+    private DateTimeOffset? findAllocationFence(HighWaterStatistics statistics, long mark)
     {
+        DateTimeOffset? fence = null;
+
         lock (_allocationHistoryLock)
         {
             for (var i = _allocationHistory.Count - 1; i >= 0; i--)
             {
                 if (_allocationHistory[i].AllocatedHigh <= mark)
                 {
-                    return _allocationHistory[i].Timestamp;
+                    fence = _allocationHistory[i].Timestamp;
+                    break;
                 }
             }
         }
 
-        return null;
+        if (statistics is MartenHighWaterStatistics { PersistedAllocationFence: { } persisted }
+            && persisted.AllocatedHigh <= mark
+            && (fence == null || persisted.ObservedAt > fence.Value))
+        {
+            fence = persisted.ObservedAt;
+        }
+
+        return fence;
     }
 
     private async Task<long> findCurrentMark(HighWaterStatistics statistics, DetectionType detectionType,

--- a/src/Marten/Events/Daemon/HighWater/HighWaterStatisticsDetector.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterStatisticsDetector.cs
@@ -28,6 +28,39 @@ internal class MartenHighWaterStatistics: HighWaterStatistics
     /// not the one being drawn from, so nothing can be concluded about allocation from it.
     /// </summary>
     public long? AllocatedSequenceHigh { get; set; }
+
+    /// <summary>
+    /// #5108: the DURABLE counterpart of the detector's in-memory allocation history — the reading
+    /// persisted by whichever detector last saw the store caught up. Null when no fence has ever been
+    /// recorded for this database (a store that was already gapped before any daemon ran, or a
+    /// tenant-partitioned store, where no sound store-global allocation reading exists).
+    /// </summary>
+    public AllocationFenceReading? PersistedAllocationFence { get; set; }
+}
+
+/// <summary>
+/// #5108: a persisted allocation-fence observation — at <paramref name="ObservedAt" /> the event
+/// sequence had handed out nothing above <paramref name="AllocatedHigh" />. Every sequence number
+/// above that value was therefore allocated strictly later, which is what lets the gap-liveness probe
+/// rule out sessions that have provably executed nothing since.
+/// </summary>
+internal sealed record AllocationFenceReading(long AllocatedHigh, DateTimeOffset ObservedAt);
+
+/// <summary>
+/// #5108: the reserved <c>mt_event_progression.name</c> under which the durable allocation fence
+/// lives. It is bookkeeping for high-water detection, NOT a projection shard: it is deliberately
+/// excluded from <c>ProjectionProgressStatement</c> so it never surfaces as a shard in
+/// <c>AllProjectionProgress()</c>, and from the blanket UPDATE in
+/// <c>HighWaterDetector.TryCorrectProgressInDatabaseAsync</c>, which would otherwise restamp it
+/// against an arbitrary sequence and make the fence claim something that was never observed.
+///
+/// A reserved row rather than a table of its own on purpose: this repairs a DEFAULT-configuration
+/// stall, so it has to engage on every existing database the moment Marten is upgraded, with no DDL
+/// migration standing between the user and the fix.
+/// </summary>
+internal static class HighWaterAllocationFence
+{
+    public const string ProgressionName = "HighWaterAllocationFence";
 }
 
 internal class HighWaterStatisticsDetector: ISingleQueryHandler<HighWaterStatistics>
@@ -72,10 +105,14 @@ select
   pg_snapshot_xmax(pg_current_snapshot())::text::bigint as current_xmax,
   p.last_seq_id,
   p.last_updated,
-  {allocatedHighSql} as allocated_high
+  {allocatedHighSql} as allocated_high,
+  f.last_seq_id as fence_allocated_high,
+  f.last_updated as fence_observed_at
 from (values (1)) as one(x)
 left join {graph.DatabaseSchemaName}.mt_event_progression p
   on p.name = '{HighWaterShardIdentity.StoreGlobal}'
+left join {graph.DatabaseSchemaName}.mt_event_progression f
+  on f.name = '{HighWaterAllocationFence.ProgressionName}'
 ".Trim();
     }
 
@@ -107,6 +144,14 @@ left join {graph.DatabaseSchemaName}.mt_event_progression p
         if (!await reader.IsDBNullAsync(5, token).ConfigureAwait(false))
         {
             statistics.AllocatedSequenceHigh = await reader.GetFieldValueAsync<long>(5, token).ConfigureAwait(false);
+        }
+
+        if (!await reader.IsDBNullAsync(6, token).ConfigureAwait(false)
+            && !await reader.IsDBNullAsync(7, token).ConfigureAwait(false))
+        {
+            statistics.PersistedAllocationFence = new AllocationFenceReading(
+                await reader.GetFieldValueAsync<long>(6, token).ConfigureAwait(false),
+                await reader.GetFieldValueAsync<DateTimeOffset>(7, token).ConfigureAwait(false));
         }
 
         return statistics;

--- a/src/Marten/Events/Daemon/Progress/ProjectionProgressStatement.cs
+++ b/src/Marten/Events/Daemon/Progress/ProjectionProgressStatement.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using JasperFx.Events.Projections;
+using Marten.Events.Daemon.HighWater;
 using Marten.Linq.SqlGeneration;
 using Weasel.Postgresql;
 
@@ -86,6 +87,13 @@ internal class ProjectionProgressStatement: Statement
             // are valid PG identifiers so they don't contain LIKE wildcards.
             builder.Append("name like ");
             builder.AppendParameter("%:" + TenantId);
+            whereStarted = true;
         }
+
+        // #5108: the allocation-fence row is high-water bookkeeping, not a projection shard, and must
+        // never be reported as one — see HighWaterAllocationFence.
+        builder.Append(whereStarted ? " and " : " where ");
+        builder.Append("name <> ");
+        builder.AppendParameter(HighWaterAllocationFence.ProgressionName);
     }
 }


### PR DESCRIPTION
Fixes #5108. Fixes #5125.

## The root cause is shared

Both reports are the same failure at **default settings**: the high water mark pins under a dead sequence gap and never advances again, with `AdvanceHighWaterMarkToLatestAsync()` as the only recovery.

The gap-liveness gate (#4953/#4977) will not skip a gap while any transaction that could still fill it looks alive, and its open-transaction clause counts every client backend whose transaction predates the gap. A session parked `idle in transaction` on an advisory lock trips that clause forever, because it never commits.

#5057 already introduced the sound answer — the **allocation fence**: the latest server time at which the sequence had handed out nothing above the mark. Everything in the gap was allocated later, so any session that has provably executed nothing since cannot be holding it. That works. The problem is that the fence lived only in the detector instance's memory (`_allocationHistory`), so a detector that started *after* the gap formed had none, silently degraded to the pre-#5057 behavior, and never advanced.

- **#5108 §1** — deploy, crash or shard rebalance while a rollback gap exists. Fresh detector, no history, and the fleet's ~57 idle Wolverine listener sessions read as live reservers.
- **#5125** — no restart needed. The store was gapped before any daemon ever ran, so no poll can *ever* observe the sequence at or below the mark and the fence is unobtainable by construction. The session tripping the clause is the daemon's **own** HotCold leadership lock, transaction-scoped by default and therefore idle-in-transaction for its whole tenure.

## The fix

### 1. The fence is durable (`ecda70074`)

No history is needed in the database. The lookup wants the newest observation whose allocated high is at or below the mark, and both values only move forward, so a **single row maintained incrementally** is exactly equivalent. Promote it while the store is caught up; the instant a gap opens, allocation passes the mark, promotion stops, and the row freezes at the last moment nothing above the mark had been handed out.

It's a reserved `mt_event_progression` row rather than a table of its own, deliberately: this repairs a *default-configuration* stall, so it has to engage on every existing database the moment Marten is upgraded, with no DDL migration standing between the user and the fix.

The write re-reads the sequence inside its own statement rather than trusting the poll's reading — a timestamp stamped against a stale allocation reading can sit *later* than the moment it claims, and a fence that is too late wrongly excludes a genuine reserver.

Two guards the reserved row requires:
- `TryCorrectProgressInDatabaseAsync` updates the table with **no WHERE clause** and would restamp the fence into a claim that was never observed.
- `ProjectionProgressStatement` returns every row, which would surface high-water bookkeeping as a projection shard in `AllProjectionProgress()`.

### 2. The daemon's own advisory-lock sessions are ruled out structurally (`ecda70074`)

This turned out to be **essential rather than a niche add-on**, and the test is what proved it: with only the durable fence, the restart case still stalled, because the *replacement* daemon's own leadership lock is a new session that postdates the fence and is therefore never quiescent. So #5125's mechanism dominates #5108 §1 too.

Those connections exist only to hold the lock and never append, so they can never be a gap's reserver. Identified server-side from `pg_locks` against Marten's own deterministic lock ids — `ProjectionLockIds.Compute` over this store's schema, shards and `DaemonLockId` — so nothing has to be plumbed out of the running coordinator. Further restricted to backends with no xid, so anything that has actually written is never excluded. This one needs no fence, so it also applies to the per-tenant path, where no sound fence can ever exist.

A blanket "holds an advisory lock" exclusion would **not** be sound: `RichEventAppender` reserves sequence numbers through `EventSequenceFetcher` as a separate statement before its inserts, so a genuine Rich-mode reserver can be sitting there with no xid and no relation lock. That window is exactly why the open-transaction clause exists, and it is also why the tempting "no `backend_xid` ⇒ not a reserver" shortcut does not hold on its own.

### 3. The whole dead span clears in one cycle (`893c13811`)

Addresses #5108 §2. The skip used to advance to the next gap edge, so N gaps cost N detection cycles and each re-paid `StaleSequenceThreshold` from a fresh observation — reported as a mark grinding 38 → 426 over 21 seconds against ~50 gaps.

One liveness verdict already covers the entire span: every sequence number at or below the ceiling recorded at observation was handed out at or before that moment (nextval runs inside the reserving transaction, so its `xact_start` cannot postdate it), and the probe just established that no transaction from before the observation is still alive. Same argument that already licensed skipping the first gap, applied to all of them at once. The `ReservedCeiling` clamp is unchanged.

## Tests

**End-to-end proof** (`src/DaemonTests.ManualOnly/Coordination/high_water_advances_past_dead_gaps_with_slow_transactions.cs`) — real HotCold daemons, real advisory locks, deliberately slow idle-in-transaction sessions, driven through actual daemon polling. Both scenarios **stall for the full 60s timeout on master** and pass in ~8s here. ManualOnly because they are slow by construction.

**CI-level regression coverage** (`Bug_5108_durable_allocation_fence`, `Bug_5108_dead_gap_span_clears_in_one_cycle`) since CI does not run ManualOnly. Checked against master's production code: the four behavioral tests fail, and the one that passes is the safety test — a genuinely live reserver must still hold the gap — which is the signature it should have.

| Suite | Result |
| --- | --- |
| DaemonTests | 273/273, net10.0 **and** net9.0 |
| EventSourcingTests | 1626/1626 |
| TenantPartitionedEventsTests | 238/238 |
| ManualOnly proof tests | 2/2 |

## Reviewer notes

- **Two behavior changes are deliberate.** `detecting_the_high_water_mark`'s multi-gap assertion encoded the old one-gap-per-cycle behavior and now pins the new one. Dropping the long-standing GH-2681 empty-tail fallback regressed six tests, so that path is preserved explicitly.
- **CoreTests fails 5 tests, pre-existing.** Baselined against unmodified master: identical 5 failures (`Unable to attain a global lock`). Not from this change.
- **Docs badge says 9.23**; current version is 9.22.2. Adjust if that is not the target release.
- **The `UseAdvisoryLockTransaction = false` guidance is now historical** — leaked and live leadership lock sessions are both recognized, so the docs note it as a workaround for older versions only.
- **Unrelated but adjacent:** #5136 (`now() at time zone 'utc'` written into `timestamptz` columns) was found while reviewing #5109. This PR deliberately does no arithmetic on `mt_events.timestamp`, so the two are independent.

## Relationship to #5109

This supersedes #5109. That PR left the liveness verdict alone and instead made the `SkipStaleGapsDespiteLiveTransactionsAfter` cap's clock durable — but the cap is opt-in and lossy by design, so it cannot fix either report's default configuration, and its evidence query is inert in #5125's exact shape (nothing committed above the mark). Once the default path recovers on its own, the cap-clock defect stops mattering.

Credit where due: @uniquelau's detector-churn test in #5109 is the best executable statement of the problem, and their diagnosis of the churn reset is correct. Worth salvaging that test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
