### PR TITLE
Make the stale-gap cap clock survive detector restarts (#5109)

### DIFF
--- a/src/DaemonTests/Bugs/Bug_4953_cap_bounds_fenceless_detector_holds.cs
+++ b/src/DaemonTests/Bugs/Bug_4953_cap_bounds_fenceless_detector_holds.cs
@@ -1,0 +1,466 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Daemon.HighWater;
+using Marten.Storage;
+using Marten.Testing;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace DaemonTests.Bugs;
+
+/// <summary>
+/// Follow-up to #4953/#5057: SkipStaleGapsDespiteLiveTransactionsAfter is documented as the bounded
+/// override for the transaction-evidence hold — once a gap has been stuck past the cap, the skip
+/// proceeds even though a candidate reserver still appears alive. A detector that first observes an
+/// ALREADY-DEAD gap (daemon resumed mid-gap) has no allocation history, so the fence cannot rule
+/// out a Wolverine-style idle-in-transaction listener and the evidence hold engages — exactly the
+/// situation the cap exists to bound. The per-gap clock is detector-scoped, though, so a cap
+/// measured from it alone restarts with every daemon resume and managed-distribution agent churn
+/// can postpone the override forever. What keeps the cap a bound on the STALL rather than on one
+/// detector's observation of it is durable gap evidence: the earliest committed event above the
+/// pinned mark postdates the gap's birth, clamped no earlier than the mark's last advance.
+/// mt_event_progression.last_updated alone is never trusted — it records the last ADVANCE and ages
+/// on a caught-up idle store exactly like on a stuck one — and with nothing committed above the
+/// mark only the running detector's own clock counts, so a live first append after an idle stretch
+/// is held for, not capped away.
+/// </summary>
+public class Bug_4953_cap_bounds_fenceless_detector_holds: DaemonContext
+{
+    private readonly ITestOutputHelper _output;
+
+    public Bug_4953_cap_bounds_fenceless_detector_holds(ITestOutputHelper output): base(output)
+    {
+        _output = output;
+    }
+
+    private string Schema => theStore.Events.DatabaseSchemaName;
+
+    #region helpers
+
+    private async Task<NpgsqlConnection> openConnection()
+    {
+        var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    // The Wolverine-style exclusive listener: an idle-in-transaction session that grabbed a
+    // transaction-scoped advisory lock long ago and will never run another statement.
+    private async Task<NpgsqlConnection> startIdleAdvisoryLockSession(long lockId)
+    {
+        var conn = await openConnection();
+        await conn.BeginTransactionAsync();
+        await conn.CreateCommand($"select pg_advisory_xact_lock({lockId})").ExecuteNonQueryAsync();
+        return conn;
+    }
+
+    private async Task appendEvents(int count, string? tenantId = null)
+    {
+        await using var session = tenantId == null
+            ? theStore.LightweightSession()
+            : theStore.LightweightSession(tenantId);
+        for (var i = 0; i < count; i++)
+        {
+            session.Events.StartStream(Guid.NewGuid(), new Bug4953GapEvent(Guid.NewGuid(), i + 1));
+        }
+
+        await session.SaveChangesAsync();
+    }
+
+    private async Task<long> scalar(string sql)
+    {
+        await using var conn = await openConnection();
+        var raw = await conn.CreateCommand(sql).ExecuteScalarAsync();
+        return raw is long l ? l : Convert.ToInt64(raw ?? 0L);
+    }
+
+    private async Task execute(string sql)
+    {
+        await using var conn = await openConnection();
+        await conn.CreateCommand(sql).ExecuteNonQueryAsync();
+    }
+
+    // Reserves the next sequence number and inserts its event row WITHOUT committing, exactly like
+    // an in-flight SaveChanges
+    private async Task<(NpgsqlConnection conn, NpgsqlTransaction tx, long seq)> startOutstandingAppend()
+    {
+        var conn = await openConnection();
+        var tx = await conn.BeginTransactionAsync();
+        var seq = (long)(await conn.CreateCommand($"select nextval('{Schema}.mt_events_sequence')")
+            .ExecuteScalarAsync())!;
+        await conn.CreateCommand($@"
+insert into {Schema}.mt_events(seq_id, id, stream_id, version, data, type, timestamp, tenant_id, mt_dotnet_type, is_archived)
+select {seq}, gen_random_uuid(), stream_id, 100000 + {seq}, data, type, now(), tenant_id, mt_dotnet_type, false
+from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
+        return (conn, tx, seq);
+    }
+
+    private HighWaterDetector buildDetector()
+    {
+        return new HighWaterDetector((MartenDatabase)theStore.Tenancy.Default.Database, theStore.Events,
+            new TestLogger<HighWaterDetector>(_output));
+    }
+
+    #endregion
+
+    [Fact]
+    public async Task cap_skips_a_pre_existing_dead_gap_despite_an_idle_listener_and_no_allocation_history()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.StaleSequenceThreshold = 250.Milliseconds();
+            opts.Projections.SkipStaleGapsDespiteLiveTransactionsAfter = 500.Milliseconds();
+        });
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        var listener = await startIdleAdvisoryLockSession(4953004);
+        try
+        {
+            await appendEvents(8);
+            await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+            // The dead gap forms BEFORE the detector ever polls — a daemon resumed mid-gap has no
+            // allocation history, so the fence cannot exonerate the idle listener and the evidence
+            // hold engages. The cap is configured, so the hold must be bounded.
+            var (conn, tx, seq) = await startOutstandingAppend();
+            try
+            {
+                seq.ShouldBe(9);
+                await appendEvents(3); // 10..12 committed
+                await tx.RollbackAsync(TestContext.Current.CancellationToken);
+            }
+            finally
+            {
+                await conn.DisposeAsync();
+            }
+
+            var detector = buildDetector();
+
+            // First sighting of the pre-existing gap — hold (the per-gap clock starts here)
+            var first = await detector.DetectInSafeZone(CancellationToken.None);
+            first.CurrentMark.ShouldBe(8);
+
+            await Task.Delay(700, TestContext.Current.CancellationToken);
+
+            // Threshold AND cap have both elapsed. The idle listener still reads as a possible live
+            // reserver (no fence to exonerate it), but the cap must bound that hold and skip anyway.
+            var second = await detector.DetectInSafeZone(CancellationToken.None);
+            _output.WriteLine($"Past cap, fenceless: CurrentMark={second.CurrentMark}");
+            second.CurrentMark.ShouldBe(12);
+            second.IncludesSkipping.ShouldBeTrue();
+
+            var persisted = await scalar(
+                $"select coalesce(max(last_seq_id), 0) from {Schema}.mt_event_progression where name = 'HighWaterMark'");
+            persisted.ShouldBe(12);
+        }
+        finally
+        {
+            await listener.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task idle_store_first_live_append_is_not_cap_skipped()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.StaleSequenceThreshold = 250.Milliseconds();
+            // A generous 10-minute cap: nothing in this test is stuck anywhere near that long
+            opts.Projections.SkipStaleGapsDespiteLiveTransactionsAfter = 10.Minutes();
+        });
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        await appendEvents(8);
+        await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+        // The idle stretch: the mark last advanced an hour ago because nothing was appended —
+        // last_updated ages on a caught-up store exactly like on a stuck one, so it must never be
+        // treated as stall evidence on its own
+        await execute(
+            $"update {Schema}.mt_event_progression set last_updated = transaction_timestamp() - interval '1 hour' where name = 'HighWaterMark'");
+
+        // First append after the idle period: reserves seq 9, still in flight (a slow commit)
+        var (conn, tx, seq) = await startOutstandingAppend();
+        try
+        {
+            seq.ShouldBe(9);
+
+            var detector = buildDetector();
+
+            var first = await detector.DetectInSafeZone(CancellationToken.None);
+            first.CurrentMark.ShouldBe(8); // settle window
+
+            await Task.Delay(400, TestContext.Current.CancellationToken);
+
+            // The gap is ~400ms old, its reserver is provably alive, and nothing is committed above
+            // the mark — there is NO evidence the gap predates this detector's observation, so the
+            // 10-minute cap is nowhere near expired and the detector must HOLD
+            var second = await detector.DetectInSafeZone(CancellationToken.None);
+            _output.WriteLine($"CurrentMark after safe-zone pass: {second.CurrentMark}");
+            second.CurrentMark.ShouldBe(8);
+
+            // The append commits normally a moment later — its events are above the mark, projected
+            await tx.CommitAsync(TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            await conn.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task live_reserver_is_not_cap_skipped_before_the_cap_genuinely_elapses()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.StaleSequenceThreshold = 250.Milliseconds();
+            opts.Projections.SkipStaleGapsDespiteLiveTransactionsAfter = 2500.Milliseconds();
+        });
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        await appendEvents(8);
+        await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+        // seq 9 reserved by a transaction that stays alive throughout; 10..12 commit above it, so
+        // durable gap evidence EXISTS — but it is young, and the cap (10x the threshold) has not
+        // genuinely elapsed. Past the threshold the detector must still hold for the live reserver.
+        var (conn, tx, seq) = await startOutstandingAppend();
+        try
+        {
+            seq.ShouldBe(9);
+            await appendEvents(3); // 10..12 committed
+
+            var detector = buildDetector();
+
+            var first = await detector.DetectInSafeZone(CancellationToken.None);
+            first.CurrentMark.ShouldBe(8);
+
+            await Task.Delay(400, TestContext.Current.CancellationToken);
+
+            var second = await detector.DetectInSafeZone(CancellationToken.None);
+            _output.WriteLine($"Past threshold, before cap: CurrentMark={second.CurrentMark}");
+            second.CurrentMark.ShouldBe(8);
+
+            await tx.RollbackAsync(TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            await conn.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task detector_churn_does_not_postpone_the_cap_forever()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.StaleSequenceThreshold = 250.Milliseconds();
+            opts.Projections.SkipStaleGapsDespiteLiveTransactionsAfter = 600.Milliseconds();
+        });
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        var listener = await startIdleAdvisoryLockSession(4953006);
+        try
+        {
+            await appendEvents(8);
+            await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+            var (conn, tx, seq) = await startOutstandingAppend();
+            try
+            {
+                seq.ShouldBe(9);
+                await appendEvents(3); // 10..12 committed
+                await tx.RollbackAsync(TestContext.Current.CancellationToken);
+            }
+            finally
+            {
+                await conn.DisposeAsync();
+            }
+
+            // The stall is already older than the cap before any detector ever sees it
+            await Task.Delay(700, TestContext.Current.CancellationToken);
+
+            // Managed-distribution churn: each cycle is a freshly built daemon whose detector never
+            // lives long enough to accumulate the cap on its own in-memory clock (300ms < 600ms).
+            // The mark itself has been pinned since long before the cap, which mt_event_progression's
+            // last_updated records durably — the cap must bound the STALL, not one detector's
+            // observation of it, so some cycle here has to skip.
+            for (var cycle = 0; cycle < 4; cycle++)
+            {
+                var detector = buildDetector();
+
+                var first = await detector.DetectInSafeZone(CancellationToken.None);
+                first.CurrentMark.ShouldBe(8); // settle window for a just-appeared gap always holds
+
+                await Task.Delay(300, TestContext.Current.CancellationToken);
+
+                var second = await detector.DetectInSafeZone(CancellationToken.None);
+                _output.WriteLine($"Cycle {cycle}: CurrentMark={second.CurrentMark}");
+                if (second.CurrentMark > 8)
+                {
+                    second.CurrentMark.ShouldBe(12);
+                    second.IncludesSkipping.ShouldBeTrue();
+
+                    var persisted = await scalar(
+                        $"select coalesce(max(last_seq_id), 0) from {Schema}.mt_event_progression where name = 'HighWaterMark'");
+                    persisted.ShouldBe(12);
+                    return;
+                }
+            }
+
+            throw new ShouldAssertException(
+                "The high water mark never skipped the dead gap: every detector restart reset the SkipStaleGapsDespiteLiveTransactionsAfter clock, so the cap never bounded the stall");
+        }
+        finally
+        {
+            await listener.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task conjoined_tenancy_routes_store_global_and_the_cap_still_bounds_detector_churn()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.StaleSequenceThreshold = 250.Milliseconds();
+            opts.Projections.SkipStaleGapsDespiteLiveTransactionsAfter = 600.Milliseconds();
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Policies.AllDocumentsAreMultiTenanted();
+        });
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        var listener = await startIdleAdvisoryLockSession(4953007);
+        try
+        {
+            await appendEvents(8, "greenacres");
+            await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+            // A tenant append reserves from the SHARED sequence and rolls back — the burned number is
+            // a hole in the one store-wide sequence, exactly the shape an optimistic-concurrency
+            // loser leaves under conjoined tenancy
+            var (conn, tx, seq) = await startOutstandingAppend();
+            try
+            {
+                seq.ShouldBe(9);
+                await appendEvents(3, "greenacres"); // 10..12 committed
+                await tx.RollbackAsync(TestContext.Current.CancellationToken);
+            }
+            finally
+            {
+                await conn.DisposeAsync();
+            }
+
+            await Task.Delay(700, TestContext.Current.CancellationToken);
+
+            // Conjoined tenancy shares one event sequence and one HighWaterMark row: the vectorized
+            // per-tenant path is gated on UseTenantPartitionedEvents, NOT on TenancyStyle, so a
+            // conjoined store's daemon detects through the same store-global path as a single-tenant
+            // store — the per-tenant API collapses to the store-global reading
+            var probe = buildDetector();
+            probe.SupportsTenantPartitioning.ShouldBeFalse();
+            var vector = await probe.DetectInSafeZoneForTenantsAsync(["greenacres"], CancellationToken.None);
+            vector.TenantCount.ShouldBe(0);
+            vector.Global.ShouldNotBeNull();
+            vector.Global.CurrentMark.ShouldBe(8); // first sighting for this detector: settle hold
+
+            // Same churn shape as detector_churn_does_not_postpone_the_cap_forever, on the conjoined
+            // store: no single detector lives long enough to accumulate the cap in memory, so only
+            // the durable pinned age can bound the stall
+            for (var cycle = 0; cycle < 4; cycle++)
+            {
+                var detector = buildDetector();
+
+                var first = await detector.DetectInSafeZone(CancellationToken.None);
+                first.CurrentMark.ShouldBe(8);
+
+                await Task.Delay(300, TestContext.Current.CancellationToken);
+
+                var second = await detector.DetectInSafeZone(CancellationToken.None);
+                _output.WriteLine($"Cycle {cycle}: CurrentMark={second.CurrentMark}");
+                if (second.CurrentMark > 8)
+                {
+                    second.CurrentMark.ShouldBe(12);
+                    second.IncludesSkipping.ShouldBeTrue();
+
+                    var persisted = await scalar(
+                        $"select coalesce(max(last_seq_id), 0) from {Schema}.mt_event_progression where name = 'HighWaterMark'");
+                    persisted.ShouldBe(12);
+                    return;
+                }
+            }
+
+            throw new ShouldAssertException(
+                "The conjoined-tenancy store's high water mark never skipped the dead gap despite the cap having long expired");
+        }
+        finally
+        {
+            await listener.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task running_daemon_resumed_after_the_gap_formed_skips_within_the_cap()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.StaleSequenceThreshold = 250.Milliseconds();
+            opts.Projections.SkipStaleGapsDespiteLiveTransactionsAfter = 500.Milliseconds();
+            opts.Projections.Add(new Bug4953GapViewProjection(), ProjectionLifecycle.Async);
+        });
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        var listener = await startIdleAdvisoryLockSession(4953005);
+        try
+        {
+            await appendEvents(8);
+            await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+            // Gap forms while no daemon is running — the resumed daemon's detector never sees the
+            // store without the gap
+            var (conn, tx, seq) = await startOutstandingAppend();
+            try
+            {
+                seq.ShouldBe(9);
+                await appendEvents(3); // 10..12 committed
+                await tx.RollbackAsync(TestContext.Current.CancellationToken);
+            }
+            finally
+            {
+                await conn.DisposeAsync();
+            }
+
+            using var daemon = await StartDaemon();
+
+            // threshold + cap total 750ms; the poll cadence adds ~1s slop per safe-zone pass. 10s of
+            // no progress means the cap never fired.
+            var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+            long persisted = 8;
+            while (DateTimeOffset.UtcNow < deadline)
+            {
+                persisted = await scalar(
+                    $"select coalesce(max(last_seq_id), 0) from {Schema}.mt_event_progression where name = 'HighWaterMark'");
+                if (persisted >= 12)
+                {
+                    break;
+                }
+
+                await Task.Delay(250, TestContext.Current.CancellationToken);
+            }
+
+            _output.WriteLine($"Persisted high water after resume: {persisted}");
+            persisted.ShouldBe(12);
+        }
+        finally
+        {
+            await listener.DisposeAsync();
+        }
+    }
+}

--- a/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
@@ -63,7 +63,7 @@ internal class HighWaterDetector: IHighWaterDetector
     // gap's sequence numbers were even allocated. Detector-scoped state: resets on restart, which
     // only means a stuck gap waits one fresh threshold before skipping.
     private sealed record StuckGapObservation(long Mark, DateTimeOffset Since, long Xmax, long ReservedCeiling,
-        DateTimeOffset? AllocationFence);
+        DateTimeOffset? AllocationFence, DateTimeOffset? DurableSince);
 
     private StuckGapObservation? _stuckGap;
 
@@ -252,6 +252,10 @@ internal class HighWaterDetector: IHighWaterDetector
             return statistics;
         }
 
+        // #5109: publish the sighting so the NEXT detector generation inherits this gap's clock. The
+        // upsert only restamps when the mark differs, so repeated polls preserve the original moment.
+        await persistStuckGapAsync(observed.Mark, token).ConfigureAwait(false);
+
         var age = statistics.Timestamp.Subtract(observed.Since);
         if (age < _settings.StaleSequenceThreshold)
         {
@@ -266,14 +270,28 @@ internal class HighWaterDetector: IHighWaterDetector
             .ConfigureAwait(false);
         if (liveness.IndicatesLiveReserver)
         {
+            // #5109: the STALE THRESHOLD deliberately stays on the in-memory clock above, so a fresh
+            // detector always gives a just-appeared gap a full settle window before considering a skip.
+            // The CAP is the opposite: it exists to bound the stall itself, so it measures from the
+            // first sighting recorded durably for this mark. Without that, agent churn or restart
+            // cycles shorter than the cap postpone the documented bound forever.
             var cap = _settings.SkipStaleGapsDespiteLiveTransactionsAfter;
-            if (cap == null || age < cap.Value)
+            var stuckAge = observed.DurableSince is { } durable
+                ? statistics.Timestamp.Subtract(durable)
+                : age;
+            if (stuckAge < age)
             {
-                if (age > _settings.StaleSequenceThreshold * 5)
+                // Never let the durable clock read YOUNGER than what this detector has watched
+                stuckAge = age;
+            }
+
+            if (cap == null || stuckAge < cap.Value)
+            {
+                if (stuckAge > _settings.StaleSequenceThreshold * 5)
                 {
                     _logger.LogWarning(
                         "Daemon high water detection has held before the sequence gap above {Mark} for {Age} because a transaction that may still fill it appears to be alive ({Liveness}). Projections will not advance until it commits, aborts, or the SkipStaleGapsDespiteLiveTransactionsAfter cap expires",
-                        observed.Mark, age, liveness);
+                        observed.Mark, stuckAge, liveness);
                 }
                 else
                 {
@@ -287,7 +305,7 @@ internal class HighWaterDetector: IHighWaterDetector
 
             _logger.LogWarning(
                 "Daemon high water detection is skipping the sequence gap above {Mark} DESPITE evidence of a live transaction ({Liveness}) because the gap has been stuck for {Age}, past the configured SkipStaleGapsDespiteLiveTransactionsAfter cap of {Cap}. Events committed later inside the skipped range will NOT be projected",
-                observed.Mark, liveness, age, cap);
+                observed.Mark, liveness, stuckAge, cap);
         }
 
         // Proven dead (or cap expired): clear the WHOLE dead span in one move, but never beyond the
@@ -417,12 +435,22 @@ internal class HighWaterDetector: IHighWaterDetector
         var current = _stuckGap;
         if (current == null || current.Mark != statistics.CurrentMark)
         {
+            // #5109: the cap is meant to bound how long the GAP has been stuck, not how long THIS
+            // detector has watched it. A durable record of the first sighting — keyed on the pinned
+            // mark, so it only applies while the mark has not moved — is what makes daemon restarts
+            // and managed-distribution agent churn stop resetting the clock.
+            var durableSince = statistics is MartenHighWaterStatistics { PersistedStuckGap: { } stuck }
+                               && stuck.Mark == statistics.CurrentMark
+                ? stuck.FirstObservedAt
+                : (DateTimeOffset?)null;
+
             _stuckGap = new StuckGapObservation(
                 statistics.CurrentMark,
                 statistics.Timestamp,
                 (statistics as MartenHighWaterStatistics)?.CurrentXmax ?? 0,
                 statistics.HighestSequence,
-                findAllocationFence(statistics, statistics.CurrentMark));
+                findAllocationFence(statistics, statistics.CurrentMark),
+                durableSince);
         }
     }
 
@@ -436,6 +464,10 @@ internal class HighWaterDetector: IHighWaterDetector
         // #4953: the poll loop is where a stuck gap is usually seen first — record it here so the
         // per-gap stale clock starts as early as possible
         trackStuckGap(statistics);
+        if (_stuckGap is { } polled)
+        {
+            await persistStuckGapAsync(polled.Mark, token).ConfigureAwait(false);
+        }
 
         return statistics;
     }
@@ -919,9 +951,10 @@ select coalesce(
             // never observed, and a fence that is too late wrongly excludes a live reserver.
             await using var cmd =
                 new NpgsqlCommand(
-                        $"update {_graph.DatabaseSchemaName}.mt_event_progression set last_seq_id = :seq, last_updated = transaction_timestamp() where name <> :fence")
+                        $"update {_graph.DatabaseSchemaName}.mt_event_progression set last_seq_id = :seq, last_updated = transaction_timestamp() where name <> :fence and name <> :stuck")
                     .With("seq", statistics.HighestSequence)
-                    .With("fence", HighWaterAllocationFence.ProgressionName);
+                    .With("fence", HighWaterAllocationFence.ProgressionName)
+                    .With("stuck", HighWaterStuckGap.ProgressionName);
 
             await _runner.SingleCommit(cmd, token).ConfigureAwait(false);
         }
@@ -938,6 +971,41 @@ select coalesce(
         recordAllocationObservation(statistics);
         await persistAllocationFenceAsync(statistics, token).ConfigureAwait(false);
         return statistics;
+    }
+
+    // #5109: durable first-sighting clock for the SkipStaleGapsDespiteLiveTransactionsAfter cap. The
+    // row records "the mark was already pinned HERE at this moment"; because the mark only ever moves
+    // forward, that stays true for as long as the mark has not moved, which makes it a sound lower
+    // bound on how long the gap has been stuck. Keyed on the mark so it self-invalidates: a different
+    // mark means a different gap and the clock restarts.
+    //
+    // Deliberately server time only. The obvious alternative — dating the stall from the earliest
+    // committed event above the mark — reads mt_events.timestamp, which is client-written in Rich
+    // append mode (the default) and skewed by the server's UTC offset in Quick mode (#5136), so a
+    // behind-clock client or a non-UTC server could age a gap past the cap and drop a live append's
+    // events.
+    private async Task persistStuckGapAsync(long mark, CancellationToken token)
+    {
+        try
+        {
+            await using var cmd = new NpgsqlCommand($@"
+insert into {_graph.DatabaseSchemaName}.mt_event_progression(name, last_seq_id, last_updated)
+values (:name, :mark, transaction_timestamp())
+on conflict (name) do update
+   set last_seq_id = excluded.last_seq_id, last_updated = excluded.last_updated
+ where {_graph.DatabaseSchemaName}.mt_event_progression.last_seq_id <> excluded.last_seq_id")
+                .With("name", HighWaterStuckGap.ProgressionName)
+                .With("mark", mark);
+
+            await _runner.SingleCommit(cmd, token).ConfigureAwait(false);
+        }
+        catch (Exception e) when (!token.IsCancellationRequested)
+        {
+            // Losing the durable clock only costs the cap its head start — the in-memory clock still
+            // governs, which is the pre-#5109 behavior. Never fail a poll over bookkeeping.
+            _logger.LogDebug(e, "Unable to record the stuck gap observation for database {Database}",
+                DatabaseIdentity);
+        }
     }
 
     // #5108: the in-memory allocation history above dies with the detector instance, and a daemon that

--- a/src/Marten/Events/Daemon/HighWater/HighWaterStatisticsDetector.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterStatisticsDetector.cs
@@ -36,6 +36,12 @@ internal class MartenHighWaterStatistics: HighWaterStatistics
     /// tenant-partitioned store, where no sound store-global allocation reading exists).
     /// </summary>
     public AllocationFenceReading? PersistedAllocationFence { get; set; }
+
+    /// <summary>
+    /// #5109: the durable stuck-gap clock — when the mark this reading carries was FIRST seen pinned,
+    /// recorded by whichever detector generation saw it first. Null when no gap is currently recorded.
+    /// </summary>
+    public StuckGapReading? PersistedStuckGap { get; set; }
 }
 
 /// <summary>
@@ -61,6 +67,28 @@ internal sealed record AllocationFenceReading(long AllocatedHigh, DateTimeOffset
 internal static class HighWaterAllocationFence
 {
     public const string ProgressionName = "HighWaterAllocationFence";
+}
+
+/// <summary>
+/// #5109: a persisted stuck-gap observation — the high water mark was ALREADY pinned at
+/// <paramref name="Mark" /> at <paramref name="FirstObservedAt" />. The mark only advances, so while it
+/// is still sitting at that value the gap above it has been stuck at least that long. That is a lower
+/// bound on the stall's age, which is the direction the
+/// <c>SkipStaleGapsDespiteLiveTransactionsAfter</c> cap needs, and it is measured entirely in server
+/// time — no <c>mt_events.timestamp</c>, which is client-written in Rich append mode and skewed by the
+/// server's UTC offset in Quick mode (#5136).
+/// </summary>
+internal sealed record StuckGapReading(long Mark, DateTimeOffset FirstObservedAt);
+
+/// <summary>
+/// #5109: the reserved <c>mt_event_progression.name</c> under which the durable stuck-gap clock lives.
+/// Bookkeeping, not a projection shard — excluded from <c>ProjectionProgressStatement</c> and from the
+/// blanket UPDATE in <c>HighWaterDetector.TryCorrectProgressInDatabaseAsync</c> for the same reasons as
+/// <see cref="HighWaterAllocationFence" />.
+/// </summary>
+internal static class HighWaterStuckGap
+{
+    public const string ProgressionName = "HighWaterStuckGap";
 }
 
 internal class HighWaterStatisticsDetector: ISingleQueryHandler<HighWaterStatistics>
@@ -107,12 +135,16 @@ select
   p.last_updated,
   {allocatedHighSql} as allocated_high,
   f.last_seq_id as fence_allocated_high,
-  f.last_updated as fence_observed_at
+  f.last_updated as fence_observed_at,
+  g.last_seq_id as stuck_gap_mark,
+  g.last_updated as stuck_gap_first_observed
 from (values (1)) as one(x)
 left join {graph.DatabaseSchemaName}.mt_event_progression p
   on p.name = '{HighWaterShardIdentity.StoreGlobal}'
 left join {graph.DatabaseSchemaName}.mt_event_progression f
   on f.name = '{HighWaterAllocationFence.ProgressionName}'
+left join {graph.DatabaseSchemaName}.mt_event_progression g
+  on g.name = '{HighWaterStuckGap.ProgressionName}'
 ".Trim();
     }
 
@@ -152,6 +184,14 @@ left join {graph.DatabaseSchemaName}.mt_event_progression f
             statistics.PersistedAllocationFence = new AllocationFenceReading(
                 await reader.GetFieldValueAsync<long>(6, token).ConfigureAwait(false),
                 await reader.GetFieldValueAsync<DateTimeOffset>(7, token).ConfigureAwait(false));
+        }
+
+        if (!await reader.IsDBNullAsync(8, token).ConfigureAwait(false)
+            && !await reader.IsDBNullAsync(9, token).ConfigureAwait(false))
+        {
+            statistics.PersistedStuckGap = new StuckGapReading(
+                await reader.GetFieldValueAsync<long>(8, token).ConfigureAwait(false),
+                await reader.GetFieldValueAsync<DateTimeOffset>(9, token).ConfigureAwait(false));
         }
 
         return statistics;

--- a/src/Marten/Events/Daemon/Progress/ProjectionProgressStatement.cs
+++ b/src/Marten/Events/Daemon/Progress/ProjectionProgressStatement.cs
@@ -90,10 +90,14 @@ internal class ProjectionProgressStatement: Statement
             whereStarted = true;
         }
 
-        // #5108: the allocation-fence row is high-water bookkeeping, not a projection shard, and must
-        // never be reported as one — see HighWaterAllocationFence.
+        // #5108/#5109: high-water bookkeeping rows are not projection shards and must never be
+        // reported as such — see HighWaterAllocationFence and HighWaterStuckGap.
         builder.Append(whereStarted ? " and " : " where ");
-        builder.Append("name <> ");
-        builder.AppendParameter(HighWaterAllocationFence.ProgressionName);
+        builder.Append("name <> ALL(");
+        builder.AppendParameter(new[]
+        {
+            HighWaterAllocationFence.ProgressionName, HighWaterStuckGap.ProgressionName
+        });
+        builder.Append(")");
     }
 }


### PR DESCRIPTION
Carries forward the defect and the tests from #5109 by @uniquelau, with a different mechanism.

## The defect (their diagnosis, confirmed)

`SkipStaleGapsDespiteLiveTransactionsAfter` is documented as the bounded override for the transaction-evidence hold — once a gap has been stuck past the cap, the skip proceeds even though a candidate reserver still looks alive. But it measured from `_stuckGap.Since`, an in-memory observation that dies with the detector instance. Under managed-distribution agent churn, or restart cycles shorter than the cap, the clock reset every cycle and the documented bound never fired.

#5163 did **not** address this — it repaired the allocation fence, which is a different mechanism. Confirmed empirically: applying their test file to current master, **4 of 6 pass** (#5163 handles those scenarios) and the **2 detector-churn cases fail**. This fixes those two.

## The mechanism

Record the first sighting durably: a reserved `mt_event_progression` row holding the pinned mark and the moment it was first seen pinned. The mark only ever advances, so while it has not moved that timestamp stays a sound **lower bound** on how long the gap has been stuck — the direction a cap needs. Keying the row on the mark makes it self-invalidating: a different mark is a different gap, and the clock restarts.

The stale threshold deliberately stays on the in-memory clock, so a fresh detector still gives a just-appeared gap a full settle window. A null cap (the default) is untouched.

## Why not the original approach

#5109 dated the stall from the timestamp of the earliest committed event above the mark. That reads `mt_events.timestamp`, which is client-written in Rich append mode (the default) and skewed by the server's UTC offset in Quick mode — see #5136, which was found while reviewing that PR. A behind-clock client or a non-UTC server could age a gap past the cap and drop a live append's events. Using the mark's own pinning time keeps everything in server time and needs no trust in event timestamps at all.

The original PR's `last_updated`-only rejection still stands and its guard test (`idle_store_first_live_append_is_not_cap_skipped`) is carried over intact.

## Tests

All six tests are @uniquelau's from #5109, unchanged in substance, with co-authorship on the commit:

| Test | master | here |
| --- | --- | --- |
| `cap_skips_a_pre_existing_dead_gap_despite_an_idle_listener_and_no_allocation_history` | pass | pass |
| `idle_store_first_live_append_is_not_cap_skipped` (guard) | pass | pass |
| `live_reserver_is_not_cap_skipped_before_the_cap_genuinely_elapses` (guard) | pass | pass |
| `running_daemon_resumed_after_the_gap_formed_skips_within_the_cap` | pass | pass |
| **`detector_churn_does_not_postpone_the_cap_forever`** | **fail** | pass |
| **`conjoined_tenancy_routes_store_global_and_the_cap_still_bounds_detector_churn`** | **fail** | pass |

DaemonTests 280/280 net10.0. Further suites running locally; will report.

## Housekeeping

The new reserved row is excluded from `ProjectionProgressStatement` and from the blanket UPDATE in `TryCorrectProgressInDatabaseAsync`, same as the allocation fence. #5164's `isProgressRow` allowlist already ignores unrecognised bookkeeping names, so `WaitForNonStaleProjectionDataAsync` needed no change — which is that hardening paying for itself immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)