### PR TITLE
Fix StreamOne streaming the document id as the body on an identity-tracking session

### DIFF
--- a/src/IssueService/StreamingMinimalEndpoints.cs
+++ b/src/IssueService/StreamingMinimalEndpoints.cs
@@ -45,6 +45,15 @@ public static class StreamingMinimalEndpoints
                     ContentType = "application/vnd.marten.issue+json"
                 });
 
+        // Streamed through an identity-tracking session rather than the QueryOnly IQuerySession every
+        // other endpoint here uses. That is not a nicety: IdColumn.ShouldSelect is
+        // storageStyle != QueryOnly, so this is the only shape whose select list starts d.id, d.data, and
+        // it is the shape a Wolverine.Http endpoint gets when the Marten integration hands it a session.
+        // Aliasing the payload by position streamed the id as the whole body here.
+        app.MapGet("/minimal/issue/{id:guid}/from-document-session",
+            (Guid id, IDocumentSession session)
+                => new StreamOne<Issue>(session.Query<Issue>().Where(x => x.Id == id)));
+
         // EmitETag = false opt-out
         app.MapGet("/minimal/issue/{id:guid}/no-etag",
             (Guid id, IQuerySession session)

--- a/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
+++ b/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
@@ -121,6 +121,39 @@ public class streaming_result_types_tests: IntegrationContext
         });
     }
 
+    [Fact]
+    public async Task stream_one_streams_the_document_through_an_identity_tracking_session()
+    {
+        // Every other endpoint here takes the QueryOnly IQuerySession, where the payload happens to be the
+        // first selected field. IdColumn.ShouldSelect is storageStyle != QueryOnly, so an identity-tracking
+        // session selects d.id, d.data, ... instead — and aliasing the payload by position then put the
+        // alias on the id, so the reader streamed the document's id as the entire body: a 200 whose payload
+        // does not deserialize into the document type.
+        var issue = new Issue { Description = "through a document session", Open = true };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}/from-document-session");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var body = result.ReadAsText();
+        body.ShouldNotBe($"\"{issue.Id}\"", "the body must be the document, not its id");
+
+        var read = result.ReadAsJson<Issue>();
+        read.Id.ShouldBe(issue.Id);
+        read.Description.ShouldBe(issue.Description);
+
+        // The ETag is the point of this code path, so prove the alias fix did not cost it.
+        result.Context.Response.Headers.ETag.ToString().ShouldNotBeNullOrEmpty();
+    }
+
     // ───────────────────────── StreamOne<T> ETag / If-None-Match ─────────────────────────
 
     [Fact]

--- a/src/Marten/Linq/SqlGeneration/VersionSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/VersionSelectClause.cs
@@ -53,6 +53,14 @@ internal class VersionSelectClause<T>: ISelectClause, IModifyableFromObject wher
     private static readonly string VersionColumn =
         $"d.{SchemaConstants.VersionColumn} as {VersionSelectClause.VersionAlias}";
 
+    /// <summary>
+    /// The payload column as the document storage selects it, used to find the field to alias rather than
+    /// assuming its position. Matches <c>DocumentStorage</c>, which builds its select fields as
+    /// <c>d.{column.Name}</c>, and <c>DataColumn</c>, whose name is the same <c>data</c> the streaming reader
+    /// looks up.
+    /// </summary>
+    private static readonly string PayloadColumn = $"d.{VersionSelectClause.DataAlias}";
+
     public VersionSelectClause(ISelectClause inner)
     {
         Inner = inner;
@@ -68,15 +76,33 @@ internal class VersionSelectClause<T>: ISelectClause, IModifyableFromObject wher
     /// <summary>
     /// The inner clause's fields with the payload explicitly aliased to <c>data</c> — see the
     /// remarks on <see cref="VersionSelectClause"/> for why the alias cannot be left implicit.
-    /// <c>DocumentTable.SelectColumns</c> guarantees the payload is the first selected field
-    /// ("the order of the selection is data, id, everything else"), so the remaining fields —
-    /// e.g. the <c>mt_version</c> a revisioned document's storage already selects — pass through
-    /// untouched and keep their own names.
+    /// <para>
+    /// The payload is <b>not</b> reliably the first selected field, whatever the older comment in
+    /// <c>DocumentTable.SelectColumns</c> says: that method puts the id first whenever the id is selected at
+    /// all, and <c>IdColumn.ShouldSelect</c> is <c>storageStyle != QueryOnly</c>. So a query through any
+    /// identity-tracking session selects <c>d.id, d.data, …</c>, aliasing field 0 put the alias on the id
+    /// column, and the streaming reader — which looks the payload up by the name <c>data</c> — found the id
+    /// and wrote the document's id as the entire response body. A 200 whose payload does not deserialize
+    /// into the document type.
+    /// </para>
+    /// <para>
+    /// Matching the payload column by name fixes that for every storage style. The positional fallback stays
+    /// for an inner clause that <i>projects</i> rather than selects the column — <c>SelectDataSelectClause</c>'s
+    /// <c>jsonb_build_object(...)</c> under a <c>Select()</c> (#5158) — where there is no column name to match
+    /// and the projection is the only candidate anyway.
+    /// </para>
     /// </summary>
     private string[] innerFields()
     {
         var fields = Inner.SelectFields().ToArray();
-        fields[0] = $"{fields[0]} as {VersionSelectClause.DataAlias}";
+
+        var payload = Array.IndexOf(fields, PayloadColumn);
+        if (payload < 0)
+        {
+            payload = 0;
+        }
+
+        fields[payload] = $"{fields[payload]} as {VersionSelectClause.DataAlias}";
         return fields;
     }
 


### PR DESCRIPTION
`StreamOne<T>` returns **200 with the document's id as the whole body** when the query runs on an identity-tracking session. Found on 9.22.3 in an application whose HTTP endpoints receive their session from Wolverine's Marten integration rather than a `QueryOnly` `IQuerySession`.

```
GET /api/v1/institution-invoice/{id}    200 OK
Content-Length: 38
ETag: "1"
Content-Type: application/json

"422c81ae-d73c-48ac-be1f-4eb65eefb606"
```

which surfaces at the caller as

```
System.Text.Json.JsonException: The JSON value could not be converted to InstitutionInvoice.
Path: $ | LineNumber: 0 | BytePositionInLine: 38
```

38 bytes is a quoted GUID, and that was the clue: the body is the id column.

## Cause

`VersionSelectClause<T>.innerFields()` aliases the payload to `data` — the name the streaming reader looks it up by — **by position**:

```csharp
var fields = Inner.SelectFields().ToArray();
fields[0] = $"{fields[0]} as {VersionSelectClause.DataAlias}";
```

on the strength of its own comment: *"`DocumentTable.SelectColumns` guarantees the payload is the first selected field ('the order of the selection is data, id, everything else')"*.

`SelectColumns` does not do that. It adds the id first whenever the id is selected:

```csharp
if (id != null) { columns.Remove(id); answer.Add(id); }
columns.Remove(data); answer.Add(data);
```

and `IdColumn.ShouldSelect` is `storageStyle != StorageStyle.QueryOnly`. So the select list starts `d.data` **only** for `QueryOnly`; through a lightweight, identity-map or dirty-tracking session it starts `d.id, d.data`. The alias landed on the id, `GetOrdinal("data")` found the id column, and `WriteJsonValueAsync` streamed the id.

The comment in `SelectColumns` is describing what *older code assumes*, not what the method guarantees — worth reading as a warning rather than a contract.

## Why the tests did not catch it

Every streaming endpoint in `IssueService` takes `IQuerySession`, which resolves to a `QueryOnly` session — the one storage style where the positional assumption happens to hold. So the entire ETag suite (#5010, #5015, #5027, #5120, #5157) exercised only the case that works.

This PR adds the missing shape: one endpoint streaming through an `IDocumentSession`, and a test that asserts the body is the document rather than its id. It fails on `main` with *"the body must be the document, not its id"*.

## Fix

Match the payload column by name instead of by position. The positional fallback stays for an inner clause that *projects* rather than selects the column — `SelectDataSelectClause`'s `jsonb_build_object(...)` under a `Select()` (#5158) — where there is no column name to match and the projection is the only candidate anyway. So both shapes that motivated the alias keep working, and the ETag assertion is in the new test to prove the fix did not cost the header this code path exists for.

```
Marten.AspNetCore.Testing: 114 passed, both TFMs
```

## Scope worth a second opinion

Only `StreamOne` goes through `VersionSelectClause`, so `StreamMany` / `StreamPaged` / `StreamPagedByCursor` are unaffected — they read `data` from an unaliased select list. `StreamAggregate` streams a live aggregation, not a document row. But `EmitETag` defaults to `true`, so on 9.22.3 every `StreamOne` endpoint that receives a tracking session returns the id instead of the document; ours was one endpoint of several and the others simply were not covered by a test that deserializes the body. That may be worth a patch release rather than waiting for the next feature drop.
