### PR TITLE
Adopt JasperFx 2.39.1 and compliance wave 4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -195,20 +195,20 @@
          conventional aggregation off the aggregate type; and the projection a scoped wrapper wraps
          is validated rather than only the wrapper, so an invalid configuration fails at startup for
          every lifetime instead of only Singleton. -->
-    <PackageVersion Include="JasperFx" Version="2.38.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.38.0" />
+    <PackageVersion Include="JasperFx" Version="2.39.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.39.1" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.38.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.38.0">
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.39.1" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.39.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.38.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.39.1" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/Bugs/Bug_4785_delete_projection_progress_by_shard_name.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4785_delete_projection_progress_by_shard_name.cs
@@ -3,6 +3,7 @@ using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten;
+using Marten.Events.Daemon.HighWater;
 using Marten.Services;
 using Marten.Storage;
 using Marten.Testing.Harness;
@@ -158,14 +159,23 @@ public class Bug_4785_delete_projection_progress_by_shard_name: BugIntegrationCo
     [Fact]
     public async Task high_water_mark_identity_is_the_literal_constant_and_is_deletable_by_it()
     {
-        // The HighWaterMark name is a special case inside the ShardName ctor —
-        // Identity is overwritten to the literal "HighWaterMark" regardless of
-        // the shardKey/version/tenant arguments. The override matches on the
-        // exact name column, so deleting via this literal works the same as
-        // any other identity. (Operational note: HighWaterMark is not an
-        // orphan — only delete it deliberately.)
-        var shard = new ShardName(ShardState.HighWaterMark, "ignored", 9, "ignored");
-        shard.Identity.ShouldBe(ShardState.HighWaterMark);
+        // The HighWaterMark name is a special case inside the ShardName ctor: the
+        // shardKey and version slots are always discarded, and as of jasperfx#618
+        // (JasperFx 2.39.0) the tenant slot is NOT — a store-global high-water shard
+        // collapses to the literal "HighWaterMark", a tenant-scoped one to
+        // "HighWaterMark:{tenant}". That is the grammar Marten has always persisted
+        // through HighWaterShardIdentity; the upstream change brought ShardName into
+        // line with it rather than the other way round.
+        //
+        // The override matches on the exact name column, so deleting via either
+        // literal works the same as any other identity. (Operational note:
+        // HighWaterMark is not an orphan — only delete it deliberately.)
+        var storeGlobal = new ShardName(ShardState.HighWaterMark, "ignored", 9);
+        storeGlobal.Identity.ShouldBe(ShardState.HighWaterMark);
+        storeGlobal.Identity.ShouldBe(HighWaterShardIdentity.StoreGlobal);
+
+        var perTenant = new ShardName(ShardState.HighWaterMark, "ignored", 9, "blue");
+        perTenant.Identity.ShouldBe(HighWaterShardIdentity.PerTenant("blue"));
 
         var database = (MartenDatabase)theStore.Storage.Database;
         await database.EnsureStorageExistsAsync(typeof(IEvent));

--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave4.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave4.cs
@@ -1,0 +1,23 @@
+using JasperFx.Events.ComplianceTests;
+using Marten;
+using Marten.Testing.Harness;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * Wave 4 enrollments. Same shape as marten_event_store_compliance.cs -- empty subclasses closing the
+ * shared suites over Marten's session pair. Kept in a separate file only while the suites are still
+ * in flight upstream; fold into the main enrollment file once the JasperFx package ships them.
+ */
+
+public class fetch_for_writing_compliance
+    : FetchForWritingCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+public class stream_read_compliance
+    : StreamReadCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+public class event_metadata_compliance
+    : EventMetadataCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+public class live_aggregation_compliance
+    : LiveAggregationCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;

--- a/src/EventSourcingTests/EventSourcingTests.csproj
+++ b/src/EventSourcingTests/EventSourcingTests.csproj
@@ -8,7 +8,14 @@
         <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <!-- Source-only: the compliance suites compile into this assembly so the aggregate source
              generator above binds Marten's session types. See Compliance/ for the enrollments. -->
-        <PackageReference Include="JasperFx.Events.ComplianceTests" />
+        <PackageReference Include="JasperFx.Events.ComplianceTests" Condition="'$(ComplianceSourceDir)' == ''" />
+        <!-- LOCAL DEV LOOP ONLY: -p:ComplianceSourceDir=/path/to/jasperfx/src/JasperFx.Events.ComplianceTests
+             swaps the published suites for a working copy, so wave-N authoring can be validated
+             against Marten before the JasperFx release. Mirrors the same switch in Polecat.Tests. -->
+        <Compile Include="$(ComplianceSourceDir)\**\*.cs"
+                 Exclude="$(ComplianceSourceDir)\bin\**\*.cs;$(ComplianceSourceDir)\obj\**\*.cs;$(ComplianceSourceDir)\Local\**\*.cs"
+                 LinkBase="ComplianceSuites"
+                 Condition="'$(ComplianceSourceDir)' != ''" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Marten.Testing/Harness/MartenComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenComplianceFixture.cs
@@ -50,6 +50,11 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
             options.Events.MetadataConfig.CausationIdEnabled = true;
         }
 
+        if (config.EnableHeaders)
+        {
+            options.Events.MetadataConfig.HeadersEnabled = true;
+        }
+
         config.ApplyTo(new MartenComplianceRegistrar(options));
 
         _store = new DocumentStore(options);

--- a/src/Marten/Events/Daemon/HighWater/HighWaterShardIdentity.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterShardIdentity.cs
@@ -11,11 +11,13 @@ namespace Marten.Events.Daemon.HighWater;
 /// being smeared across SQL string concatenations.
 ///
 /// <para>
-/// The high-water grammar is intentionally asymmetric to the rest of <see cref="ShardName"/>:
-/// JasperFx's <c>ShardName</c> constructor special-cases the HighWaterMark name and collapses
-/// its <c>Identity</c> to the literal constant (dropping any tenant slot). Marten layers
-/// per-tenant high-water tracking on top by writing one row per tenant under the convention
-/// <c>"{HighWaterMark}:{tenantId}"</c>. See the comment in <c>EventProgressionTable</c> for the
+/// The high-water grammar is asymmetric to the rest of <see cref="ShardName"/>: JasperFx's
+/// <c>ShardName</c> constructor special-cases the HighWaterMark name and discards the shard-key
+/// and version slots. It used to discard the tenant slot too, collapsing every high-water shard
+/// to the bare constant; as of jasperfx#618 (JasperFx 2.39.0) it keeps it, so a tenant-scoped
+/// high-water shard now composes to <c>"{HighWaterMark}:{tenantId}"</c> — the very convention
+/// Marten already wrote through this class, which is why that change needed no adjustment on
+/// this side. See the comment in <c>EventProgressionTable</c> for the
 /// surrounding storage-side context — both sides need to agree on this shape exactly, and any
 /// drift (a missing colon, a different separator) silently desyncs the writers from the
 /// readers because the SQL is keyed by string equality on <c>name</c>.


### PR DESCRIPTION
Bumps JasperFx 2.38.0 → **2.39.1** and enrolls the four compliance suites that shipped in it (JasperFx/jasperfx#620).

| Suite | Tests | Issue |
|---|---|---|
| `fetch_for_writing_compliance` | 13 | #5137 |
| `stream_read_compliance` | 11 | #5139 |
| `event_metadata_compliance` | 9 | #5143 |
| `live_aggregation_compliance` | 7 | #5141 |

Marten's compliance coverage goes **65 → 105 tests, zero capability gates**. The suites were authored against Marten and Polecat working copies simultaneously, so both stores were green before the upstream PR was opened.

## Verified locally on net9.0, against the published packages

- 105/105 compliance
- **1667/0/7** EventSourcingTests
- **280/280** DaemonTests

DaemonTests was run deliberately rather than as a formality: 2.39.x carries four daemon-side JasperFx changes (heartbeat removal, extended-progression writer scoping, per-tenant lag reads, EventProjection teardown targets).

## The one thing in here that is not routine

The bump carries **jasperfx#618**, which stops `ShardName` discarding the tenant slot for `HighWaterMark` names. A store-global high-water shard still collapses to the literal `"HighWaterMark"`; a tenant-scoped one now composes to `"HighWaterMark:{tenant}"`.

**That is the grammar Marten already persisted**, through `HighWaterShardIdentity.StoreGlobal` / `PerTenant`. So the upstream change brought `ShardName` into line with Marten rather than the other way round, and the runtime needed no change — I checked every `ShardState.HighWaterMark` construction site in `src/Marten` to confirm the high-water row name is built from those constants and never from a `ShardName` ctor.

What did need updating is `Bug_4785_delete_projection_progress_by_shard_name`, whose assertion encoded the old *"the tenant slot is always discarded"* behaviour and failed deterministically on the bump. It now pins both halves of the new grammar, and cross-checks them against Marten's own constants so the two definitions cannot drift apart silently. The `HighWaterShardIdentity` doc comment describing the superseded behaviour is corrected in the same commit.

I want to flag that explicitly rather than bury it: **a test assertion changed as part of a dependency bump.** It is a stale-premise fix, not a softened assertion — the test is strictly stronger now (two identity shapes pinned instead of one, tied to the product constants) — but it is the kind of change that deserves a second pair of eyes.

## Also included

`EventSourcingTests.csproj` gains the `ComplianceSourceDir` switch Polecat.Tests already had:

```bash
dotnet test src/EventSourcingTests/EventSourcingTests.csproj -f net9.0 \
    -p:ComplianceSourceDir=/path/to/jasperfx/src/JasperFx.Events.ComplianceTests
```

It swaps the published suites for a jasperfx working copy so a wave can be validated against Marten before the JasperFx release — which is what made same-day two-store verification possible for wave 4. Without the property, nothing changes.

`MartenComplianceFixture` resolves the new `ComplianceStoreConfig.EnableHeaders` flag onto `Events.MetadataConfig.HeadersEnabled`, exactly as it already resolves `EnableCorrelationTracking`.

Polecat's matching adoption is JasperFx/polecat#410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde
