### PR TITLE
Split the high-water assertions in Bug_4785 and cover the per-tenant delete path

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4785_delete_projection_progress_by_shard_name.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4785_delete_projection_progress_by_shard_name.cs
@@ -156,35 +156,88 @@ public class Bug_4785_delete_projection_progress_by_shard_name: BugIntegrationCo
         (await readSequenceFor(shard.Identity)).ShouldBeNull();
     }
 
+    /// <summary>
+    /// Contract check across the JasperFx/Marten boundary, not a test of the delete path.
+    /// <para>
+    /// The HighWaterMark name is a special case inside the <see cref="ShardName"/> ctor: the
+    /// shardKey and version slots are always discarded, and as of jasperfx#618 (JasperFx 2.39.0)
+    /// the tenant slot is <em>not</em> — a store-global high-water shard collapses to the literal
+    /// <c>"HighWaterMark"</c>, a tenant-scoped one to <c>"HighWaterMark:{tenant}"</c>. That is the
+    /// grammar Marten has always persisted through <see cref="HighWaterShardIdentity"/>, so the
+    /// upstream change brought <c>ShardName</c> into line with Marten rather than the other way
+    /// round.
+    /// </para>
+    /// <para>
+    /// Both sides have to agree on this shape exactly. The progression SQL is keyed by string
+    /// equality on <c>name</c>, so any drift — a different separator, a dropped slot, an added
+    /// version prefix — silently desyncs the writers from the readers instead of failing loudly.
+    /// Nothing pinned that agreement before jasperfx#618 moved one side of it.
+    /// </para>
+    /// </summary>
     [Fact]
-    public async Task high_water_mark_identity_is_the_literal_constant_and_is_deletable_by_it()
+    public void high_water_identity_grammar_agrees_between_shard_name_and_marten()
     {
-        // The HighWaterMark name is a special case inside the ShardName ctor: the
-        // shardKey and version slots are always discarded, and as of jasperfx#618
-        // (JasperFx 2.39.0) the tenant slot is NOT — a store-global high-water shard
-        // collapses to the literal "HighWaterMark", a tenant-scoped one to
-        // "HighWaterMark:{tenant}". That is the grammar Marten has always persisted
-        // through HighWaterShardIdentity; the upstream change brought ShardName into
-        // line with it rather than the other way round.
-        //
-        // The override matches on the exact name column, so deleting via either
-        // literal works the same as any other identity. (Operational note:
-        // HighWaterMark is not an orphan — only delete it deliberately.)
         var storeGlobal = new ShardName(ShardState.HighWaterMark, "ignored", 9);
         storeGlobal.Identity.ShouldBe(ShardState.HighWaterMark);
         storeGlobal.Identity.ShouldBe(HighWaterShardIdentity.StoreGlobal);
 
         var perTenant = new ShardName(ShardState.HighWaterMark, "ignored", 9, "blue");
         perTenant.Identity.ShouldBe(HighWaterShardIdentity.PerTenant("blue"));
+        perTenant.Identity.ShouldBe($"{ShardState.HighWaterMark}:blue");
+    }
 
+    [Fact]
+    public async Task store_global_high_water_row_is_deletable_by_its_literal_identity()
+    {
+        // The override matches on the exact name column, so the high-water row deletes
+        // like any other identity. (Operational note: HighWaterMark is not an orphan —
+        // only delete it deliberately.)
         var database = (MartenDatabase)theStore.Storage.Database;
         await database.EnsureStorageExistsAsync(typeof(IEvent));
 
-        await seedProgressionRow(ShardState.HighWaterMark, 999);
+        await seedProgressionRow(HighWaterShardIdentity.StoreGlobal, 999);
         await ((IEventDatabase)database).DeleteProjectionProgressByShardNameAsync(
-            ShardState.HighWaterMark, default);
+            HighWaterShardIdentity.StoreGlobal, default);
 
-        (await readSequenceFor(ShardState.HighWaterMark)).ShouldBeNull();
+        (await readSequenceFor(HighWaterShardIdentity.StoreGlobal)).ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Per-tenant high-water rows became a first-class shape in jasperfx#618, and the delete
+    /// path had no coverage for them. The tenant ids here are chosen deliberately:
+    /// <c>acme_corp</c> and <c>acmeXcorp</c> differ in exactly one character, and that character
+    /// is <c>_</c> — a <c>LIKE</c> single-character wildcard in PostgreSQL.
+    /// <para>
+    /// So if this delete ever stopped being <c>where name = ?</c> and became a pattern match,
+    /// deleting <c>acme_corp</c>'s row would silently take <c>acmeXcorp</c>'s with it. That is
+    /// not hypothetical for this table: #5171 is exactly this bug in the per-tenant progression
+    /// <em>read</em> filter, which builds an unescaped <c>name like '%:' || tenant</c>. The
+    /// delete path is correct today; this pins it so the two paths cannot converge on the wrong
+    /// answer.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task deleting_one_tenants_high_water_row_leaves_a_lookalike_tenant_alone()
+    {
+        var database = (MartenDatabase)theStore.Storage.Database;
+        await database.EnsureStorageExistsAsync(typeof(IEvent));
+
+        var target = HighWaterShardIdentity.PerTenant("acme_corp");
+        var lookalike = HighWaterShardIdentity.PerTenant("acmeXcorp");
+
+        await seedProgressionRow(HighWaterShardIdentity.StoreGlobal, 100);
+        await seedProgressionRow(target, 200);
+        await seedProgressionRow(lookalike, 300);
+
+        await ((IEventDatabase)database).DeleteProjectionProgressByShardNameAsync(target, default);
+
+        (await readSequenceFor(target)).ShouldBeNull();
+
+        // The underscore must not have matched the sibling...
+        (await readSequenceFor(lookalike)).ShouldBe(300);
+
+        // ...and the store-global row is a prefix of both, so a prefix match would eat it too.
+        (await readSequenceFor(HighWaterShardIdentity.StoreGlobal)).ShouldBe(100);
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #5176. That PR updated `Bug_4785_delete_projection_progress_by_shard_name` for jasperfx#618 — `ShardName` no longer discards the tenant slot for `HighWaterMark` names — but left it in a state worth tidying. Test-only.

## The name was the actual defect

The test was still called `high_water_mark_identity_is_the_literal_constant_and_is_deletable_by_it`, while the entire content of the change was that the identity is **not** always the literal constant. The body and comment were updated; the name was left asserting the premise the change disproved. Anyone grepping for the contract months from now would have been misled by exactly the part of a test that is meant to be self-describing.

## It was doing two unrelated jobs

They fail for different reasons and should not share a name, so they are now separate:

- **`high_water_identity_grammar_agrees_between_shard_name_and_marten`** (no DB) — pins that JasperFx's `ShardName` composition and Marten's `HighWaterShardIdentity` produce the same string, for both the store-global and tenant-scoped shapes. This agreement matters more than it looks: the progression SQL is keyed by string equality on `name`, so drift — a different separator, a dropped slot, an added version prefix — silently desyncs the writers from the readers instead of failing loudly. `HighWaterShardIdentity`'s own doc warns about this, and nothing pinned it until jasperfx#618 moved one side.
- **`store_global_high_water_row_is_deletable_by_its_literal_identity`** — the original delete assertion, unchanged in substance.

## The coverage gap the bump exposed

Per-tenant high-water rows became a first-class shape and **never went through the delete path at all**. New test: `deleting_one_tenants_high_water_row_leaves_a_lookalike_tenant_alone`.

The tenant ids are chosen, not arbitrary. `acme_corp` and `acmeXcorp` differ in exactly one character, and that character is `_` — a `LIKE` single-character wildcard in PostgreSQL. If this delete ever stopped being `where name = ?` and became a pattern match, deleting one tenant's row would silently take the other's. The store-global row is seeded too, since it is a prefix of both and a prefix match would eat it as well.

I checked the test discriminates rather than passing vacuously:

```
select 'HighWaterMark:acmeXcorp' like 'HighWaterMark:acme_corp',  -- t
       'HighWaterMark:acmeXcorp' =    'HighWaterMark:acme_corp';  -- f
```

**This is not a hypothetical failure mode for this table.** #5171 is exactly this bug in the per-tenant progression *read* filter, which builds an unescaped `name like '%:' || tenant`. The delete path is correct today — `DeleteProjectionProgress` emits parameterized `where name = ?` — and this pins it so the two paths cannot converge on the wrong answer while #5171 is still open.

## Verification

26/26 in the file on net9.0 (was 24; one test became three).

The related design question — whether the identity-grammar assertion belongs in Marten at all, given Polecat composes the same grammar independently — is filed separately as #5177 rather than decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde
