### PR TITLE
Per-tenant progression filter no longer treats the tenant id as a LIKE pattern (#5171)

### DIFF
--- a/src/DaemonTests/Bugs/Bug_5171_tenant_progression_filter.cs
+++ b/src/DaemonTests/Bugs/Bug_5171_tenant_progression_filter.cs
@@ -1,0 +1,119 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten.Events.Daemon.Progress;
+using Marten.Storage;
+using Marten.Testing;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.Bugs;
+
+/// <summary>
+/// #5171 — the per-tenant progression filter used an unescaped <c>LIKE '%:' || tenantId</c>. Since
+/// <c>_</c> is both a legal tenant-id character and a LIKE single-character wildcard, a read scoped to
+/// <c>acme_corp</c> also matched <c>acmeXcorp</c>'s rows and reported them as <c>acme_corp</c>'s progress.
+/// The narrower sibling: a tenant-less identity whose shard key equals the tenant id (<c>Foo:acme</c>)
+/// ends in the same suffix and was attributed to the tenant as well.
+/// </summary>
+public class Bug_5171_tenant_progression_filter: OneOffConfigurationsContext, IAsyncLifetime
+{
+    public override async ValueTask InitializeAsync()
+    {
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.EnsureStorageExistsAsync(typeof(IEvent));
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        Dispose();
+        return base.DisposeAsync();
+    }
+
+    private async Task seedProgression(params (ShardName name, long sequence)[] rows)
+    {
+        foreach (var (name, sequence) in rows)
+        {
+            theSession.QueueOperation(new InsertProjectionProgress(theStore.Events, new EventRange(name, sequence)));
+        }
+
+        await theSession.SaveChangesAsync();
+    }
+
+    private Task<System.Collections.Generic.IReadOnlyList<ShardState>> progressFor(string tenantId) =>
+        ((IEventDatabase)theStore.Tenancy.Default.Database).AllProjectionProgress(tenantId, CancellationToken.None);
+
+    [Fact]
+    public async Task underscore_in_a_tenant_id_is_not_treated_as_a_wildcard()
+    {
+        await seedProgression(
+            (ShardName.Compose("Orders", tenantId: "acme_corp"), 10),
+            (ShardName.Compose("Orders", tenantId: "acmeXcorp"), 99),
+            (ShardName.Compose("Orders", tenantId: "acme-corp"), 77));
+
+        var rows = await progressFor("acme_corp");
+
+        rows.Select(x => x.ShardName).ShouldBe(["Orders:All:acme_corp"]);
+        rows.Single().Sequence.ShouldBe(10);
+
+        // ...and the neighbors still resolve to their own rows, at their own heights.
+        (await progressFor("acmeXcorp")).Single().Sequence.ShouldBe(99);
+        (await progressFor("acme-corp")).Single().Sequence.ShouldBe(77);
+    }
+
+    [Fact]
+    public async Task percent_in_a_tenant_id_does_not_match_everything()
+    {
+        await seedProgression(
+            (ShardName.Compose("Orders", tenantId: "a%b"), 10),
+            (ShardName.Compose("Orders", tenantId: "axxb"), 99));
+
+        (await progressFor("a%b")).Single().Sequence.ShouldBe(10);
+    }
+
+    [Fact]
+    public async Task a_shard_key_equal_to_a_tenant_id_is_not_reported_as_that_tenants_progress()
+    {
+        await seedProgression(
+            (ShardName.Compose("Orders", shardKey: "acme"), 500),                 // Orders:acme    — no tenant
+            (ShardName.Compose("Orders", shardKey: "acme", version: 2), 600),     // Orders:V2:acme — no tenant
+            (ShardName.Compose("Orders", tenantId: "acme"), 7));                  // Orders:All:acme
+
+        var rows = await progressFor("acme");
+
+        rows.Select(x => x.ShardName).ShouldBe(["Orders:All:acme"]);
+        rows.Single().Sequence.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task the_tenants_high_water_row_is_still_included()
+    {
+        await seedProgression(
+            (ShardName.HighWaterMarkFor("acme_corp"), 250),
+            (ShardName.Compose("Orders", tenantId: "acme_corp"), 10));
+
+        var rows = await progressFor("acme_corp");
+
+        rows.Select(x => x.ShardName).OrderBy(x => x, System.StringComparer.Ordinal)
+            .ShouldBe(["HighWaterMark:acme_corp", "Orders:All:acme_corp"]);
+    }
+
+    [Fact]
+    public async Task a_null_tenant_still_returns_every_row()
+    {
+        await seedProgression(
+            (ShardName.Compose("Orders"), 1),
+            (ShardName.Compose("Orders", shardKey: "acme"), 2),
+            (ShardName.Compose("Orders", tenantId: "acme"), 3));
+
+        var rows = await ((IEventDatabase)theStore.Tenancy.Default.Database)
+            .AllProjectionProgress(tenantId: null, CancellationToken.None);
+
+        rows.Select(x => x.ShardName).OrderBy(x => x, System.StringComparer.Ordinal)
+            .ShouldBe(["Orders:All", "Orders:All:acme", "Orders:acme"]);
+    }
+}

--- a/src/Marten/Events/Daemon/Progress/ProjectionProgressStatement.cs
+++ b/src/Marten/Events/Daemon/Progress/ProjectionProgressStatement.cs
@@ -82,11 +82,17 @@ internal class ProjectionProgressStatement: Statement
         if (TenantId != null)
         {
             builder.Append(whereStarted ? " and " : " where ");
-            // Tenant-bearing ShardName.Identity always ends in `:{tenantId}`.
-            // Match the trailing tenant suffix via LIKE — partition suffixes
-            // are valid PG identifiers so they don't contain LIKE wildcards.
-            builder.Append("name like ");
-            builder.AppendParameter("%:" + TenantId);
+
+            // #5171: a tenant-bearing ShardName.Identity always ends in `:{tenantId}`, but this used to
+            // be matched with `name like '%:' || tenantId`, and `_` is BOTH a legal tenant-id character
+            // and a LIKE single-character wildcard — so tenant `acme_corp` also swept in `acmeXcorp`'s
+            // rows. Compare the literal trailing substring instead: no pattern grammar, no escaping to
+            // get wrong, and index-neutral (the old leading-`%` LIKE could never use an index either).
+            var suffix = ":" + TenantId;
+            builder.Append("right(name, char_length(");
+            builder.AppendParameter(suffix);
+            builder.Append(")) = ");
+            builder.AppendParameter(suffix);
             whereStarted = true;
         }
 

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -377,12 +377,28 @@ select count(*) from {Options.Events.DatabaseSchemaName}.mt_streams;
             handler.ConfigureCommand(builder, null);
 
             await using var reader = await conn.ExecuteReaderAsync(builder, token).ConfigureAwait(false);
-            return await handler.HandleAsync(reader, null, token).ConfigureAwait(false);
+            var states = await handler.HandleAsync(reader, null, token).ConfigureAwait(false);
+
+            return tenantId == null ? states : states.Where(x => belongsToTenant(x, tenantId)).ToList();
         }
         finally
         {
             await conn.CloseAsync().ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// #5171: the SQL suffix filter narrows the read to rows ending in <c>:{tenantId}</c>, which is the
+    /// most a string comparison can do — but <see cref="ShardName.Identity"/> without a tenant is
+    /// <c>{Name}:{ShardKey}</c>, so a projection sliced by a shard key that happens to equal a tenant id
+    /// ends in the same suffix and would be reported as that tenant's progress. Parsing settles it:
+    /// <see cref="ShardName.TryParse"/> puts <c>Foo:acme</c>'s trailing segment in the shard-key slot and
+    /// <c>Orders:All:acme</c>'s (and <c>HighWaterMark:acme</c>'s) in the tenant slot. A name that doesn't
+    /// parse at all isn't attributable to a tenant, so it's excluded rather than guessed at.
+    /// </summary>
+    private static bool belongsToTenant(ShardState state, string tenantId)
+    {
+        return ShardName.TryParse(state.ShardName, out var shard) && shard?.TenantId == tenantId;
     }
 
     /// <summary>

--- a/src/TenantPartitionedEventsTests/Admin/admin_api_tenant_overloads.cs
+++ b/src/TenantPartitionedEventsTests/Admin/admin_api_tenant_overloads.cs
@@ -113,8 +113,8 @@ public class admin_api_tenant_overloads
         var betaOnly = await db.AllProjectionProgress(tenantId: beta, CancellationToken.None);
         var everything = await db.AllProjectionProgress(tenantId: null, CancellationToken.None);
 
-        // tenant filter is a SQL LIKE on a trailing `:tenant` suffix, so this test's
-        // unique tenant id is the only matching row even on a shared store.
+        // #5171: the tenant filter is a literal trailing-`:tenant` comparison (no LIKE grammar),
+        // so this test's unique tenant id is the only matching row even on a shared store.
         alphaOnly.Select(s => s.ShardName).ShouldHaveSingleItem().ShouldBe(alphaName.Identity);
         betaOnly.Select(s => s.ShardName).ShouldHaveSingleItem().ShouldBe(betaName.Identity);
         // The tenantless query returns EVERY row in the table — including other


### PR DESCRIPTION
Closes #5171.

## The bug

`ProjectionProgressStatement`'s per-tenant filter built `name like '%:' || tenantId`, with a comment asserting that "partition suffixes are valid PG identifiers so they don't contain LIKE wildcards". That premise is wrong: `_` is *both* a perfectly legal tenant-id character and a LIKE single-character wildcard.

So a read scoped to tenant `acme_corp` also matched the progression rows of `acmeXcorp`, `acme-corp`, `acme corp` — any tenant differing only in that one position — and reported them as `acme_corp`'s progress. A `%` in a tenant id would match everything.

## The fix

Compare the literal trailing substring instead of pattern-matching:

```sql
right(name, char_length(:suffix)) = :suffix
```

No pattern grammar, nothing to escape, and index-neutral — the old leading-`%` LIKE could never use an index either.

That still admits the narrower sibling defect the issue calls out: a tenant-less `ShardName.Identity` is `{Name}:{ShardKey}`, so a projection sliced by a shard key that happens to equal a tenant id (`Foo:acme`) ends in the same suffix. `AllProjectionProgress(tenantId, …)` now settles that by parsing the name rather than suffix-matching a string grammar — `ShardName.TryParse` puts `Foo:acme`'s trailing segment in the shard-key slot and `Orders:All:acme`'s in the tenant slot. Per-tenant high-water rows keep flowing through, since `HighWaterMark:acme` parses with `TenantId = acme` (jasperfx#618).

## Tests

`DaemonTests/Bugs/Bug_5171_tenant_progression_filter.cs` — five cases seeding progression rows directly:

- `_` in a tenant id no longer sweeps in neighbors, and each neighbor still reads back at its own height
- `%` in a tenant id doesn't match everything
- a shard key equal to a tenant id is not reported as that tenant's progress
- the tenant's own `HighWaterMark:{tenant}` row is still included
- a null tenant still returns every row

All 5 pass, along with the existing `read_projection_progress` suite (13 total, net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CTtw2kVRSZKp1p5RTxgAy