### PR TITLE
High-water health check no longer reads a heartbeat column nothing writes (#5174)

### DIFF
--- a/docs/events/projections/healthchecks.md
+++ b/docs/events/projections/healthchecks.md
@@ -113,9 +113,9 @@ Services.AddHealthChecks().AddMartenHighWaterHealthCheck(
     databaseFilter: db => LocallyOwnedDatabaseIdentifiers.Contains(db.Identifier),
 
     // Assert even under DaemonMode.ExternallyManaged (Wolverine-managed distribution). In this
-    // mode only the liveness heartbeat signal is used (never the sequence-gap fallback), because
-    // an external owner can legitimately pause the mark — so this requires
-    // Events.EnableExtendedProgressionTracking to be turned on.
+    // mode only the per-tenant poll-cycle signal is used (never the store-global sequence-gap
+    // heuristic), because an external owner can legitimately pause the mark — so a non-partitioned
+    // store has nothing to assert on there.
     includeExternallyManaged: true);
 ```
 
@@ -148,11 +148,22 @@ Both overloads register the settings through a factory, so replacing
 you need to reach further into DI than the predicate allows.
 
 Under `UseTenantPartitionedEvents` the high-water mark is tracked **per tenant** as
-`HighWaterMark:<tenant>` progression rows rather than a single store-global `HighWaterMark`. The
-check evaluates those per-tenant rows too, using the liveness heartbeat (the sequence-gap
-fallback is store-global and cannot be applied per tenant). Enable
-`Events.EnableExtendedProgressionTracking` so the per-tenant heartbeats are persisted, otherwise
-a stalled per-tenant high-water agent cannot be detected.
+`HighWaterMark:<tenant>` progression rows rather than a single store-global `HighWaterMark`, and
+those are the rows the check evaluates. It uses a different — and better — signal there: every
+vectorized per-tenant poll re-stamps the row's `last_updated` column whether or not the mark
+advances, so its age proves the poll loop is still *cycling*, independent of whether new events
+exist. A quiet tenant never false-positives, and the sequence-gap heuristic (which is inherently
+store-global) is never applied per tenant. No extra configuration is needed —
+`EnableExtendedProgressionTracking` is not involved
+(see [marten#5174](https://github.com/JasperFx/marten/issues/5174)).
+
+::: warning
+On the **store-global** `HighWaterMark` row `last_updated` only moves when the mark *advances*, so
+it says nothing about liveness and the sequence-gap heuristic is the only signal available from the
+database. That means a store-global poll loop that has wedged while fully caught up is not
+detectable from the progression table. For in-process detection of that case use
+`IProjectionDaemon.HighWaterAgent.IsStale` / `LastPolledAt` on the node hosting the daemon.
+:::
 
 ::: tip INFO
 This health check does **not** force the high-water mark forward — it is detection only.

--- a/src/DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests.cs
+++ b/src/DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests.cs
@@ -73,38 +73,19 @@ public class HighWaterHealthCheckTests: DaemonContext
         await session.SaveChangesAsync();
     }
 
-    private async Task seedHighWaterMarkAsync(long sequence)
-    {
-        var sql =
-            $"insert into {theStore.Events.DatabaseSchemaName}.mt_event_progression (name, last_seq_id, last_updated) " +
-            $"values ('HighWaterMark', {sequence}, now()) " +
-            "on conflict (name) do update set last_seq_id = excluded.last_seq_id";
-        await theSession.ExecuteAsync(new NpgsqlCommand(sql));
-    }
-
-    // Seeds the HighWaterMark row's liveness heartbeat (jasperfx#539). Requires
-    // EnableExtendedProgressionTracking so the `heartbeat` column exists.
-    private async Task seedHighWaterHeartbeatAsync(long sequence, DateTimeOffset heartbeat)
-    {
-        var sql =
-            $"insert into {theStore.Events.DatabaseSchemaName}.mt_event_progression (name, last_seq_id, last_updated, heartbeat) " +
-            $"values ('HighWaterMark', {sequence}, now(), '{heartbeat:O}'::timestamptz) " +
-            "on conflict (name) do update set last_seq_id = excluded.last_seq_id, heartbeat = excluded.heartbeat";
-        await theSession.ExecuteAsync(new NpgsqlCommand(sql));
-    }
+    private Task seedHighWaterMarkAsync(long sequence) => seedProgressionRowAsync("HighWaterMark", sequence);
 
     // Seeds an arbitrary progression row (store-global "HighWaterMark" or a per-tenant
-    // "HighWaterMark:<tenant>" row) with an optional liveness heartbeat. The heartbeat column only
-    // exists when EnableExtendedProgressionTracking is on, so pass a heartbeat only in that case.
-    private async Task seedProgressionRowAsync(string name, long sequence, DateTimeOffset? heartbeat = null)
+    // "HighWaterMark:<tenant>" row). marten#5174: last_updated is the per-cycle liveness signal for
+    // per-tenant rows -- mt_mark_event_progression stamps it on EVERY vectorized poll, mark advance or
+    // not -- so it is settable here to simulate a poll loop that has stopped cycling.
+    private async Task seedProgressionRowAsync(string name, long sequence, DateTimeOffset? lastUpdated = null)
     {
-        var sql = heartbeat is { } hb
-            ? $"insert into {theStore.Events.DatabaseSchemaName}.mt_event_progression (name, last_seq_id, last_updated, heartbeat) " +
-              $"values ('{name}', {sequence}, now(), '{hb:O}'::timestamptz) " +
-              "on conflict (name) do update set last_seq_id = excluded.last_seq_id, heartbeat = excluded.heartbeat"
-            : $"insert into {theStore.Events.DatabaseSchemaName}.mt_event_progression (name, last_seq_id, last_updated) " +
-              $"values ('{name}', {sequence}, now()) " +
-              "on conflict (name) do update set last_seq_id = excluded.last_seq_id";
+        var stamp = lastUpdated is { } at ? $"'{at:O}'::timestamptz" : "now()";
+        var sql =
+            $"insert into {theStore.Events.DatabaseSchemaName}.mt_event_progression (name, last_seq_id, last_updated) " +
+            $"values ('{name}', {sequence}, {stamp}) " +
+            "on conflict (name) do update set last_seq_id = excluded.last_seq_id, last_updated = excluded.last_updated";
         await theSession.ExecuteAsync(new NpgsqlCommand(sql));
     }
 
@@ -241,22 +222,25 @@ public class HighWaterHealthCheckTests: DaemonContext
         result.Status.ShouldBe(HealthStatus.Healthy);
     }
 
-    // ---- heartbeat primary signal (marten#4986) ------------------------------------------
+    // ---- per-tenant poll-cycle signal (marten#4986, revised by marten#5174) ---------------
+
+    // marten#5174: the ExtendedProgression `heartbeat` column is never written for high-water rows
+    // (ExtendedProgressionWriter.OnNext drops HighWaterMark states outright), so the check no longer
+    // reads it. For per-tenant rows the real per-cycle signal is last_updated, which
+    // mt_mark_event_progression stamps on every vectorized poll whether or not the mark advances.
 
     [Fact]
-    public async Task healthy_when_heartbeat_is_fresh_even_though_mark_is_behind()
+    public async Task healthy_when_the_per_tenant_poll_is_fresh_even_though_the_mark_is_behind()
     {
-        // ExtendedProgression on -> the heartbeat is the primary signal. A fresh heartbeat means the
-        // agent is cycling, so a mark sitting behind the latest event is NOT unhealthy (unlike the gap
-        // heuristic, which would trip here).
+        // A fresh poll cycle means the agent is alive, so a per-tenant mark sitting behind the latest
+        // event is NOT unhealthy.
         StoreOptions(x =>
         {
             x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
             x.Projections.AsyncMode = DaemonMode.Solo;
-            x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
-        await seedHighWaterHeartbeatAsync(1, _now.AddSeconds(-5)); // mark stuck at 1, but heartbeat is 5s old
+        await seedProgressionRowAsync("HighWaterMark:acme", 1, _now.AddSeconds(-5));
 
         var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
@@ -264,10 +248,31 @@ public class HighWaterHealthCheckTests: DaemonContext
     }
 
     [Fact]
-    public async Task unhealthy_when_heartbeat_is_stale_even_though_mark_is_caught_up()
+    public async Task unhealthy_when_the_per_tenant_poll_is_stale_even_though_the_mark_is_caught_up()
     {
-        // A stale heartbeat means the loop stopped cycling. This trips even when the mark is fully caught
-        // up (gap == 0) — the case the gap heuristic is blind to.
+        // A stale poll cycle means the loop stopped cycling. This trips even when the mark is fully
+        // caught up — the case the store-global gap heuristic is blind to.
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+        });
+        await appendEventsAsync(20);
+        var stats = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
+        await seedProgressionRowAsync("HighWaterMark:acme", stats.EventSequenceNumber, _now.AddSeconds(-90));
+
+        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task the_extended_progression_heartbeat_column_is_never_consulted()
+    {
+        // The pin for marten#5174. With ExtendedProgression on and a heartbeat that is *fresh*, a
+        // store-global mark stuck behind the latest event must still be caught by the gap heuristic --
+        // proving the check no longer defers to a column the daemon does not write. (Before this change
+        // the fresh heartbeat short-circuited the whole assessment.)
         StoreOptions(x =>
         {
             x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
@@ -275,12 +280,18 @@ public class HighWaterHealthCheckTests: DaemonContext
             x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
-        var stats = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
-        await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90)); // caught up, heartbeat 90s old
+        await seedProgressionRowAsync("HighWaterMark", 1);
+        await theSession.ExecuteAsync(new NpgsqlCommand(
+            $"update {theStore.Events.DatabaseSchemaName}.mt_event_progression set heartbeat = '{_now:O}'::timestamptz where name = 'HighWaterMark'"));
 
-        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+        var check = buildCheck(30.Seconds());
 
-        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status
+            .ShouldBe(HealthStatus.Healthy);
+
+        _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
+        (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status
+            .ShouldBe(HealthStatus.Unhealthy);
     }
 
     // ---- autoRestart remediation (marten#4986) -------------------------------------------
@@ -292,11 +303,10 @@ public class HighWaterHealthCheckTests: DaemonContext
         {
             x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
             x.Projections.AsyncMode = DaemonMode.Solo;
-            x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
         var stats = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
-        await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90));
+        await seedProgressionRowAsync("HighWaterMark:acme", stats.EventSequenceNumber, _now.AddSeconds(-90));
 
         var daemon = Substitute.For<IProjectionDaemon>();
         var coordinator = new FakeCoordinator(daemon);
@@ -319,11 +329,10 @@ public class HighWaterHealthCheckTests: DaemonContext
         {
             x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
             x.Projections.AsyncMode = DaemonMode.Solo;
-            x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
         var stats = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
-        await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90));
+        await seedProgressionRowAsync("HighWaterMark:acme", stats.EventSequenceNumber, _now.AddSeconds(-90));
 
         var daemon = Substitute.For<IProjectionDaemon>();
         var coordinator = new FakeCoordinator(daemon);
@@ -475,19 +484,18 @@ public class HighWaterHealthCheckTests: DaemonContext
     // ---- ExternallyManaged gate (marten#4991) --------------------------------------------
 
     [Fact]
-    public async Task healthy_under_externally_managed_by_default_even_if_heartbeat_stale()
+    public async Task healthy_under_externally_managed_by_default_even_if_per_tenant_poll_stale()
     {
         // Default: ExternallyManaged (e.g. Wolverine-managed distribution) hosts no local daemon, so the
-        // check stays a no-op and a stale heartbeat is not asserted.
+        // check stays a no-op and a stalled poll is not asserted.
         StoreOptions(x =>
         {
             x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
             x.Projections.AsyncMode = DaemonMode.ExternallyManaged;
-            x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
         var stats = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
-        await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90));
+        await seedProgressionRowAsync("HighWaterMark:acme", stats.EventSequenceNumber, _now.AddSeconds(-90));
 
         var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
@@ -495,18 +503,17 @@ public class HighWaterHealthCheckTests: DaemonContext
     }
 
     [Fact]
-    public async Task unhealthy_under_externally_managed_when_opted_in_and_heartbeat_stale()
+    public async Task unhealthy_under_externally_managed_when_opted_in_and_per_tenant_poll_stale()
     {
-        // Opted in: assert under ExternallyManaged too — via the heartbeat signal.
+        // Opted in: assert under ExternallyManaged too — via the per-tenant poll-cycle signal.
         StoreOptions(x =>
         {
             x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
             x.Projections.AsyncMode = DaemonMode.ExternallyManaged;
-            x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
         var stats = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
-        await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90));
+        await seedProgressionRowAsync("HighWaterMark:acme", stats.EventSequenceNumber, _now.AddSeconds(-90));
 
         var result = await buildCheck(30.Seconds(), includeExternallyManaged: true)
             .CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
@@ -515,10 +522,10 @@ public class HighWaterHealthCheckTests: DaemonContext
     }
 
     [Fact]
-    public async Task externally_managed_opted_in_does_not_use_gap_fallback_without_heartbeat()
+    public async Task externally_managed_opted_in_does_not_use_the_store_global_gap_heuristic()
     {
-        // Opted in but ExtendedProgression off -> no heartbeat. The gap fallback must be suppressed under
-        // ExternallyManaged because an external owner can legitimately pause the mark; it stays Healthy.
+        // Opted in, store-global row only. The gap heuristic must be suppressed under ExternallyManaged
+        // because an external owner can legitimately pause the mark; it stays Healthy.
         StoreOptions(x =>
         {
             x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
@@ -538,16 +545,16 @@ public class HighWaterHealthCheckTests: DaemonContext
     // ---- per-tenant high water (marten#4991) ---------------------------------------------
 
     [Fact]
-    public async Task detects_stale_per_tenant_high_water_via_heartbeat()
+    public async Task detects_a_stale_per_tenant_high_water_row()
     {
         // UseTenantPartitionedEvents persists HighWaterMark:<tenant> rows rather than a single
         // store-global HighWaterMark. The original check matched only "HighWaterMark" and was blind to
-        // a stalled per-tenant agent; now a stale per-tenant heartbeat is detected.
+        // a stalled per-tenant agent; now a per-tenant row whose poll has stopped cycling is detected --
+        // with no dependency on ExtendedProgression (marten#5174).
         StoreOptions(x =>
         {
             x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
             x.Projections.AsyncMode = DaemonMode.Solo;
-            x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
         await seedProgressionRowAsync("HighWaterMark:acme", 5, _now.AddSeconds(-90));
@@ -558,13 +565,12 @@ public class HighWaterHealthCheckTests: DaemonContext
     }
 
     [Fact]
-    public async Task healthy_when_per_tenant_high_water_heartbeat_is_fresh()
+    public async Task healthy_when_the_per_tenant_high_water_row_was_just_polled()
     {
         StoreOptions(x =>
         {
             x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
             x.Projections.AsyncMode = DaemonMode.Solo;
-            x.Events.EnableExtendedProgressionTracking = true;
         });
         await appendEventsAsync(20);
         await seedProgressionRowAsync("HighWaterMark:acme", 5, _now.AddSeconds(-5));
@@ -575,24 +581,27 @@ public class HighWaterHealthCheckTests: DaemonContext
     }
 
     [Fact]
-    public async Task per_tenant_high_water_without_heartbeat_is_not_gap_assessed()
+    public async Task a_per_tenant_row_is_never_gap_assessed()
     {
-        // ExtendedProgression off -> a per-tenant row has no heartbeat, and there is no per-tenant
-        // highest-sequence to compute a meaningful gap (FetchHighestEventSequenceNumber is store-global),
-        // so the gap fallback must NOT run for it — otherwise a tenant with no new events false-positives.
+        // There is no per-tenant highest-sequence to compute a meaningful gap against
+        // (FetchHighestEventSequenceNumber is store-global), so the gap heuristic must never run for a
+        // per-tenant row -- otherwise a tenant with no new events false-positives. Its poll cycle is
+        // fresh, so it stays Healthy no matter how far behind the store-global sequence it sits.
         StoreOptions(x =>
         {
             x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
             x.Projections.AsyncMode = DaemonMode.Solo;
         });
         await appendEventsAsync(20);
-        await seedProgressionRowAsync("HighWaterMark:acme", 1);
 
         var check = buildCheck(30.Seconds());
 
+        await seedProgressionRowAsync("HighWaterMark:acme", 1, _now);
         (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Healthy);
 
+        // The poll keeps cycling at the same mark; still healthy a full window later.
         _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
+        await seedProgressionRowAsync("HighWaterMark:acme", 1, _now.AddSeconds(60));
         (await check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Healthy);
     }
 

--- a/src/Marten.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
+++ b/src/Marten.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
@@ -4,13 +4,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten.Events.Daemon.HighWater;
 using Marten.Storage;
+using Weasel.Postgresql;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NpgsqlTypes;
 
 namespace Marten.Events.Daemon;
 
@@ -22,21 +25,29 @@ namespace Marten.Events.Daemon;
 ///     reports Healthy. This check instead detects that the high-water agent has stopped and,
 ///     optionally, restarts it.
 ///     <para>
-///         Two staleness signals, best first (marten#4986):
+///         Two staleness signals, each used where it is actually valid (marten#4986, revised in
+///         marten#5174):
 ///         <list type="number">
 ///             <item>
-///                 <b>Heartbeat age (primary).</b> When ExtendedProgression is enabled, the
-///                 high-water agent stamps a liveness heartbeat on the <c>HighWaterMark</c>
-///                 progression row on every completed poll cycle (JasperFx/jasperfx#539). Its age
-///                 is a direct signal that the loop is <em>cycling</em>, independent of whether the
-///                 mark <em>advances</em> — so a quiet store with no new events never trips it.
+///                 <b>Poll-cycle age — per-tenant rows.</b> Under
+///                 <c>UseTenantPartitionedEvents</c> every vectorized per-tenant poll re-stamps the
+///                 <c>HighWaterMark:&lt;tenant&gt;</c> row through <c>mt_mark_event_progression</c>,
+///                 which always sets <c>last_updated</c> — even when the mark does not move. Its age
+///                 is therefore a direct signal that the loop is <em>cycling</em>, independent of
+///                 whether the mark <em>advances</em>, so a quiet tenant never trips it. No extra
+///                 write, and no dependency on ExtendedProgression.
 ///             </item>
 ///             <item>
-///                 <b>Sequence gap (fallback).</b> When ExtendedProgression is off, no heartbeat is
-///                 persisted, so the check falls back to the original heuristic: the store-global
-///                 mark sitting unchanged while later events pile up past it.
+///                 <b>Sequence gap — the store-global row.</b> There <c>last_updated</c> only moves
+///                 when the mark advances, so it says nothing about liveness and the original
+///                 heuristic is the honest one: the mark sitting unchanged while later events pile
+///                 up past it.
 ///             </item>
 ///         </list>
+///         The ExtendedProgression <c>heartbeat</c> column is deliberately <em>not</em> consulted:
+///         it is never written for high-water rows (<c>ExtendedProgressionWriter.OnNext</c> drops
+///         <c>HighWaterMark</c> states outright), so reading it only made the check look like it had
+///         a signal it did not have — marten#5174.
 ///     </para>
 ///     <para>
 ///         marten#4991: on a multi-database (sharded / <c>MultiTenantedWithShardedDatabases</c>)
@@ -45,26 +56,25 @@ namespace Marten.Events.Daemon;
 ///         for — otherwise a probe fans a connection out across all N databases and (with
 ///         <c>autoRestart</c>) would try to restart agents this node does not own. Under
 ///         <c>UseTenantPartitionedEvents</c> the high-water mark is tracked per tenant
-///         (<c>HighWaterMark:&lt;tenant&gt;</c> rows), and those are evaluated too — via the
-///         heartbeat signal, which is the only reliable per-tenant staleness signal.
+///         (<c>HighWaterMark:&lt;tenant&gt;</c> rows), and those are the rows evaluated.
 ///     </para>
 /// </summary>
 public static class HighWaterHealthCheckExtensions
 {
     /// <summary>
     ///     Adds a health check that reports <see cref="HealthCheckResult.Unhealthy" /> when the
-    ///     high-water agent has stopped for at least <paramref name="staleThreshold" /> — via its
-    ///     liveness heartbeat where available, otherwise via the sequence-gap heuristic
-    ///     (marten#4961 / marten#4986).
+    ///     high-water agent has stopped for at least <paramref name="staleThreshold" /> — via the age
+    ///     of its last completed poll cycle on per-tenant rows, otherwise via the sequence-gap
+    ///     heuristic (marten#4961 / marten#4986 / marten#5174).
     /// </summary>
     /// <param name="builder"><see cref="IHealthChecksBuilder" /></param>
     /// <param name="staleThreshold">
-    ///     How long the high-water agent may go without a heartbeat (or, on the fallback path, how
-    ///     long the mark may sit unchanged while behind the latest event sequence) before the store
-    ///     is considered unhealthy. Defaults to 30 seconds.
+    ///     How long the high-water agent may go without completing a poll cycle (or, on the
+    ///     store-global gap path, how long the mark may sit unchanged while behind the latest event
+    ///     sequence) before the store is considered unhealthy. Defaults to 30 seconds.
     /// </param>
     /// <param name="minimumGap">
-    ///     Fallback path only: the gap (highest event sequence minus high-water mark) that is
+    ///     Store-global gap path only: the gap (highest event sequence minus high-water mark) that is
     ///     treated as "caught up" and never trips the check, absorbing the normal safe-harbor lag.
     ///     Defaults to 1.
     /// </param>
@@ -95,8 +105,9 @@ public static class HighWaterHealthCheckExtensions
     ///     <see cref="DaemonMode.HotCold" />, because in <see cref="DaemonMode.ExternallyManaged" />
     ///     this store hosts no daemon and a frozen mark is legitimate. Set this to <c>true</c> to
     ///     also assert under <see cref="DaemonMode.ExternallyManaged" /> (e.g. Wolverine-managed
-    ///     distribution) — in which case only the <em>heartbeat</em> signal is used, never the gap
-    ///     fallback, since an external owner can legitimately pause the mark. Combine with
+    ///     distribution) — in which case only the per-tenant poll-cycle signal is used, never the
+    ///     store-global gap heuristic, since an external owner can legitimately pause the mark.
+    ///     A non-partitioned store therefore has nothing to assert on there. Combine with
     ///     <paramref name="databaseFilter" /> so the check only asserts on databases the local node
     ///     actually owns. Defaults to <c>false</c>.
     /// </param>
@@ -267,18 +278,18 @@ public static class HighWaterHealthCheckExtensions
 
                 // Solo / HotCold host the daemon here, so use every available signal. ExternallyManaged
                 // (e.g. Wolverine-managed distribution, marten#4991) hosts no local daemon — opt in with
-                // includeExternallyManaged to still assert, but only via the heartbeat signal (the gap
-                // fallback would false-positive when an external owner legitimately pauses the mark).
-                // Disabled and everything else stays a no-op.
+                // includeExternallyManaged to still assert, but only via the per-tenant poll-cycle signal
+                // (the store-global gap heuristic would false-positive when an external owner legitimately
+                // pauses the mark). Disabled and everything else stays a no-op.
                 var mode = projections.AsyncMode;
-                bool heartbeatOnly;
+                bool skipGapHeuristic;
                 if (mode is DaemonMode.Solo or DaemonMode.HotCold)
                 {
-                    heartbeatOnly = false;
+                    skipGapHeuristic = false;
                 }
                 else if (mode == DaemonMode.ExternallyManaged && _includeExternallyManaged)
                 {
-                    heartbeatOnly = true;
+                    skipGapHeuristic = true;
                 }
                 else
                 {
@@ -313,7 +324,7 @@ public static class HighWaterHealthCheckExtensions
 
                 foreach (var database in scoped)
                 {
-                    var result = await checkDatabaseAsync(database, heartbeatOnly, perTenantHighWater,
+                    var result = await checkDatabaseAsync(database, skipGapHeuristic, perTenantHighWater,
                             cancellationToken)
                         .ConfigureAwait(false);
                     if (result.Status != HealthStatus.Healthy)
@@ -330,15 +341,11 @@ public static class HighWaterHealthCheckExtensions
             }
         }
 
-        private async Task<HealthCheckResult> checkDatabaseAsync(IMartenDatabase database, bool heartbeatOnly,
+        private async Task<HealthCheckResult> checkDatabaseAsync(IMartenDatabase database, bool skipGapHeuristic,
             bool perTenantHighWater, CancellationToken token)
         {
-            var allProgress = await database.AllProjectionProgress(token).ConfigureAwait(false);
-
-            var allHighWater = allProgress
-                .Where(x => string.Equals(x.ShardName, HighWaterMarkShard, StringComparison.Ordinal)
-                            || x.ShardName.StartsWith(PerTenantHighWaterPrefix, StringComparison.Ordinal))
-                .ToArray();
+            var allHighWater = await readHighWaterRowsAsync(database, _store.Options.Events.DatabaseSchemaName, token)
+                .ConfigureAwait(false);
 
             // marten#4991: under UseTenantPartitionedEvents the authoritative rows are the per-tenant
             // HighWaterMark:<tenant> rows (the original check matched only the exact "HighWaterMark"
@@ -347,17 +354,9 @@ public static class HighWaterHealthCheckExtensions
             // per-tenant rows, and evaluate only the authoritative set — so the store-global row (which is
             // intentionally frozen under partitioning, the daemon skips its loop) is never gap-assessed
             // there and can't false-positive.
-            var perTenantMode = perTenantHighWater ||
-                                allHighWater.Any(x =>
-                                    x.ShardName.StartsWith(PerTenantHighWaterPrefix, StringComparison.Ordinal));
+            var perTenantMode = perTenantHighWater || allHighWater.Any(x => x.IsPerTenant);
 
-            var highWaterRows = perTenantMode
-                ? allHighWater
-                    .Where(x => x.ShardName.StartsWith(PerTenantHighWaterPrefix, StringComparison.Ordinal))
-                    .ToArray()
-                : allHighWater
-                    .Where(x => string.Equals(x.ShardName, HighWaterMarkShard, StringComparison.Ordinal))
-                    .ToArray();
+            var highWaterRows = allHighWater.Where(x => x.IsPerTenant == perTenantMode).ToArray();
 
             // No HighWaterMark progression row yet -> the daemon has not started here. Nothing to assert.
             if (highWaterRows.Length == 0)
@@ -371,21 +370,31 @@ public static class HighWaterHealthCheckExtensions
 
             foreach (var row in highWaterRows)
             {
-                var isPerTenant =
-                    !string.Equals(row.ShardName, HighWaterMarkShard, StringComparison.Ordinal);
                 var key = trackingKey(database.Identifier, row.ShardName);
 
-                // Primary signal (marten#4986): the liveness heartbeat (jasperfx#539), present only when
-                // ExtendedProgression is enabled. Heartbeat age proves the poll loop is *cycling*
-                // independent of whether the mark *advances*, so a quiet store never trips it — a strictly
-                // better signal than the gap heuristic, and the only reliable per-tenant signal. Use it
-                // whenever it is available.
-                if (row.LastHeartbeat is { } lastHeartbeat)
+                // Primary signal, per-tenant rows only (marten#5174). Every vectorized per-tenant poll
+                // re-stamps HighWaterMark:<tenant> through mt_mark_event_progression, which always sets
+                // last_updated = transaction_timestamp() — even when the mark does not move. So its age
+                // proves the poll loop is *cycling* independent of whether the mark *advances*, which is
+                // what a liveness check needs and what no other persisted column offers here. It costs
+                // nothing extra: the write already happens on every cycle.
+                //
+                // This replaces the ExtendedProgression `heartbeat` column, which this check used to read
+                // as its primary signal. That column is never written for high-water rows —
+                // ExtendedProgressionWriter.OnNext drops HighWaterMark states outright (pinned by
+                // skips_high_water_mark_and_all_projections_states) — so the branch was unreachable in any
+                // real deployment and the check silently degraded to the gap heuristic.
+                if (row.IsPerTenant)
                 {
-                    // The gap tracker is only for the fallback path; keep it clear while on the heartbeat path.
+                    // The gap tracker is only for the store-global fallback path; keep it clear here.
                     _tracker.Readings.TryRemove(key, out _);
 
-                    var age = now - lastHeartbeat;
+                    if (row.LastUpdated is not { } lastUpdated)
+                    {
+                        continue;
+                    }
+
+                    var age = now - lastUpdated;
                     if (age < _staleThreshold)
                     {
                         continue;
@@ -393,16 +402,14 @@ public static class HighWaterHealthCheckExtensions
 
                     var restartNote = await tryAutoRestartAsync(database.Identifier, now, token).ConfigureAwait(false);
                     return HealthCheckResult.Unhealthy(
-                        $"Unhealthy: the high-water agent for '{shardDescription(database, row)}' last reported a liveness heartbeat {age.TotalSeconds:F0}s ago (at {lastHeartbeat:O}), exceeding the {_staleThreshold} staleness threshold. Its poll loop has stopped cycling (see JasperFx/jasperfx#539 / marten#4961).{restartNote}");
+                        $"Unhealthy: the high-water agent for '{shardDescription(database, row)}' last completed a poll cycle {age.TotalSeconds:F0}s ago (at {lastUpdated:O}), exceeding the {_staleThreshold} staleness threshold. Its poll loop has stopped cycling (see marten#4961).{restartNote}");
                 }
 
-                // No heartbeat. The gap fallback is only reliable for the store-global mark under a mode
-                // this store actually hosts:
-                //  - heartbeatOnly (ExternallyManaged) -> an external owner may legitimately pause the mark.
-                //  - per-tenant -> there is no per-tenant highest-sequence to compute a meaningful gap
-                //    (FetchHighestEventSequenceNumber is store-global), so a tenant with no new events would
-                //    look permanently "behind". Enable ExtendedProgression for per-tenant staleness.
-                if (heartbeatOnly || isPerTenant)
+                // Store-global row. last_updated only moves when the mark ADVANCES here
+                // (HighWaterDetector.persistDetectedMarkAsync returns early when nothing changed), so it is
+                // not a liveness signal and the gap heuristic is the only honest one. It is unusable under
+                // skipGapHeuristic (ExternallyManaged), where an external owner may legitimately pause the mark.
+                if (skipGapHeuristic)
                 {
                     _tracker.Readings.TryRemove(key, out _);
                     continue;
@@ -442,11 +449,63 @@ public static class HighWaterHealthCheckExtensions
             return HealthCheckResult.Healthy("Healthy");
         }
 
-        private static string shardDescription(IMartenDatabase database, JasperFx.Events.Projections.ShardState row)
+        /// <summary>
+        ///     marten#5174: read just the high-water progression rows, with <c>last_updated</c>. This used
+        ///     to go through <see cref="IEventDatabase.AllProjectionProgress(CancellationToken)" /> and
+        ///     filter in memory, which pulled every projection × tenant row on every probe and still could
+        ///     not see <c>last_updated</c> — <see cref="JasperFx.Events.Projections.ShardState" /> has no
+        ///     field for it. Two high-water rows out of hundreds is the whole working set here.
+        /// </summary>
+        private static async Task<IReadOnlyList<HighWaterRow>> readHighWaterRowsAsync(IMartenDatabase database,
+            string schema, CancellationToken token)
         {
-            return string.Equals(row.ShardName, HighWaterMarkShard, StringComparison.Ordinal)
-                ? $"database '{database.Identifier}'"
-                : $"database '{database.Identifier}', shard '{row.ShardName}'";
+            await database.EnsureStorageExistsAsync(typeof(IEvent), token).ConfigureAwait(false);
+
+            var rows = new List<HighWaterRow>();
+
+            await using var conn = database.CreateConnection();
+            await conn.OpenAsync(token).ConfigureAwait(false);
+            try
+            {
+                // Both operands are compile-time constants from HighWaterShardIdentity, so there is no
+                // pattern grammar reaching this from user input.
+                await using var reader = await conn
+                    .CreateCommand(
+                        $"select name, last_seq_id, last_updated from {schema}.mt_event_progression where name = :global or name like :prefix")
+                    .With("global", HighWaterMarkShard, NpgsqlDbType.Varchar)
+                    .With("prefix", PerTenantHighWaterPrefix + "%", NpgsqlDbType.Varchar)
+                    .ExecuteReaderAsync(token).ConfigureAwait(false);
+
+                while (await reader.ReadAsync(token).ConfigureAwait(false))
+                {
+                    var name = await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false);
+                    var sequence = await reader.GetFieldValueAsync<long>(1, token).ConfigureAwait(false);
+                    DateTimeOffset? lastUpdated = await reader.IsDBNullAsync(2, token).ConfigureAwait(false)
+                        ? null
+                        : await reader.GetFieldValueAsync<DateTimeOffset>(2, token).ConfigureAwait(false);
+
+                    rows.Add(new HighWaterRow(name, sequence, lastUpdated));
+                }
+            }
+            finally
+            {
+                await conn.CloseAsync().ConfigureAwait(false);
+            }
+
+            return rows;
+        }
+
+        private record HighWaterRow(string ShardName, long Sequence, DateTimeOffset? LastUpdated)
+        {
+            public bool IsPerTenant { get; } =
+                !string.Equals(ShardName, HighWaterMarkShard, StringComparison.Ordinal);
+        }
+
+        private static string shardDescription(IMartenDatabase database, HighWaterRow row)
+        {
+            return row.IsPerTenant
+                ? $"database '{database.Identifier}', shard '{row.ShardName}'"
+                : $"database '{database.Identifier}'";
         }
 
         private static string trackingKey(string databaseIdentifier, string shardName) =>


### PR DESCRIPTION
Closes #5174.

## The bug

`HighWaterHealthCheckExtensions` filtered `AllProjectionProgress` down to the `HighWaterMark` rows and used `row.LastHeartbeat` as its **primary** staleness signal. That column is never written for those rows:

- `ExtendedProgressionWriter.OnNext` returns early for `ShardState.HighWaterMark` / `AllProjections` — pinned upstream by `skips_high_water_mark_and_all_projections_states`.
- `HighWaterDetector.MarkHighWaterMarkInDatabaseAsync` / `MarkHighWaterForTenantAsync` and `BulkEventAppender`'s high-water upserts write `name` and `last_seq_id` only.
- `WriteExtendedProgressionAsync` is the only statement that sets `heartbeat`, and it only ever receives shard rows.

So the branch was unreachable in production and the check silently degraded to the gap heuristic — which, under `UseTenantPartitionedEvents`, is explicitly skipped for per-tenant rows. The per-tenant path asserted **nothing**. The tests didn't catch it because they seeded `heartbeat` with raw SQL, passing against a state the daemon never produces.

(JasperFx 2.39.1 already corrected the `JasperFxAsyncDaemon` doc comment that made this assumption look sound — jasperfx#622.)

## The fix

Not option 1 from the issue (start writing high-water heartbeats): that adds a periodic write stream at exactly the scale #5167 is about, and jasperfx#622 has just turned the *existing* periodic beat off by default for cost reasons. Instead, the issue's option 2 — with the better signal it points at:

**Per-tenant rows use `last_updated`.** `mt_mark_event_progression` always sets `last_updated = transaction_timestamp()`, and `TenantedHighWaterCoordinator` calls it on **every** vectorized poll, mark advance or not. Its age is therefore a genuine "the poll loop is cycling" signal — the thing the phantom heartbeat was supposed to provide — at zero extra write cost and with no dependency on `EnableExtendedProgressionTracking`. This is a real capability the check did not have before.

**The store-global row keeps the gap heuristic.** There `last_updated` only moves when the mark advances (`persistDetectedMarkAsync` returns early when `!HasChanged`), so it is not a liveness signal and pretending otherwise would false-positive on a quiet store. The docs now state plainly that a store-global loop wedged *while caught up* is not detectable from the progression table, and point at `IProjectionDaemon.HighWaterAgent.IsStale` / `LastPolledAt` for the in-process case.

The `heartbeatOnly` flag is renamed `skipGapHeuristic`, which is what it actually meant.

## Bonus

The row read no longer goes through `AllProjectionProgress`. That pulled every projection × tenant row on every probe to keep two of them, and still couldn't see `last_updated` — `ShardState` has no field for it. It's now a targeted two-row query.

## Tests

`DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests.cs` reworked: the heartbeat seeding helper is gone, `seedProgressionRowAsync` now takes a `last_updated`. New/changed cases:

- fresh per-tenant poll + mark behind → Healthy
- stale per-tenant poll + mark caught up → Unhealthy (the case the gap heuristic is blind to)
- **`the_extended_progression_heartbeat_column_is_never_consulted`** — the pin: with a *fresh* heartbeat written directly, a stuck store-global mark must still trip the gap heuristic
- a per-tenant row is never gap-assessed
- ExternallyManaged opt-in now asserts via the per-tenant poll signal

23/23 pass on net10.0. Docs updated (`docs/events/projections/healthchecks.md`), markdownlint + cspell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CTtw2kVRSZKp1p5RTxgAy