### PR TITLE
Composite members registered through a wrapper are torn down on rebuild (#5175)

### DIFF
--- a/src/DaemonTests/Composites/Bug_5175_composite_member_teardown.cs
+++ b/src/DaemonTests/Composites/Bug_5175_composite_member_teardown.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Projections.Composite;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.Composites;
+
+/// <summary>
+/// #5175 — a composite's rebuild tears its members down by reading each member's own
+/// <c>Options.CleanUps</c>. Two of the four registration paths wrap the projection in a source with a
+/// fresh, EMPTY <c>AsyncOptions</c>, so those members contributed no teardown at all: the rebuild
+/// restarted from sequence zero against a table still holding the previous run's documents. The
+/// composite's own options were never applied either.
+/// </summary>
+public class Bug_5175_composite_member_teardown: HostedStoreContext
+{
+    private const string CompositeName = "Teardown5175";
+
+    private async Task<IDocumentStore> startAsync()
+    {
+        var host = await StartHostAsync(opts =>
+            {
+                opts.Projections.CompositeProjectionFor(CompositeName, projection =>
+                {
+                    // Path 3 in the issue's table: the source is a CompositeProjectionWithServicesSource<T>
+                    // whose options used to stay empty.
+                    projection.AddProjectionWithServices<Teardown5175ProductProjection>(ServiceLifetime.Scoped);
+
+                    // Path 4: a raw IProjection wrapped in CompositeIProjectionSource. It declares nothing
+                    // about its own storage, so the teardown rule is declared at registration.
+                    projection.Add(new Teardown5175MetricProjection(),
+                        options => options.DeleteViewTypeOnTeardown<Teardown5175Metric>());
+                });
+            },
+            configureServices: services => services.AddScoped<ITeardown5175Pricing, Teardown5175Pricing>(),
+            configureMarten: marten => marten.ApplyAllDatabaseChangesOnStartup());
+
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
+        return store;
+    }
+
+    private static CompositeProjection compositeFor(IDocumentStore store) =>
+        ((DocumentStore)store).Options.Projections.All.OfType<CompositeProjection>().Single(x => x.Name == CompositeName);
+
+    [Fact]
+    public async Task every_member_reports_its_own_teardown_rules()
+    {
+        var store = await startAsync();
+
+        var cleanupTypes = compositeFor(store).AllProjections()
+            .SelectMany(x => x.Options.CleanUps)
+            .OfType<DeleteDocuments>()
+            .Select(x => x.DocumentType)
+            .ToArray();
+
+        // Before #5175 both of these were absent — the wrappers carried an empty AsyncOptions.
+        cleanupTypes.ShouldContain(typeof(Teardown5175Product));
+        cleanupTypes.ShouldContain(typeof(Teardown5175Metric));
+    }
+
+    [Fact]
+    public async Task rebuilding_deletes_every_members_documents_first()
+    {
+        var store = await startAsync();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Teardown5175Product>(
+                new Teardown5175Registered("Ankle Socks", "Socks"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using (var daemon = await store.BuildProjectionDaemonAsync())
+        {
+            await daemon.StartAllAsync();
+            await daemon.WaitForNonStaleData(30.Seconds());
+            await daemon.StopAllAsync();
+        }
+
+        // Orphans: rows of each member's view type that NO event can reproduce. If the rebuild's teardown
+        // reaches every member, they are gone afterwards; if a member contributes no teardown, its orphan
+        // survives and the rebuild replays into a table that still holds the previous run's documents.
+        var orphanId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new Teardown5175Product { Id = orphanId, Name = "Ghost", Category = "Ghost" });
+            session.Store(new Teardown5175Metric { Id = orphanId, Price = 999 });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using (var daemon = await store.BuildProjectionDaemonAsync())
+        {
+            await daemon.RebuildProjectionAsync(CompositeName, 60.Seconds(), TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<Teardown5175Product>(orphanId, TestContext.Current.CancellationToken))
+            .ShouldBeNull("the AddProjectionWithServices member's documents must be torn down on rebuild");
+        (await query.LoadAsync<Teardown5175Metric>(orphanId, TestContext.Current.CancellationToken))
+            .ShouldBeNull("the raw IProjection member's documents must be torn down on rebuild");
+
+        // ...and the rebuild genuinely reproduced the real read models it deleted.
+        (await query.Query<Teardown5175Product>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
+        (await query.Query<Teardown5175Metric>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
+    }
+}
+
+public interface ITeardown5175Pricing
+{
+    double PriceFor(string category);
+}
+
+public class Teardown5175Pricing: ITeardown5175Pricing
+{
+    public double PriceFor(string category) => category == "Socks" ? 12.5 : 5;
+}
+
+public record Teardown5175Registered(string Name, string Category);
+
+public class Teardown5175Product
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public string Category { get; set; }
+    public double Price { get; set; }
+}
+
+public class Teardown5175Metric
+{
+    public Guid Id { get; set; }
+    public double Price { get; set; }
+}
+
+public partial class Teardown5175ProductProjection: SingleStreamProjection<Teardown5175Product, Guid>
+{
+    private readonly ITeardown5175Pricing _pricing;
+
+    public Teardown5175ProductProjection(ITeardown5175Pricing pricing)
+    {
+        _pricing = pricing;
+        Name = "Teardown5175Product";
+    }
+
+    public override Teardown5175Product Evolve(Teardown5175Product snapshot, Guid id, IEvent e)
+    {
+        snapshot ??= new Teardown5175Product { Id = id };
+
+        if (e.Data is Teardown5175Registered registered)
+        {
+            snapshot.Name = registered.Name;
+            snapshot.Category = registered.Category;
+            snapshot.Price = _pricing.PriceFor(registered.Category);
+        }
+
+        return snapshot;
+    }
+}
+
+public class Teardown5175MetricProjection: IProjection
+{
+    public Task ApplyAsync(IDocumentOperations operations, IReadOnlyList<IEvent> events,
+        CancellationToken cancellation)
+    {
+        foreach (var e in events)
+        {
+            if (e.Data is Teardown5175Registered)
+            {
+                operations.Store(new Teardown5175Metric { Id = e.StreamId, Price = 1 });
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -241,11 +241,11 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
                 teardownProjectionStorage(leafSource, session);
             }
 
-            // Have to do the parent projection too!
-            foreach (var agent in source.Shards())
-            {
-                session.QueueOperation(new DeleteProjectionProgress(Events, agent.Name.Identity));
-            }
+            // #5175: the parent composite goes through the SAME teardown as any other source rather
+            // than only having its progression rows dropped. Previously its own AsyncOptions were
+            // never consulted at all, so `composite.Options.DeleteViewTypeOnTeardown<T>()` and
+            // `composite.Options.TeardownDataOnRebuild = false` were silent no-ops.
+            teardownProjectionStorage(composite, session);
         }
         else
         {
@@ -328,6 +328,9 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
             {
                 teardownProjectionStorageForTenant(leafSource, session, tenantId);
             }
+
+            // #5175: same as the store-global twin -- the composite's own teardown rules apply too.
+            teardownProjectionStorageForTenant(composite, session, tenantId);
         }
         else
         {

--- a/src/Marten/Events/Projections/CompositeProjection.cs
+++ b/src/Marten/Events/Projections/CompositeProjection.cs
@@ -111,6 +111,26 @@ public class CompositeProjection : CompositeProjection<IDocumentOperations, IQue
     }
 
     /// <summary>
+    /// Add a custom IProjection implementation to be executed within this composite, declaring what it
+    /// writes so a rebuild can tear that data down first.
+    /// </summary>
+    /// <remarks>
+    /// #5175: a raw <see cref="IProjection"/> describes neither its storage nor its teardown, so a
+    /// composite rebuild has nothing to delete for it and would replay into surviving rows. Use this
+    /// overload — typically <c>options => options.DeleteViewTypeOnTeardown&lt;MyView&gt;()</c> — for any
+    /// custom projection that writes documents.
+    /// </remarks>
+    /// <param name="projection">The custom IProjection implementation</param>
+    /// <param name="configure">Configure the member's async options, principally its teardown rules</param>
+    /// <param name="stageNumber">Optionally move the execution to a later stage. The default is 1</param>
+    public void Add(IProjection projection, Action<AsyncOptions> configure, int stageNumber = 1)
+    {
+        var wrapper = new CompositeIProjectionSource(projection);
+        configure(wrapper.Options);
+        StageFor(stageNumber).Add(wrapper);
+    }
+
+    /// <summary>
     /// Add a projection to be executed within this composite. The stage number is optional
     /// </summary>
     /// <param name="stageNumber">Optionally move the execution of this snapshot projection to a later stage. The default is 1</param>
@@ -258,6 +278,18 @@ internal class CompositeProjectionWithServicesSource<TProjection> :
             _configure?.Invoke(projection);
             projection.Name = Name;
             projection.OverwriteVersion(Version);
+
+            // #5175: adopt the built projection's options, exactly as ProjectionWrapper /
+            // ScopedProjectionWrapper do. Without this the wrapper keeps the empty AsyncOptions it was
+            // constructed with, and the composite's rebuild teardown -- which reads each member's own
+            // Options.CleanUps -- queues NOTHING for this member. The rebuild then restarts from zero
+            // against a table that still holds the previous run's documents.
+            replaceOptions(projection.Options);
+
+            foreach (var publishedType in projection.PublishedTypes())
+            {
+                RegisterPublishedType(publishedType);
+            }
         }
 
         return source;
@@ -548,6 +580,25 @@ internal class CompositeIProjectionSource :
         if (_projection.GetType().TryGetAttribute<ProjectionVersionAttribute>(out var att))
         {
             Version = att.Version;
+        }
+
+        // #5175: if the wrapped projection carries its own options, adopt them the way
+        // ProjectionWrapper does -- otherwise this wrapper's empty AsyncOptions is what the composite's
+        // rebuild teardown consults, and the member's documents survive the rebuild. Name and Version
+        // are deliberately NOT adopted: they compose this member's ShardName.Identity, and changing
+        // them would orphan every existing progression row.
+        //
+        // A raw IProjection that is not a ProjectionBase declares nothing about what it writes, so
+        // there is nothing to tear down for it and the composite cannot invent one. Register such a
+        // projection through Add(IProjectionSource) if its documents must be wiped on rebuild.
+        if (projection is ProjectionBase source)
+        {
+            replaceOptions(source.Options);
+
+            foreach (var publishedType in source.PublishedTypes())
+            {
+                RegisterPublishedType(publishedType);
+            }
         }
     }
 


### PR DESCRIPTION
Closes #5175.

## The bug

A composite's rebuild tears its members down by looping `composite.AllProjections()` and reading each member's own `Options.CleanUps`. Two of the four registration paths produce a source with a fresh, **empty** `AsyncOptions`:

| registration | member source type | `Options.CleanUps` (before) |
|---|---|---|
| `Snapshot<T>(stage)` | `SingleStreamProjection<T,TId>` | populated |
| `Add(IProjectionSource, stage)` | as supplied | populated if the source populates it |
| **`AddProjectionWithServices<T>(...)`** | `CompositeProjectionWithServicesSource<T>` | **empty** |
| **`Add(IProjection, stage)`** | `CompositeIProjectionSource` | **empty** |

So `teardownProjectionStorage` ran against those leaves and queued nothing. Progression rows and dead-letter rows *were* still deleted, so the rebuild restarted from sequence zero and replayed into a table that still held the previous run's documents — silently.

## The fix

**1. The wrappers adopt the wrapped projection's options.** `CompositeProjectionWithServicesSource<T>` and `CompositeIProjectionSource` now call `replaceOptions(...)` and register the inner projection's published types, exactly as `ProjectionWrapper` (`:51`) and `ScopedProjectionWrapper` (`:53`) have always done.

`Name` and `Version` are deliberately **not** adopted — they compose the member's `ShardName.Identity`, and changing them would orphan every existing progression row.

**2. A raw `IProjection` can declare its teardown.** A custom `IProjection` that isn't a `ProjectionBase` describes neither its storage nor its teardown, so there is nothing to adopt and nothing the composite can invent. New overload:

```csharp
projection.Add(new MyCustomProjection(),
    options => options.DeleteViewTypeOnTeardown<MyView>());
```

An added overload, not a changed signature, so existing `Add(IProjection, int)` callers are untouched.

**3. The composite's own options are applied.** The `is CompositeProjection` branch never called `teardownProjectionStorage(composite, …)`, so `composite.Options.DeleteViewTypeOnTeardown<T>()` and `composite.Options.TeardownDataOnRebuild = false` were silent no-ops on the parent. It now goes through the same teardown as any other source rather than only having its progression rows dropped — which also means its dead-letter rows are cleared. Same for the per-tenant twin (`teardownProjectionStorageForTenant`).

## Tests

`DaemonTests/Composites/Bug_5175_composite_member_teardown.cs`:

- `every_member_reports_its_own_teardown_rules` — each member's `Options.CleanUps` carries a `DeleteDocuments` for the type it writes
- `rebuilding_deletes_every_members_documents_first` — an end-to-end rebuild over a composite with an `AddProjectionWithServices` member and a raw `IProjection` member. Orphan rows of each view type (that no event can reproduce) must be gone afterwards, and the real read models must be back.

Falsified: with the two `replaceOptions(...)` calls reverted, **both tests fail** (`the AddProjectionWithServices member's documents must be torn down on rebuild`).

Full `DaemonTests` suite green: 292/292 on net10.0.

## Related

#5169 (the `EventProjectionScenario` wipe being a no-op for composites) is the same family but a different mechanism — the harness derives its wipe list from `Options.StorageTypes`, which a composite never populates. Handled separately so the two stay reviewable; the design there is to have the composite *surface* its members' storage types without duplicating their `CleanUps`, so it does not double up with this teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CTtw2kVRSZKp1p5RTxgAy