### PR TITLE
Document and pin the extended-progression heartbeat cost model (#5167)

### DIFF
--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -720,6 +720,41 @@ compose. (Note that `opts.Events` -- Marten's `EventGraph` -- does not itself
 implement `IEventStoreInstrumentation`; use the `EnableExtendedProgressionTracking`
 property shown above.)
 
+### What extended progression actually costs
+
+The columns themselves are free -- they ride along on writes the daemon already makes when a shard
+starts, pauses or stops. What is **not** free is the *periodic* heartbeat: a timer-driven flush that
+opens its own connection and transaction **per shard database, per node**.
+
+Marten 9.22.4 / JasperFx 2.39 turns that periodic beat **off by default**. Only status transitions
+reach the database, so an idle store makes no telemetry writes at all. Before that it ran on a
+hardcoded 5-second interval with no configuration path, which on a 512-shard-database store worked out
+to roughly 37 connection acquisitions per second per node to keep a handful of rows current -- enough
+to exhaust a small per-database connection pool and queue application requests behind it
+(see [marten#5167](https://github.com/JasperFx/marten/issues/5167)).
+
+If you want the periodic beat back -- a monitoring console that needs to distinguish "this shard is
+alive but idle" from "this shard's agent died" -- opt in explicitly and pick a cadence that suits your
+database count:
+
+```cs
+opts.Events.EnableExtendedProgressionTracking = true;
+
+// Off by default. Any positive value restores the periodic flush at that cadence;
+// null, zero or negative keeps it off.
+opts.Projections.ExtendedProgressionHeartbeatInterval = TimeSpan.FromSeconds(30);
+```
+
+Budget it as `databases-on-this-node / interval` connection acquisitions per second. All shard states
+that arrive within one interval are coalesced into a single batched `UPDATE`, so the cost scales with
+the number of databases rather than the number of shards.
+
+::: tip
+Status transitions are always written immediately regardless of this setting, so `agent_status`,
+`pause_reason` and the `failure_*` columns stay current with the beat switched off. The only thing you
+lose is the periodic refresh of `heartbeat` on a shard that is quietly making progress.
+:::
+
 ## Advanced Skipping Tracking <Badge type="tip" text="8.6" />
 
 ::: info

--- a/src/DaemonTests/Bugs/Bug_5167_extended_progression_heartbeat_interval.cs
+++ b/src/DaemonTests/Bugs/Bug_5167_extended_progression_heartbeat_interval.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace DaemonTests.Bugs;
+
+/// <summary>
+/// #5167 — <c>EnableExtendedProgressionTracking</c> used to cost one pooled connection and one
+/// transaction per shard database every 5 seconds, on a hardcoded interval no application could reach.
+/// At 512 tenant databases that is ~37 connection acquisitions per second per node purely for
+/// telemetry, and it contends for the very rows the progress writer updates.
+///
+/// <para>
+/// jasperfx#622 (JasperFx 2.39.0) turned the periodic beat OFF by default and put it behind
+/// <c>DaemonSettings.ExtendedProgressionHeartbeatInterval</c>, which Marten exposes on
+/// <c>opts.Projections</c>. These tests pin both halves of that from the Marten side, because the
+/// difference is invisible from the API surface and easy to regress: with the default, only status
+/// TRANSITIONS reach the database; with an interval configured, ordinary progress publications do too.
+/// </para>
+/// </summary>
+public class Bug_5167_extended_progression_heartbeat_interval: OneOffConfigurationsContext
+{
+    [Fact]
+    public void periodic_heartbeat_writes_are_off_by_default()
+    {
+        StoreOptions(x => x.Events.EnableExtendedProgressionTracking = true);
+
+        theStore.Options.Projections.ExtendedProgressionHeartbeatInterval.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task by_default_ordinary_progress_does_not_rewrite_the_heartbeat()
+    {
+        var heartbeats = await captureHeartbeatsAsync(interval: null);
+
+        // The second batch's Updated publications carry a heartbeat, but with the periodic beat off they
+        // are dropped rather than flushed -- no connection, no transaction, no row touched.
+        heartbeats.After.ShouldBe(heartbeats.Before);
+    }
+
+    [Fact]
+    public async Task configuring_an_interval_restores_the_periodic_heartbeat()
+    {
+        var heartbeats = await captureHeartbeatsAsync(interval: 1.Milliseconds());
+
+        heartbeats.After.ShouldNotBeNull();
+        heartbeats.After.ShouldNotBe(heartbeats.Before);
+    }
+
+    private async Task<(DateTime? Before, DateTime? After)> captureHeartbeatsAsync(TimeSpan? interval)
+    {
+        StoreOptions(x =>
+        {
+            x.Events.EnableExtendedProgressionTracking = true;
+            x.Projections.ExtendedProgressionHeartbeatInterval = interval;
+            x.Projections.Add(new Heartbeat5167Projection(), ProjectionLifecycle.Async);
+        });
+
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+
+        await appendAsync();
+
+        using var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(30.Seconds());
+
+        var before = await readHeartbeatAsync();
+
+        // A second batch produces ShardAction.Updated publications -- progress, not a status transition.
+        await appendAsync();
+        await daemon.WaitForNonStaleData(30.Seconds());
+
+        // The write is posted to a background block, so give it a beat to land before reading.
+        await Task.Delay(500, TestContext.Current.CancellationToken);
+        var after = await readHeartbeatAsync();
+
+        await daemon.StopAllAsync();
+
+        return (before, after);
+    }
+
+    private async Task appendAsync()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream<Heartbeat5167Doc>(Guid.NewGuid(), new Heartbeat5167Event());
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<DateTime?> readHeartbeatAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+
+        var raw = await conn
+            .CreateCommand(
+                $"select heartbeat from {theStore.Events.DatabaseSchemaName}.mt_event_progression where name like 'Heartbeat5167%'")
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken);
+
+        return raw is null or DBNull ? null : (DateTime)raw;
+    }
+}
+
+public record Heartbeat5167Event;
+
+public class Heartbeat5167Doc
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+}
+
+public partial class Heartbeat5167Projection: SingleStreamProjection<Heartbeat5167Doc, Guid>
+{
+    public Heartbeat5167Projection()
+    {
+        Name = "Heartbeat5167";
+    }
+
+    public void Apply(Heartbeat5167Doc doc, Heartbeat5167Event _) => doc.Count++;
+}


### PR DESCRIPTION
Closes #5167.

## Status: the mechanism is already fixed upstream

The reporter's headline cost — one pooled connection and one transaction **per shard database, per node, every 5 seconds**, on an interval no application could reach — was fixed by **jasperfx#622** in JasperFx 2.39.0, which master picked up in #5176.

`ExtendedProgressionWriter.HeartbeatWriteInterval` now defaults to `TimeSpan.Zero` (periodic beat **off**), and `JasperFxAsyncDaemon` reads it from `DaemonSettings.ExtendedProgressionHeartbeatInterval` — which Marten already surfaces, since `ProjectionOptions : ProjectionGraph<…> : DaemonSettings`. So on current master:

- an idle store makes **no** telemetry writes at all;
- ordinary progress publications are dropped outright rather than queued;
- status transitions (`Started` / `Paused` / `Stopped`) are still written immediately, so `agent_status`, `pause_reason` and the `failure_*` columns stay current;
- `opts.Projections.ExtendedProgressionHeartbeatInterval = TimeSpan.FromSeconds(30)` restores the beat at a cadence the application chooses.

That is the issue's item 4, plus most of item 3 (with the beat off, the only writes left *are* the ones that changed something).

## What this PR adds

The behavior change is invisible from Marten's API surface and easy to regress silently, and it was undocumented on the Marten side. So:

**Docs** — a new "What extended progression actually costs" section in `docs/events/projections/async-daemon.md`: what is and isn't free, the default, the knob, how to budget it (`databases-on-this-node / interval` connection acquisitions per second, coalesced into one batched `UPDATE` per database), and the note that transitions are unaffected.

**Tests** — `DaemonTests/Bugs/Bug_5167_extended_progression_heartbeat_interval.cs`, three cases:

- `periodic_heartbeat_writes_are_off_by_default` — the setting reads null on a Marten store
- `by_default_ordinary_progress_does_not_rewrite_the_heartbeat` — a second batch of events produces `ShardAction.Updated` publications carrying a heartbeat; with the default they never reach the row
- `configuring_an_interval_restores_the_periodic_heartbeat` — with an interval set, the same publications do write

No production code changes.

## Not addressed here

The issue's items 1 and 2 — moving the beat to one row per node in the master/references database, and off `mt_event_progression` onto its own table — are a cross-repo storage-shape change (`IEventDatabase` + every store implementation + the CritterWatch console that reads it), not something Marten can decide alone. With the periodic beat now off by default, they stop being urgent: the contention the issue measured came from the 5-second flush, and there is no longer one unless you ask for it. Worth keeping open as a design discussion in JasperFx if the periodic beat turns out to be something monitoring users routinely switch back on at scale.

The observation about `mt_event_progression` accumulating rows for every projection version ever deployed (150 of 159 rows dead on the reporter's shard) is a separate cleanup concern and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CTtw2kVRSZKp1p5RTxgAy