### PR TITLE
EventProjectionScenario's wipe covers composite projections (#5169)

### DIFF
--- a/src/DaemonTests/EventProjections/Bug_5169_composite_scenario_wipe.cs
+++ b/src/DaemonTests/EventProjections/Bug_5169_composite_scenario_wipe.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.EventProjections;
+
+/// <summary>
+/// #5169 — <c>EventProjectionScenario</c>'s up-front wipe derived its list of document types from
+/// <c>Options.StorageTypes</c>. A <c>CompositeProjection</c> never populates its own <c>StorageTypes</c>
+/// (its members hold theirs), so for a store whose entire read side is one composite the wipe loop
+/// iterated NOTHING: event data was deleted, the composite's read models were not, and every scenario
+/// after the first ran against the previous scenario's documents — now orphaned from any events.
+/// Silent, and the exact opposite of what the harness leads with.
+/// </summary>
+public class Bug_5169_composite_scenario_wipe: OneOffConfigurationsContext
+{
+    private void configure()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.CompositeProjectionFor("Wipe5169", composite =>
+            {
+                // Stage 1 snapshot, stage 2 read model — the reporter's shape.
+                composite.Snapshot<Wipe5169Invoice>();
+                composite.Add(new Wipe5169OverviewProjection(), 2);
+            });
+        });
+    }
+
+    [Fact]
+    public void the_composite_reports_the_document_types_its_members_write()
+    {
+        configure();
+
+        var published = theStore.Options.Projections.All.SelectMany(x => x.PublishedTypes()).ToArray();
+
+        published.ShouldContain(typeof(Wipe5169Invoice));
+        published.ShouldContain(typeof(Wipe5169Overview));
+
+        // ...and why the wipe could not use StorageTypes: a composite holds none of its own. That list is
+        // documented as a schema-building hint, and the members are where the real values live.
+        theStore.Options.Projections.All.SelectMany(x => x.Options.StorageTypes).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_second_scenario_starts_from_a_clean_slate()
+    {
+        configure();
+
+        var first = Guid.NewGuid();
+
+        await theStore.Advanced.EventProjectionScenario(scenario =>
+        {
+            scenario.StartStream<Wipe5169Invoice>(first, new Wipe5169Created(1_000_000m));
+            scenario.DocumentShouldExist<Wipe5169Invoice>(first);
+            scenario.DocumentShouldExist<Wipe5169Overview>(first);
+        });
+
+        // A second scenario touching nothing related. Before #5169 the first scenario's read models
+        // survived the wipe while its events were deleted, so this saw both.
+        var second = Guid.NewGuid();
+
+        await theStore.Advanced.EventProjectionScenario(scenario =>
+        {
+            scenario.StartStream<Wipe5169Invoice>(second, new Wipe5169Created(1m));
+            scenario.DocumentShouldExist<Wipe5169Invoice>(second);
+            scenario.DocumentShouldExist<Wipe5169Overview>(second);
+        });
+
+        await using var query = theStore.QuerySession();
+
+        // The leak the issue is about: an unfiltered Query<T>() inside AssertAgainstProjectedData used to
+        // see every prior scenario's rows.
+        (await query.Query<Wipe5169Overview>().CountAsync()).ShouldBe(1);
+        (await query.Query<Wipe5169Invoice>().CountAsync()).ShouldBe(1);
+
+        (await query.LoadAsync<Wipe5169Overview>(first)).ShouldBeNull();
+        (await query.LoadAsync<Wipe5169Invoice>(first)).ShouldBeNull();
+    }
+}
+
+public record Wipe5169Created(decimal Amount);
+
+// Self-aggregating: CompositeProjection.Snapshot<T>() builds a SingleStreamProjection<T, TId> over it.
+public class Wipe5169Invoice
+{
+    public Guid Id { get; set; }
+    public decimal Amount { get; set; }
+
+    public void Apply(Wipe5169Created e) => Amount = e.Amount;
+}
+
+public class Wipe5169Overview
+{
+    public Guid Id { get; set; }
+    public decimal ClaimedAmount { get; set; }
+}
+
+public partial class Wipe5169OverviewProjection: SingleStreamProjection<Wipe5169Overview, Guid>
+{
+    public void Apply(Wipe5169Overview overview, Wipe5169Created e) => overview.ClaimedAmount = e.Amount;
+}

--- a/src/Marten/Events/TestSupport/ProjectionScenario.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenario.cs
@@ -25,11 +25,20 @@ public class ProjectionScenario: JasperFx.Events.TestSupport.ProjectionScenario<
         _store = store;
     }
 
+    /// <summary>
+    ///     #5169: the wipe list comes from <see cref="IProjectionSource{TOperations,TQuerySession}.PublishedTypes" />,
+    ///     not <c>Options.StorageTypes</c>. A <c>CompositeProjection</c> never populates its own
+    ///     <c>StorageTypes</c> — its members hold theirs — so the loop iterated nothing for a store whose read
+    ///     side is a composite, and every scenario after the first ran against the previous scenario's
+    ///     documents while their events had already been deleted. <c>PublishedTypes()</c> is the traversal that
+    ///     already knows to expand a composite into its members (and is a superset of <c>StorageTypes</c> for
+    ///     everything else), which is why Marten's own schema build-out uses it.
+    /// </summary>
     protected override async Task DeleteExistingDataAsync(CancellationToken ct)
     {
         await _store.Advanced.Clean.DeleteAllEventDataAsync(ct).ConfigureAwait(false);
         foreach (var storageType in
-                 _store.Options.Projections.All.SelectMany(x => x.Options.StorageTypes))
+                 _store.Options.Projections.All.SelectMany(x => x.PublishedTypes()).Distinct())
         {
             await _store.Advanced.Clean.DeleteDocumentsByTypeAsync(storageType, ct).ConfigureAwait(false);
         }


### PR DESCRIPTION
Closes #5169.

## The bug

`ProjectionScenario.DeleteExistingDataAsync` built its wipe list from `Options.StorageTypes`:

```csharp
await _store.Advanced.Clean.DeleteAllEventDataAsync(ct);
foreach (var storageType in _store.Options.Projections.All.SelectMany(x => x.Options.StorageTypes))
{
    await _store.Advanced.Clean.DeleteDocumentsByTypeAsync(storageType, ct);
}
```

A `CompositeProjection` never populates its own `Options.StorageTypes` (nor `CleanUps`) — its members hold theirs. So for a store whose read side is one composite over ~10 members, the loop iterated **nothing**. Event data was deleted, the composite's read models were not, and every scenario after the first ran against the previous scenario's documents while their events were gone. Because the events *were* deleted, nothing downstream could reconstruct or even notice the leftovers.

Tests stayed accidentally correct as long as they used unique ids per scenario. Any unfiltered `Query<T>()` inside `AssertAgainstProjectedData` saw prior scenarios' rows — which is how the reporter hit it: an ordered `Query<InvoiceOverviewItem>()` asserting `[100m, 200m]` returned `[90m, 100m, 100m, 200m, 250m]`.

## The fix

The wipe walks `PublishedTypes()` instead:

```csharp
foreach (var storageType in _store.Options.Projections.All.SelectMany(x => x.PublishedTypes()).Distinct())
```

That is the right traversal for three independent reasons:

- `CompositeProjection<,>.PublishedTypes()` already unions its stages' members, so composites expand correctly with no new machinery;
- it is a superset of `Options.StorageTypes` for every `ProjectionBase` (`PublishedTypes()` = `_publishedTypes ∪ Options.StorageTypes`), so nothing that was wiped before stops being wiped;
- it is what Marten's own schema build-out uses (`StorageFeatures` → `AllPublishedTypes()`), whereas `StorageTypes` is documented as a schema-building *hint* — "used to help build out schema objects if the async daemon is started before the rest of the application" — not a teardown list.

That covers the issue's suggested fix 1. Fix 2 (having the composite populate its own `StorageTypes`/`CleanUps` from its members) is deliberately **not** taken: duplicating the members' `CleanUps` onto the parent would make the rebuild teardown in #5175 truncate every member table twice, and the schema-build concern it was meant to address is already handled by `PublishedTypes()`.

## Tests

`DaemonTests/EventProjections/Bug_5169_composite_scenario_wipe.cs`:

- `the_composite_reports_the_document_types_its_members_write` — the composite's `PublishedTypes()` carries both a stage-1 snapshot type and a stage-2 read model, *and* its `Options.StorageTypes` is empty (documenting why the old source could not work)
- `a_second_scenario_starts_from_a_clean_slate` — the issue's repro: two sequential `EventProjectionScenario` runs over a composite; the second must see exactly one invoice and one overview, and the first scenario's documents must be gone

Falsified: reverting the one-line change makes `a_second_scenario_starts_from_a_clean_slate` fail. All 26 `EventProjections` + `Bug_5169` tests pass on net10.0.

Adjacent to #5175, which is the same family (a composite's members being invisible from the outside) but a different mechanism — rebuild teardown reading each member's `CleanUps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CTtw2kVRSZKp1p5RTxgAy