### PR TITLE
The extended-progression batch write no longer builds a lock convoy (#5167)

### DIFF
--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -745,8 +745,18 @@ opts.Projections.ExtendedProgressionHeartbeatInterval = TimeSpan.FromSeconds(30)
 ```
 
 Budget it as `databases-on-this-node / interval` connection acquisitions per second. All shard states
-that arrive within one interval are coalesced into a single batched `UPDATE`, so the cost scales with
-the number of databases rather than the number of shards.
+that arrive within one interval are coalesced into a single flush on one rented connection, so the
+connection cost scales with the number of databases rather than the number of shards.
+
+Within that flush each shard's row is written by its **own single-row statement, in its own implicit
+transaction**. That is deliberate and load-bearing: a batch is there to amortize the *connection*, not
+the transaction. Marten 9.22.4 and earlier folded the flush into one `UPDATE ... FROM unnest(...)`,
+which takes a row lock on every shard in the batch and holds all of them until it commits — so a single
+slow projection batch sitting on one progression row stalled the telemetry write of every *other* shard
+on that database, and whatever was queued behind those. If you are diagnosing lock waits on
+`mt_event_progression` on an older version, note that `pg_blocking_pids()` reports only *direct*
+blockers: the telemetry `UPDATE` genuinely is the blocker, and the projection transaction that is the
+real root is one hop further down the chain. Walk it recursively.
 
 ::: tip
 Status transitions are always written immediately regardless of this setting, so `agent_status`,

--- a/src/DaemonTests/extended_progression_batch_write.cs
+++ b/src/DaemonTests/extended_progression_batch_write.cs
@@ -6,6 +6,8 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten.Events.Aggregation;
 using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
 using Shouldly;
 using Weasel.Core;
 using Xunit;
@@ -33,9 +35,14 @@ public partial class OtherBatchTelemetryProjection: SingleStreamProjection<Batch
 
 // jasperfx#553 — the batched extended-progression write. The JasperFx.Events ExtendedProgressionWriter
 // coalesces every shard's heartbeat on a database into one batch per flush interval; Marten's overload
-// must land the whole batch in ONE round trip with the exact semantics of
+// must land the whole batch on ONE rented connection with the exact semantics of
 // mt_mark_event_progression_extended: update-only telemetry decoration of existing progression rows,
 // never INSERT, never touch last_seq_id / last_updated.
+//
+// #5167 — and it must land as one single-row statement per shard, each its own implicit transaction.
+// The batch amortizes the CONNECTION, not the transaction: a multi-row statement holds a row lock on
+// every shard in the batch until it commits, so one slow projection batch on one row stalls every other
+// shard's telemetry (and whatever queues behind that) on the whole database.
 public class extended_progression_batch_write: DaemonContext
 {
     public extended_progression_batch_write(ITestOutputHelper output): base(output)
@@ -159,6 +166,110 @@ public class extended_progression_batch_write: DaemonContext
         (await countRowsAsync()).ShouldBe(rowsBefore); // and nothing was inserted
         var missing = await readRowAsync("NoSuchProjection:All:98123456");
         missing.status.ShouldBeNull();
+    }
+
+    // #5167 — the lock-convoy regression. A row that is locked by an in-flight projection batch is the
+    // normal case, not an exotic one, and the batch write is going to wait on it either way. What must
+    // NOT happen is the batch dragging every OTHER shard's row into that wait: measured against
+    // PostgreSQL, an unrelated shard's progress write timed out after 4s queued behind a telemetry
+    // statement that had locked its row on the way to a different, genuinely contended one.
+    //
+    // The rows are written in shard-name order, so "BatchTelemetryStream:All" goes first and the write
+    // then parks on the deliberately-locked "OtherBatchTelemetry:All". Seeing the first row's telemetry
+    // from ANOTHER connection while the batch is still parked is proof that its write committed on its
+    // own — under a single multi-row statement nothing would be visible until the whole batch committed,
+    // and the row would still be locked.
+    [Fact]
+    public async Task a_contended_row_does_not_hold_the_locks_of_the_rows_already_written()
+    {
+        await seedProgressionRowsAsync();
+
+        var database = (MartenDatabase)theStore.Storage.Database;
+        var schema = theStore.Events.DatabaseSchemaName;
+
+        await using var blocker = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await blocker.OpenAsync(TestContext.Current.CancellationToken);
+        await using var blocking = await blocker.BeginTransactionAsync(TestContext.Current.CancellationToken);
+
+        // Stands in for a projection batch transaction sitting on its own progression row
+        await blocker
+            .CreateCommand(
+                $"update {schema}.mt_event_progression set last_seq_id = last_seq_id where name = 'OtherBatchTelemetry:All'")
+            .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+
+        var write = database.WriteExtendedProgressionAsync([
+            telemetry("BatchTelemetryStream:All", "Running", node: 3),
+            telemetry("OtherBatchTelemetry:All", "Paused", "boom")
+        ], TestContext.Current.CancellationToken);
+
+        // The first row's write commits on its own while the batch is parked on the contended one
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(3);
+        while ((await readRowAsync("BatchTelemetryStream:All")).status == null)
+        {
+            DateTimeOffset.UtcNow.ShouldBeLessThan(deadline,
+                "The first row's telemetry never became visible -- the batch is holding its lock");
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+        }
+
+        // ...and it is genuinely still parked, so that visibility was not just "the batch finished"
+        write.IsCompleted.ShouldBeFalse();
+
+        // The counterfactual from the report: an unrelated writer touching the already-written row must
+        // not queue behind the batch. lock_timeout makes "it waited" a failure instead of a hang.
+        await using (var unrelated = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await unrelated.OpenAsync(TestContext.Current.CancellationToken);
+            await unrelated.CreateCommand($"""
+                set lock_timeout = '2s';
+                update {schema}.mt_event_progression set last_seq_id = last_seq_id
+                where name = 'BatchTelemetryStream:All';
+                """).ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        await blocking.RollbackAsync(TestContext.Current.CancellationToken);
+
+        await write;
+        (await readRowAsync("OtherBatchTelemetry:All")).status.ShouldBe("Paused");
+    }
+
+    // #5167 Finding 3 — the SET list used to be unconditional, so every flush gave every matched row a
+    // new tuple version whether anything had changed or not, on a small hot table. xmin is the
+    // inserting transaction of the live tuple, so an unchanged xmin is exactly "this row was not
+    // rewritten".
+    [Fact]
+    public async Task replaying_identical_telemetry_does_not_rewrite_the_row()
+    {
+        await seedProgressionRowsAsync();
+
+        var database = (MartenDatabase)theStore.Storage.Database;
+        var state = telemetry("BatchTelemetryStream:All", "Running", node: 3);
+
+        await database.WriteExtendedProgressionAsync([state], TestContext.Current.CancellationToken);
+        var written = await readTupleVersionAsync("BatchTelemetryStream:All");
+
+        // Byte-identical replay: nothing to change, so nothing is written
+        await database.WriteExtendedProgressionAsync([state], TestContext.Current.CancellationToken);
+        (await readTupleVersionAsync("BatchTelemetryStream:All")).ShouldBe(written);
+
+        // ...but a real change still lands
+        await database.WriteExtendedProgressionAsync([
+            telemetry("BatchTelemetryStream:All", "Paused", "boom", node: 3)
+        ], TestContext.Current.CancellationToken);
+
+        (await readTupleVersionAsync("BatchTelemetryStream:All")).ShouldNotBe(written);
+        (await readRowAsync("BatchTelemetryStream:All")).status.ShouldBe("Paused");
+    }
+
+    private async Task<string> readTupleVersionAsync(string shard)
+    {
+        await using var session = theStore.QuerySession();
+        var raw = await session.Connection
+            .CreateCommand(
+                $"select xmin::text from {theStore.Events.DatabaseSchemaName}.mt_event_progression where name = :name")
+            .With("name", shard)
+            .ExecuteScalarAsync();
+
+        return (string)raw!;
     }
 
     [Fact]

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -19,6 +19,7 @@ using Marten.Linq.QueryHandlers;
 using Marten.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 
@@ -60,17 +61,39 @@ public partial class MartenDatabase : IEventDatabase
     }
 
     /// <summary>
-    ///     Persist the extended progression telemetry for a whole batch of shards in ONE round trip on
-    ///     ONE rented connection. The JasperFx.Events <c>ExtendedProgressionWriter</c> coalesces every
-    ///     shard's heartbeat on a database into one batch per flush interval and drives this overload,
-    ///     because the per-shard single-row write does not scale under per-tenant agent fan-out
-    ///     (agents = projections × tenants — jasperfx#553). Deliberately a plain UPDATE ... FROM unnest
-    ///     join instead of a database function, so no schema object is added and deployments running
-    ///     <c>AutoCreate.None</c> pick it up without a migration. Semantics match the
-    ///     <c>mt_mark_event_progression_extended</c> function this replaced (the function is still
-    ///     installed for anything calling it directly): update-only telemetry decoration of existing
-    ///     progression rows — never INSERT, never touch <c>last_seq_id</c> / <c>last_updated</c>, shards
-    ///     without a progression row yet are skipped silently.
+    ///     Persist the extended progression telemetry for a whole batch of shards on ONE rented
+    ///     connection, as ONE SINGLE-ROW STATEMENT PER SHARD. The JasperFx.Events
+    ///     <c>ExtendedProgressionWriter</c> coalesces every shard's heartbeat on a database into one batch
+    ///     per flush interval and drives this overload, because renting a connection per shard does not
+    ///     scale under per-tenant agent fan-out (agents = projections × tenants — jasperfx#553).
+    ///     Deliberately plain UPDATE statements instead of a database function, so no schema object is
+    ///     added and deployments running <c>AutoCreate.None</c> pick it up without a migration. Semantics
+    ///     match the <c>mt_mark_event_progression_extended</c> function this replaced (the function is
+    ///     still installed for anything calling it directly): update-only telemetry decoration of
+    ///     existing progression rows — never INSERT, never touch <c>last_seq_id</c> / <c>last_updated</c>,
+    ///     shards without a progression row yet are skipped silently.
+    ///     <para>
+    ///     #5167: this used to be ONE <c>UPDATE … FROM unnest(…)</c> covering the whole batch, and that
+    ///     is a lock convoy. A multi-row statement takes a row lock on EVERY shard in the batch and holds
+    ///     all of them until it commits, so one slow projection batch sitting on one row stalls the
+    ///     telemetry write of every OTHER shard on the database — and, transitively, the progress writes
+    ///     queued behind those. Measured against PostgreSQL: an unrelated shard's progress write,
+    ///     contending with nothing, timed out after 4s queued behind a telemetry statement that had
+    ///     locked its row on the way to a different, genuinely contended one; rewritten this way the same
+    ///     collision clears in ~1ms and only the genuinely contended row waits. The load-bearing property
+    ///     is ONE ROW PER TRANSACTION, so these must stay separate round trips in autocommit — several
+    ///     statements batched into one Npgsql command would share an implicit transaction and reproduce
+    ///     the convoy exactly. What is amortized is the CONNECTION, which is what jasperfx#553 was about.
+    ///     Writes are applied in shard-name order so two writers racing over the same rows cannot take
+    ///     their locks in opposite orders. Being separate transactions, a failure partway through leaves
+    ///     the earlier rows written — correct for best-effort telemetry, where an all-or-nothing batch
+    ///     buys nothing.
+    ///     </para>
+    ///     <para>
+    ///     The <c>is distinct from</c> guard makes a replay of unchanged telemetry an <c>UPDATE 0</c>
+    ///     rather than a new tuple version. <c>mt_event_progression</c> is small and hot, and every
+    ///     avoided rewrite is also an avoided row lock.
+    ///     </para>
     ///     <para>
     ///     #5048 / jasperfx#565: the four <c>failure_*</c> columns follow a different rule from the rest.
     ///     They are written when the state carries a <see cref="ShardState.Failure" />, CLEARED when a
@@ -89,71 +112,77 @@ public partial class MartenDatabase : IEventDatabase
 
         await EnsureStorageExistsAsync(typeof(IEvent), token).ConfigureAwait(false);
 
-        var names = new string[states.Count];
-        var heartbeats = new DateTimeOffset?[states.Count];
-        var statuses = new string?[states.Count];
-        var reasons = new string?[states.Count];
-        var nodes = new int?[states.Count];
-        var touchFailures = new bool[states.Count];
-        var failureCategories = new string?[states.Count];
-        var failureSequences = new long?[states.Count];
-        var failureEventTypes = new string?[states.Count];
-        var failureTenantIds = new string?[states.Count];
-
-        for (var i = 0; i < states.Count; i++)
-        {
-            var state = states[i];
-
-            names[i] = state.ShardName;
-            heartbeats[i] = state.LastHeartbeat;
-            statuses[i] = state.AgentStatus;
-            reasons[i] = state.PauseReason;
-            nodes[i] = state.RunningOnNode;
-
-            var failure = state.Failure;
-            touchFailures[i] = failure != null || state.Action == ShardAction.Started;
-            failureCategories[i] = failure?.Category.ToString();
-            failureSequences[i] = failure?.Event?.Sequence;
-            failureEventTypes[i] = failure?.Event?.EventTypeName;
-            failureTenantIds[i] = failure?.Event?.TenantId;
-        }
-
         await using var conn = CreateConnection();
         try
         {
             await conn.OpenAsync(token).ConfigureAwait(false);
-            await conn.CreateCommand($"""
-                update {Options.EventGraph.DatabaseSchemaName}.mt_event_progression as p
-                set heartbeat = t.heartbeat,
-                    agent_status = t.agent_status,
-                    pause_reason = t.pause_reason,
-                    running_on_node = t.running_on_node,
-                    failure_category = case when t.touch_failure then t.failure_category else p.failure_category end,
-                    failure_event_sequence = case when t.touch_failure then t.failure_event_sequence else p.failure_event_sequence end,
-                    failure_event_type = case when t.touch_failure then t.failure_event_type else p.failure_event_type end,
-                    failure_event_tenant_id = case when t.touch_failure then t.failure_event_tenant_id else p.failure_event_tenant_id end
-                from unnest(:names, :heartbeats, :statuses, :reasons, :nodes, :touch_failures,
-                    :failure_categories, :failure_sequences, :failure_event_types, :failure_tenant_ids)
-                    as t(name, heartbeat, agent_status, pause_reason, running_on_node, touch_failure,
-                        failure_category, failure_event_sequence, failure_event_type, failure_event_tenant_id)
-                where p.name = t.name
-                """)
-                .With("names", names, NpgsqlDbType.Array | NpgsqlDbType.Varchar)
-                .With("heartbeats", heartbeats, NpgsqlDbType.Array | NpgsqlDbType.TimestampTz)
-                .With("statuses", statuses, NpgsqlDbType.Array | NpgsqlDbType.Varchar)
-                .With("reasons", reasons, NpgsqlDbType.Array | NpgsqlDbType.Text)
-                .With("nodes", nodes, NpgsqlDbType.Array | NpgsqlDbType.Integer)
-                .With("touch_failures", touchFailures, NpgsqlDbType.Array | NpgsqlDbType.Boolean)
-                .With("failure_categories", failureCategories, NpgsqlDbType.Array | NpgsqlDbType.Varchar)
-                .With("failure_sequences", failureSequences, NpgsqlDbType.Array | NpgsqlDbType.Bigint)
-                .With("failure_event_types", failureEventTypes, NpgsqlDbType.Array | NpgsqlDbType.Varchar)
-                .With("failure_tenant_ids", failureTenantIds, NpgsqlDbType.Array | NpgsqlDbType.Varchar)
-                .ExecuteNonQueryAsync(token).ConfigureAwait(false);
+
+            using var command = conn.CreateCommand(extendedProgressionSql());
+
+            var name = command.Parameters.Add(new NpgsqlParameter("name", NpgsqlDbType.Varchar));
+            var heartbeat = command.Parameters.Add(new NpgsqlParameter("heartbeat", NpgsqlDbType.TimestampTz));
+            var status = command.Parameters.Add(new NpgsqlParameter("agent_status", NpgsqlDbType.Varchar));
+            var reason = command.Parameters.Add(new NpgsqlParameter("pause_reason", NpgsqlDbType.Text));
+            var node = command.Parameters.Add(new NpgsqlParameter("running_on_node", NpgsqlDbType.Integer));
+            var touchFailure = command.Parameters.Add(new NpgsqlParameter("touch_failure", NpgsqlDbType.Boolean));
+            var failureCategory = command.Parameters.Add(new NpgsqlParameter("failure_category", NpgsqlDbType.Varchar));
+            var failureSequence = command.Parameters.Add(new NpgsqlParameter("failure_sequence", NpgsqlDbType.Bigint));
+            var failureEventType =
+                command.Parameters.Add(new NpgsqlParameter("failure_event_type", NpgsqlDbType.Varchar));
+            var failureTenantId =
+                command.Parameters.Add(new NpgsqlParameter("failure_tenant_id", NpgsqlDbType.Varchar));
+
+            // The writer already hands these over sorted, but a direct caller need not, and the ordering
+            // is what keeps two racing writers from deadlocking against each other.
+            foreach (var state in states.OrderBy(x => x.ShardName, StringComparer.Ordinal))
+            {
+                var failure = state.Failure;
+
+                name.Value = state.ShardName;
+                heartbeat.Value = (object?)state.LastHeartbeat ?? DBNull.Value;
+                status.Value = (object?)state.AgentStatus ?? DBNull.Value;
+                reason.Value = (object?)state.PauseReason ?? DBNull.Value;
+                node.Value = (object?)state.RunningOnNode ?? DBNull.Value;
+                touchFailure.Value = failure != null || state.Action == ShardAction.Started;
+                failureCategory.Value = (object?)failure?.Category.ToString() ?? DBNull.Value;
+                failureSequence.Value = (object?)failure?.Event?.Sequence ?? DBNull.Value;
+                failureEventType.Value = (object?)failure?.Event?.EventTypeName ?? DBNull.Value;
+                failureTenantId.Value = (object?)failure?.Event?.TenantId ?? DBNull.Value;
+
+                // One ExecuteNonQueryAsync per shard, deliberately: each is its own implicit transaction,
+                // so this loop never holds more than a single row lock at a time.
+                await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            }
         }
         finally
         {
             await conn.CloseAsync().ConfigureAwait(false);
         }
+    }
+
+    private string extendedProgressionSql()
+    {
+        return $"""
+            update {Options.EventGraph.DatabaseSchemaName}.mt_event_progression as p
+            set heartbeat = :heartbeat,
+                agent_status = :agent_status,
+                pause_reason = :pause_reason,
+                running_on_node = :running_on_node,
+                failure_category = case when :touch_failure then :failure_category else p.failure_category end,
+                failure_event_sequence = case when :touch_failure then :failure_sequence else p.failure_event_sequence end,
+                failure_event_type = case when :touch_failure then :failure_event_type else p.failure_event_type end,
+                failure_event_tenant_id = case when :touch_failure then :failure_tenant_id else p.failure_event_tenant_id end
+            where p.name = :name
+              and (p.heartbeat is distinct from :heartbeat
+                or p.agent_status is distinct from :agent_status
+                or p.pause_reason is distinct from :pause_reason
+                or p.running_on_node is distinct from :running_on_node
+                or (:touch_failure
+                    and (p.failure_category is distinct from :failure_category
+                      or p.failure_event_sequence is distinct from :failure_sequence
+                      or p.failure_event_type is distinct from :failure_event_type
+                      or p.failure_event_tenant_id is distinct from :failure_tenant_id)))
+            """;
     }
 
     public async Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token)


### PR DESCRIPTION
Closes the lock-wait half of #5167. jasperfx#622 (adopted in #5176, documented in #5183) removed the *steady-state* cost by turning the periodic beat off; this removes the *blast radius* of the writes that remain.

## The finding

The production report that this statement increases database lock waits is correct, and the mechanism is **not** write volume — it is that a *single* statement takes row locks on **every shard in the batch at once** and holds them until it completes.

Three sessions against a stand-in for `mt_event_progression` — **P** a projection batch transaction holding one row (`shard_d`), **H** the batched telemetry UPDATE covering all six, **Q** an unrelated projection committing progress for `shard_a`:

```
  pid  | state  | wait_event_type |  wait_event   | blocked_by |  query
 11762 | active | Lock            | transactionid | {11763}    | UPDATE ... WHERE name = 'shard_a'      <- Q
 11763 | active | Lock            | transactionid | {11765}    | UPDATE ... SET heartbeat = t.heartbeat <- H
 11765 | active | Timeout         | PgSleep       | {}         | (the projection batch holding shard_d) <- P
```

`Q` — which touches a shard the telemetry statement has no business serializing — **blocked and timed out after 4s**. It was never contending with `P`; it was queued behind `H`, which had already locked `shard_a` on its way to `shard_d` and then stalled there.

With `H` replaced by six single-row autocommit UPDATEs:

```
H2: starting per-row writes   14:57:25.008
H2: a,b,c committed           14:57:25.009      <-- 1 ms
Q:  updating shard_a          14:57:28.011
Q:  SUCCEEDED                 14:57:28.012      <-- 1 ms, no wait
H2: d finally done            14:57:37.013      <-- only the genuinely contended row waited
```

This also explains the observation in #5167 that the reporter could not account for — "the blocker and the blocked statement were both this heartbeat UPDATE, within the same database". `pg_blocking_pids()` reports *direct* blockers only. The heartbeat UPDATE genuinely is the blocker; the projection transaction that is the real root is one hop further down the chain and invisible unless you walk it recursively. No second concurrent writer is required to produce that picture.

**Why #622 alone was not enough.** It made this rarer without making it milder. The transitions that still reach the database are precisely the *correlated* ones — node start, node stop, rollout, agent rebalance — when many shards on a database transition together, which is when a batch is at its widest and when projection batches are being cancelled and re-established on those same rows.

## What changed

**One row per transaction.** The flush is now one single-row `UPDATE` per shard on the same rented connection, each in its own implicit transaction. That is the load-bearing property — six single-row statements *inside* one transaction would reproduce the convoy exactly, which is why they must stay separate round trips rather than one batched Npgsql command (several statements in one command share an implicit transaction). What a batch amortizes is the **connection**, which is all jasperfx#553 ever needed: N single-row statements on one rented connection still cost one rent. Writes go in shard-name order so two writers racing over the same rows cannot take their locks in opposite orders.

**A change guard.** The `SET` list was unconditional, so every flush gave every matched row a new tuple version whether anything had changed or not — on a small, hot table (two byte-identical replays of a 6-row batch left 31 dead tuples). An `is distinct from` guard makes the replay an `UPDATE 0`. This is secondary to the convoy, but each avoided rewrite is also an avoided row lock.

Semantics are otherwise unchanged: update-only, never INSERT, never touches `last_seq_id` / `last_updated`, missing rows skipped silently, and the #5048 `failure_*` columns keep their write / clear-on-`Started` / leave-alone rule.

## Verification

`DaemonTests` green on net9.0 (300 tests). Two new tests, both **falsified** — each fails against the shape it guards:

| test | falsified against | failure |
|---|---|---|
| `a_contended_row_does_not_hold_the_locks_of_the_rows_already_written` | the same loop wrapped in an explicit transaction | first row's telemetry never becomes visible while the batch is parked |
| `replaying_identical_telemetry_does_not_rewrite_the_row` | the `is distinct from` guard neutralized | `xmin` changes on a byte-identical replay |

The lock test holds a real row lock from a second connection, then asserts the earlier row's write is visible from a third connection *while the batch is still parked* — and that an unrelated writer touching that row completes under a 2s `lock_timeout` rather than queuing behind the batch.

Companion contract change in JasperFx.Events: JasperFx/jasperfx#630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CTtw2kVRSZKp1p5RTxgAy