### PR TITLE
Adopt JasperFx 2.39.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -194,21 +194,29 @@
          single stream rebuilds run the actual projection instead of silently falling through to
          conventional aggregation off the aggregate type; and the projection a scoped wrapper wraps
          is validated rather than only the wrapper, so an invalid configuration fails at startup for
-         every lifetime instead of only Singleton. -->
-    <PackageVersion Include="JasperFx" Version="2.39.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.39.1" />
+         every lifetime instead of only Singleton.
+         JasperFx 2.39.2: jasperfx#630 (marten#5167) — the IEventDatabase batched extended-progression
+         contract now REQUIRES one row per transaction, and ExtendedProgressionWriter flushes each
+         batch ordered by shard name. A batch amortizes the CONNECTION, never the transaction: a
+         multi-row statement holds a row lock on every shard in the batch until it commits, so one
+         slow projection batch on one row stalled every other shard's telemetry on that database
+         (Marten's side of this is #5186, which does not depend on this bump). The ordering closes
+         the cross-writer deadlock hazard — the tracker is per-database and shared, and
+         BuildProjectionDaemonAsync is not cached, so two writers can race over the same rows. -->
+    <PackageVersion Include="JasperFx" Version="2.39.2" />
+    <PackageVersion Include="JasperFx.Events" Version="2.39.2" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.39.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.39.1">
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.39.2" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.39.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.39.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.39.2" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Companion bump for #5186. [jasperfx#630](https://github.com/JasperFx/jasperfx/pull/630).

**The contract is now explicit.** `IEventDatabase.WriteExtendedProgressionAsync(IReadOnlyList<ShardState>, …)` previously asked for "as few round-trips as the store can manage — ideally one" and said nothing about transaction scope, which is exactly what made a single `UPDATE … FROM unnest(…)` a reasonable reading of it. It now states that one row per transaction is **required**, that what a batch amortizes is the **connection** (jasperfx#553's actual concern — N single-row statements on one rented connection still cost one rent), and that implementations should skip rows whose telemetry is unchanged. Polecat needs this before it implements the batched overload.

**Batches flush ordered by shard name.** With one row per transaction a single writer never holds more than one row lock, but `Tracker` is per-database and shared and `BuildProjectionDaemonAsync` is not cached, so two writers can race over the same rows — and the pending dictionary's enumeration order is an implementation detail, not an agreement between them.

Marten's own fix in #5186 does **not** depend on this bump; the convoy was in Marten's SQL. What this adds is closing the cross-writer deadlock hazard and pinning the contract for the next implementer.

## Verification

Restored and built against the published 2.39.2 packages (all five: JasperFx, JasperFx.Events, ComplianceTests, and both source generators).

- `DaemonTests` — 300/300 green, net9.0
- `CoreTests` `jasper_fx_mechanics` (the extended-progression configuration tests) — 18/18 green, net9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CTtw2kVRSZKp1p5RTxgAy