### PR TITLE
Adopt JasperFx 2.39.4 and compliance wave 5 part 1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -214,20 +214,20 @@
          warning. It used to announce itself as lock contention; one-row-per-transaction writes made
          it harmless to correctness and therefore silent, while still meaning two daemons are
          started for one database. Reported, never refused: the duplicate is the symptom. -->
-    <PackageVersion Include="JasperFx" Version="2.39.3" />
-    <PackageVersion Include="JasperFx.Events" Version="2.39.3" />
+    <PackageVersion Include="JasperFx" Version="2.39.4" />
+    <PackageVersion Include="JasperFx.Events" Version="2.39.4" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.39.3" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.39.3">
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.39.4" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.39.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.39.3" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.39.4" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave5.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave5.cs
@@ -1,0 +1,20 @@
+using JasperFx.Events.ComplianceTests;
+using Marten;
+using Marten.Testing.Harness;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * Wave 5 enrollments. Same shape as marten_event_store_compliance.cs -- empty subclasses closing
+ * the shared suites over Marten's session pair. Separate file only while the suites are in flight
+ * upstream; fold into the main enrollment file once the JasperFx package ships them.
+ */
+
+public class fetch_latest_compliance
+    : FetchLatestCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+public class stream_archiving_compliance
+    : StreamArchivingCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+public class event_store_explorer_compliance
+    : EventStoreExplorerCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;


### PR DESCRIPTION
Bumps JasperFx 2.39.3 → **2.39.4** and enrolls the three compliance suites that shipped in it (JasperFx/jasperfx#633).

| Suite | Tests | Issue |
|---|---|---|
| `fetch_latest_compliance` | 7 | #5138 |
| `stream_archiving_compliance` | 6 | #5140 |
| `event_store_explorer_compliance` | 6 | #5146 |

Marten's compliance coverage goes **105 → 124 tests, zero capability gates**. No Marten code changes — every entry point the three suites exercise was already on the shared JasperFx surfaces, so this is a version bump plus one file of empty subclasses.

## Verified

net9.0, against the published 2.39.4 packages: 124/124 compliance, and the full EventSourcingTests suite green.

The suites were authored against Marten and Polecat working copies simultaneously via a local pack feed, so both stores were passing before the upstream PR was opened — not written against one store and ported afterwards.

## What the wave found

Adoption surfaced two real defects, both on the **Polecat** side and both already fixed (polecat#411, polecat#412): an empty `usage.Events` collection, and a null `StreamMetadata.Tags` where the record declares it non-nullable. Marten was correct on both counts. They are worth mentioning here because they are the argument for the shared suite — neither was caught by either product's own tests, and both sit on the descriptor surface CritterWatch reads.

Closes #5138
Closes #5140
Closes #5146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde
