### PR TITLE
fix(#5192): bundle the JasperFx.Events.SourceGenerator 2.42.1 published-types fix

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -223,7 +223,24 @@
       which closes the seam, lives beside the rest of the harness.
     -->
     <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.41.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.41.0">
+    <!--
+      Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
+      the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
+      declares no dependencies, and Marten bundles its dll into Marten.nupkg (see
+      _BundleEventsSourceGeneratorAnalyzer in Marten.csproj, marten#4557), so its version is
+      independent of the runtime family's.
+
+      2.42.1: jasperfx#637 (marten#5192) — the generator used to register an EventProjection's
+      discovered published document types by emitting a parameterless constructor into the user's
+      partial class. That is illegal on a type declaring a primary constructor, so
+      `partial class MyProjection(ILogger logger) : EventProjection` failed to build with CS8862; and
+      for a projection registered through AddProjectionWithServices the container calls the
+      dependency-taking constructor, so the generated one never ran and the published types went
+      silently unregistered. Registration now rides an override of ProjectionBase.PublishedTypes(),
+      which does not care how the instance was constructed. The generator is otherwise byte-identical
+      from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
+    -->
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.42.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/src/EventSourcingTests/Bugs/Bug_5192_event_projection_with_injected_dependencies.cs
+++ b/src/EventSourcingTests/Bugs/Bug_5192_event_projection_with_injected_dependencies.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+// Regression guard for https://github.com/JasperFx/marten/issues/5192, fixed in the bundled
+// JasperFx.Events.SourceGenerator by jasperfx#637.
+//
+// The generator registers an EventProjection's discovered published document types -- the ones it sees
+// flowing through ops.Store/Insert/Update inside an ApplyAsync override (marten#4166). It used to do that
+// by emitting a parameterless constructor into the user's partial class, which failed two ways for exactly
+// the projections that need dependencies injected, i.e. the ones registered through AddProjectionWithServices:
+//
+//   1. It does not compile at all against a primary constructor. C# requires every other constructor to
+//      chain through the primary one, so the generated file broke the whole build with CS8862. That
+//      half of this test is the mere existence of DependencyAwareProjection below -- if the generator
+//      regresses, this project stops compiling.
+//
+//   2. Where it did compile -- an ordinary dependency-taking constructor -- the container calls THAT
+//      constructor, so the generated parameterless one never ran and the published types went silently
+//      unregistered. Only PublishedTypes() can see that, which is what the test asserts.
+//
+// Both shapes are covered because they hit different generator paths, and shape 2 is the one that fails
+// quietly rather than loudly.
+// (partial because the generator wraps a nested projection's emitted members in its containing types.)
+public partial class Bug_5192_event_projection_with_injected_dependencies
+{
+    public record ThingCreated(Guid Id, string Name);
+
+    public class Thing
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class OtherThing
+    {
+        public Guid Id { get; set; }
+    }
+
+    // Shape 1: a primary constructor. Before the fix the generated partial did not compile.
+    public partial class PrimaryConstructorProjection(ILogger<PrimaryConstructorProjection> logger): EventProjection
+    {
+        public override ValueTask ApplyAsync(IDocumentOperations operations, IEvent e,
+            CancellationToken cancellation)
+        {
+            if (e.Data is ThingCreated created)
+            {
+                logger.LogDebug("Storing {Name}", created.Name);
+                operations.Store(new Thing { Id = created.Id, Name = created.Name });
+            }
+
+            return new ValueTask();
+        }
+    }
+
+    // Shape 2: an ordinary injected constructor. Before the fix this compiled and registered nothing.
+    public partial class DependencyAwareProjection: EventProjection
+    {
+        private readonly ILogger<DependencyAwareProjection> _logger;
+
+        public DependencyAwareProjection(ILogger<DependencyAwareProjection> logger) => _logger = logger;
+
+        public override ValueTask ApplyAsync(IDocumentOperations operations, IEvent e,
+            CancellationToken cancellation)
+        {
+            if (e.Data is ThingCreated created)
+            {
+                _logger.LogDebug("Storing {Name}", created.Name);
+                operations.Store(new Thing { Id = created.Id, Name = created.Name });
+                operations.Store(new OtherThing { Id = created.Id });
+            }
+
+            return new ValueTask();
+        }
+    }
+
+    [Fact]
+    public void published_types_are_registered_on_a_projection_with_a_primary_constructor()
+    {
+        new PrimaryConstructorProjection(NullLogger<PrimaryConstructorProjection>.Instance)
+            .PublishedTypes()
+            .ShouldContain(typeof(Thing));
+    }
+
+    [Fact]
+    public void published_types_are_registered_on_a_container_built_projection()
+    {
+        // The instance is built the way AddProjectionWithServices builds it -- through the constructor
+        // that takes the dependency, never through a parameterless one.
+        var publishedTypes = new DependencyAwareProjection(NullLogger<DependencyAwareProjection>.Instance)
+            .PublishedTypes()
+            .ToArray();
+
+        publishedTypes.ShouldContain(typeof(Thing));
+        publishedTypes.ShouldContain(typeof(OtherThing));
+    }
+
+    [Fact]
+    public async Task the_store_provisions_storage_for_the_discovered_published_types()
+    {
+        // The point of registering published types: a projection's document storage is known ahead of
+        // time rather than only provisioned on demand. Nothing here constructs the projection by hand.
+        await using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "bug_5192";
+            opts.Projections.Add(
+                new DependencyAwareProjection(NullLogger<DependencyAwareProjection>.Instance),
+                ProjectionLifecycle.Inline);
+        });
+
+        store.Options.Projections.AllPublishedTypes().ShouldContain(typeof(Thing));
+        store.Options.Projections.AllPublishedTypes().ShouldContain(typeof(OtherThing));
+    }
+}


### PR DESCRIPTION
Fixes #5192. Consumes [jasperfx#637](https://github.com/JasperFx/jasperfx/pull/637), shipped in JasperFx 2.42.1.

## The bug

The bundled `JasperFx.Events.SourceGenerator` registers an `EventProjection`'s discovered published document types (#4166) by writing into the user's partial class. It used to do that by emitting a parameterless constructor — which fails for exactly the projections that need dependencies injected, i.e. the ones that have to be registered through `AddProjectionWithServices`.

**A primary constructor made it a build break.** C# requires every other constructor to chain through the primary one, so this failed to compile with **CS8862** inside the generated `<T>.TypeRegistration.g.cs`:

```csharp
public partial class MyProjection(ILogger<MyProjection> logger) : EventProjection
{
    public override ValueTask ApplyAsync(IDocumentOperations operations, IEvent e, CancellationToken cancellation)
    {
        operations.Store(new Thing());
        return new ValueTask();
    }
}
```

That is what #5192 reported.

**An ordinary injected constructor made it a silent no-op.** The container calls the dependency-taking constructor, so the generated parameterless one never ran and the published types went unregistered — which also left jasperfx#626's teardown registration nothing to register. Confirmed on 9.22.4:

```
new MyProjection(logger).PublishedTypes()  ->  []
```

jasperfx#637 moves registration onto an override of `ProjectionBase.PublishedTypes()`, which does not care how the instance was constructed.

## Regression window

Marten **9.22.2 builds, 9.22.3 does not**. 9.22.3 bundles a generator built from JasperFx.Events 2.38.0, which included jasperfx#611 — published-type discovery became semantic. Before that only an explicit `Store<Doc>(x)` produced a registration and the far more common `Store(doc)` produced none, so the constructor was rarely emitted at all. The constructor defect itself is older: `Store<Doc>(x)` plus a primary constructor breaks on 9.22.0 too.

## Why only the source generator pin moves

`JasperFx.Events.SourceGenerator` goes 2.41.0 → 2.42.1 while the rest of the JasperFx line stays at 2.41.0. That package is analyzer-only, declares no dependencies, and Marten bundles its dll into `Marten.nupkg` (`_BundleEventsSourceGeneratorAnalyzer`, #4557), so its version is independent of the runtime family's — which should stay at 2.41.0 until Marten adopts the strong-typed identity compliance suite that landed in 2.42.0. The generator is **byte-identical from 2.38.0 through 2.42.0**, so this is an isolated swap of that one fix rather than a version of drift. The reasoning is recorded in a comment on the pin itself.

## Behavior change worth knowing

The generator used to skip registration entirely when the class already had an explicit parameterless constructor — a guard that existed only because you cannot add a second one. An override has no such conflict, so those projections now get their published types registered too. That is the intended #4166 behavior, but it means this upgrade can newly provision document storage, and newly register teardown targets under jasperfx#626, for a projection that was quietly getting neither.

## Verification

`Bug_5192_event_projection_with_injected_dependencies` covers both shapes plus a store-level assertion that the discovered types reach `AllPublishedTypes()`.

The primary-constructor half is enforced by compilation itself — pinned back to the older generator, the test file does not build, with exactly the error the issue reported:

```
Bug_5192_..._PrimaryConstructorProjection.TypeRegistration.g.cs(12,12):
error CS8862: A constructor declared in a type with parameter list must have 'this' constructor initializer.
```

Locally against the published 2.42.1: the three new tests pass, full `Marten.slnx` builds, and `EventSourcingTests` (net9.0) runs 1627 passed / 0 failed / 7 skipped.

(One incidental note: the test class is `partial` because the generator wraps a nested projection's emitted members in their containing types. Pre-existing generator behavior, not introduced here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde
