### PR TITLE
feat(#5195): stop EventProjectionScenario sleeping through its own runs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -214,15 +214,15 @@
          warning. It used to announce itself as lock contention; one-row-per-transaction writes made
          it harmless to correctness and therefore silent, while still meaning two daemons are
          started for one database. Reported, never refused: the duplicate is the symptom. -->
-    <PackageVersion Include="JasperFx" Version="2.41.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.41.0" />
+    <PackageVersion Include="JasperFx" Version="2.42.2" />
+    <PackageVersion Include="JasperFx.Events" Version="2.42.2" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.41.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.42.2" />
     <!--
       Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
       the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
@@ -240,11 +240,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.42.1">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.42.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.41.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.42.2" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/Marten.Testing/Harness/MartenComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenComplianceFixture.cs
@@ -209,6 +209,15 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
         public void LiveAggregation<TDoc>() where TDoc : notnull
             => _options.Projections.LiveStreamAggregation<TDoc>();
 
+        /// <summary>
+        ///     Marten needs a strong-typed identifier registered before it can use it in LINQ and identity
+        ///     mapping, so this maps straight onto StoreOptions.RegisterValueType. Polecat implements the same
+        ///     seam as a no-op because it derives the same information from ValueTypeInfo when it builds the
+        ///     document mapping — the asymmetry the seam exists to absorb.
+        /// </summary>
+        public void RegisterValueType<TValue>() where TValue : notnull
+            => _options.RegisterValueType<TValue>();
+
         public void AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle)
             => _options.Projections.Add((IProjectionSource<IDocumentOperations, IQuerySession>)projection, lifecycle);
     }

--- a/src/Marten/Events/TestSupport/ProjectionScenario.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenario.cs
@@ -46,6 +46,15 @@ public class ProjectionScenario: JasperFx.Events.TestSupport.ProjectionScenario<
 
     protected override bool HasAnyAsyncProjections => _store.Options.Projections.HasAnyAsyncProjections();
 
+    /// <summary>
+    ///     #5195: opt into the scenario's in-process daemon wakeup. Marten's ProjectionGraph IS the
+    ///     DaemonSettings the daemon reads, so handing it over lets the harness signal the high-water agent
+    ///     the instant it commits instead of leaving each append to race a 1 second SlowPollingTime back-off.
+    ///     The base class restores whatever was there when the run finishes, and never displaces a wakeup the
+    ///     store already configured (e.g. UseListenNotifyForEventAppends).
+    /// </summary>
+    protected override DaemonSettings DaemonSettings => _store.Options.Projections;
+
     protected override async ValueTask<IProjectionDaemon> BuildDaemonAsync(string? tenantId)
     {
         return await _store.BuildProjectionDaemonAsync(tenantId).ConfigureAwait(false);


### PR DESCRIPTION
Addresses the larger half of #5195, by adopting [jasperfx#638](https://github.com/JasperFx/jasperfx/pull/638) (JasperFx 2.42.2).

## The problem

Almost none of an `EventProjectionScenario`'s wall clock was work. A scenario with one batch boundary took ~1.3s against a local Postgres, of which under 200ms was building the daemon, the wipe, and the projection actually catching up.

`ExecuteAsync` wipes the event store and *then* starts the daemon, so the high-water agent's first `Detect()` lands on `HighWaterStatistics.InterpretStatus`'s `HighestSequence == 1 && CurrentMark == 0` branch, reads `CaughtUp`, and settles into `SlowPollingTime` — one second by default. Every append then races a sleeping agent.

**It is not a one-time startup cost.** After each batch drains, `CurrentMark == HighestSequence` puts the agent straight back into the slow interval, so the penalty recurs at *every* boundary. That also rules out the "start the daemon before the wipe" fix the issue proposed — it would only help the first append. And a boundary is the harness's main expressive feature, the way a scenario says "these appends must land in different daemon batches", so today the more precisely a test describes its batching, the slower it gets.

## The fix

A scenario owns both ends of this — it appends the events *and* runs the daemon that has to notice them — so it now signals directly, through an in-process `IDaemonWakeup`: a semaphore release, no database round trip and no LISTEN/NOTIFY.

Marten opts in by handing over its `ProjectionGraph`, which *is* the `DaemonSettings` the daemon reads. The harness restores whatever was there when the run finishes, and never displaces a wakeup the store already configured — so `UseListenNotifyForEventAppends` is unaffected, since that wakeup already does this job.

| batch boundaries | before | after |
|---|---|---|
| 1 | 1290ms | 300ms |
| 3 | 3357ms | 815ms |
| 5 | — | 1320ms |

## What this deliberately does not fix

A flat ~250ms per boundary remains, from the hard-coded `Task.Delay(250ms)` in `WaitForNonStaleDataAsync`. I built that half and backed it out: replacing the flat delays with 5ms-doubling backoff destabilizes `DaemonTests.EventProjections.event_projections_end_to_end_ihost.run_simultaneously`. Isolated carefully, because the first comparison was confounded by the local pack also moving JasperFx 2.41.0 → 2.42.x:

| configuration | failures |
|---|---|
| master baseline | 0/18 |
| master + JasperFx 2.42.x (version delta alone) | 0/18 |
| this wakeup only | 0/12 |
| wakeup + poll backoff | **2/21** |

`isCaughtUp` is monotone — progression rows only advance — so polling faster cannot observe a state a slower poll would have missed; it can only return sooner. So the 250ms was papering over a latent race in that test (it starts two daemons and asserts `distances.Count == travels.Count` immediately after the wait) rather than holding the wait up. That deserves its own investigation, not a tuned constant, so it stays on #5195.

## Also in this PR

Adopting JasperFx 2.42.2 brings the strong-typed identity compliance suite from 2.42.0, which adds `IComplianceStoreRegistrar.RegisterValueType<T>()`. Marten does not compile without implementing it, so `MartenComplianceRegistrar` now maps it onto `StoreOptions.RegisterValueType<T>()` — Marten needs a value type registered before it can use it in LINQ and identity mapping, where Polecat derives the same information from `ValueTypeInfo` and implements the seam as a no-op. That is the asymmetry the seam exists to absorb.

The family moves 2.41.0 → 2.42.2 together (the source generator from 2.42.1, merged in #5196).

## Verification

Against the published 2.42.2 packages: full `Marten.slnx` builds, scenario suite 27/27, compliance suites **170/170** (up from 124 before the wave-5 adoptions), and full `EventSourcingTests` 1731 passed / 0 failed / 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde
