### PR TITLE
Enrol StrongTypedIdentityCompliance (#5144)

### DIFF
--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave6.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave6.cs
@@ -1,0 +1,18 @@
+using JasperFx.Events.ComplianceTests;
+using Marten;
+using Marten.Testing.Harness;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * Wave 6 enrollments. Same shape as the earlier enrollment files -- empty subclasses closing the
+ * shared suites over Marten's session pair.
+ *
+ * StrongTypedIdentityCompliance shipped in JasperFx 2.42.0 (jasperfx#636) alongside the
+ * ComplianceStoreConfig.RegisterValueType<T>() seam member that MartenComplianceFixture already
+ * implements. It arrived in the package with the 2.42.2 bump but was never enrolled, so these tests
+ * were shipping unrun on this store.
+ */
+
+public class strong_typed_identity_compliance
+    : StrongTypedIdentityCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;


### PR DESCRIPTION
The `StrongTypedIdentityCompliance` suite shipped in **JasperFx 2.42.0** (jasperfx#636). It arrived in this repo with the 2.42.2 bump in #5197 — which also added the `RegisterValueType<T>()` registrar member the suite needs, because that member sits on `IComplianceStoreRegistrar` and `MartenComplianceFixture` had to implement it to compile at all.

The subclass closing the suite over Marten's session pair was never added, so **these 11 tests have been shipping unrun on this store.** This PR is the missing three lines.

## What it covers

11 tests across {Guid-backed, string-backed} × {live, inline, async} × {`AggregateStream`, `FetchForWriting`, `FetchForExclusiveWriting`, `FetchLatest`} — deliberately broad, because strong-typed id failures cluster at the edges and a suite proving one path proves very little. That breadth is exactly what found the bug fixed in #5193: `determineFetchPlan` sent any non-`Guid`/`string` `TId` down the natural-key branch and stored a `null` identity strategy.

## Cost

**Nothing.** No package bump (already on 2.42.2), no seam change, no alias, no fixture member. Additive file only, in its own schema (`compliance_strong_typed` / `compliance_strong_typed_string`).

## Verification

`strong_typed_identity_compliance` **11 passed / 0 failed** on net9.0. Full `EventSourcingTests` run attached below once complete.

Marten now runs **178 shared compliance tests across 22 suites**, no capability gates.

Polecat's enrolment follows in its 2.42.2 catch-up — it is currently on 2.39.4 and a full wave behind.

Closes #5144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde