### PR TITLE
Every matching masking rule runs, not just the first (#5199)

### DIFF
--- a/src/EventSourcingTests/removing_protected_information.cs
+++ b/src/EventSourcingTests/removing_protected_information.cs
@@ -456,6 +456,45 @@ public class removing_protected_information : OneOffConfigurationsContext
         brandybuck.Headers["color"].ShouldBe("blue");
         brandybuck.Data.Members.All(x => x != "*****").ShouldBeTrue();
     }
+
+    /// <summary>
+    ///     Regression for #5199. Every masking test above registers rules over *disjoint* event
+    ///     types, so no event ever matched more than one rule and the short-circuiting
+    ///     `matched || masker.TryMask(e)` in TryMask was unobservable: the first rule to match an
+    ///     event stopped every later rule from being invoked at all, and the operation still
+    ///     reported success. On a right-to-erasure path that leaves protected information in place.
+    /// </summary>
+    [Fact]
+    public void every_matching_rule_runs_not_just_the_first()
+    {
+        theEvents.AddMaskingRuleForProtectedInformation<IAccountEvent>(x => x.Name = "****");
+        theEvents.AddMaskingRuleForProtectedInformation<AccountChanged>(x => x.Email = "****");
+
+        var changed = new AccountChanged { Name = "Harry", Email = "harry@example.com" };
+
+        theEvents.TryMask(new Event<AccountChanged>(changed)).ShouldBeTrue();
+
+        changed.Name.ShouldBe("****");
+        changed.Email.ShouldBe("****");
+    }
+
+    /// <summary>
+    ///     ... and the same in the other registration order, so the test cannot pass by accident of
+    ///     whichever rule happens to be registered first.
+    /// </summary>
+    [Fact]
+    public void every_matching_rule_runs_regardless_of_registration_order()
+    {
+        theEvents.AddMaskingRuleForProtectedInformation<AccountChanged>(x => x.Email = "****");
+        theEvents.AddMaskingRuleForProtectedInformation<IAccountEvent>(x => x.Name = "****");
+
+        var changed = new AccountChanged { Name = "Harry", Email = "harry@example.com" };
+
+        theEvents.TryMask(new Event<AccountChanged>(changed)).ShouldBeTrue();
+
+        changed.Name.ShouldBe("****");
+        changed.Email.ShouldBe("****");
+    }
 }
 
 public interface IAccountEvent
@@ -466,6 +505,10 @@ public interface IAccountEvent
 public class AccountChanged: IAccountEvent
 {
     public string Name { get; set; }
+
+    // A second protected member, so a concrete-type rule has something to mask that the
+    // interface rule above does not reach. See #5199.
+    public string Email { get; set; }
 }
 
 public static class DocumentationSamples

--- a/src/Marten/Events/EventGraph.Masking.cs
+++ b/src/Marten/Events/EventGraph.Masking.cs
@@ -39,7 +39,11 @@ public partial class EventGraph
         var matched = false;
         foreach (var masker in _maskers)
         {
-            matched = matched || masker.TryMask(e);
+            // |= and NOT ||=. With the short-circuiting form, the first rule to match an event
+            // stopped every later rule from even being invoked, so only one of several applicable
+            // rules ever ran -- and the operation still reported success. For a right-to-erasure
+            // feature that means protected information silently survives a masking pass.
+            matched |= masker.TryMask(e);
         }
 
         return matched;


### PR DESCRIPTION
`EventGraph.TryMask` applied its maskers with a short-circuiting `||`:

```csharp
matched = matched || masker.TryMask(e);
```

Once `matched` went `true`, `masker.TryMask(e)` was **never invoked again**. The first rule to match an event silently stopped every later rule from running against it — and `ApplyEventDataMasking` still reported success.

## Why this matters

This is the right-to-erasure path. The failure mode is that protected information stays in the database after a masking pass that looked like it worked:

```csharp
opts.Events.AddMaskingRuleForProtectedInformation<IAccountEvent>(x => x.Name = "****");
opts.Events.AddMaskingRuleForProtectedInformation<AccountChanged>(x => x.Email = "****");
```

`AccountChanged` matches both. Only the first-registered rule runs, so `Name` is masked and **`Email` is not**. Rules matching contravariantly is a supported, documented property of the feature — `apply_with_contra_variance` tests it directly — so an interface rule alongside a concrete-type rule is an ordinary thing to write, not an exotic one. Registration order deciding which of your rules is honoured is not a property anyone would design around.

The fix is `|=`: run every masker, accumulate whether any matched.

## Why nothing caught it

Every existing test in `removing_protected_information.cs` registers rules over **disjoint** event types, so no event ever matched more than one rule and the short-circuit was unobservable. `end_to_end_for_Guid_identified_stream_multiple_rules_and_single_stream` has "multiple rules" in its name, but they do not overlap on a single event.

## Tests

Two regression tests, in **both registration orders**, so neither can pass by accident of which rule happens to be registered first. `AccountChanged` gains an `Email` property so the concrete-type rule has something to mask that the interface rule does not reach.

Both verified to fail on master first — along with the compliance suite's `rules_compose_rather_than_replace_one_another`, which is what surfaced this:

```
removing_protected_information.every_matching_rule_runs_not_just_the_first [FAIL]
event_data_masking_compliance.rules_compose_rather_than_replace_one_another [FAIL]
removing_protected_information.every_matching_rule_runs_regardless_of_registration_order [FAIL]
```

With the fix: `removing_protected_information` **13/13** on net9.0.

## Cross-store

Found by the new `EventDataMaskingCompliance` suite (jasperfx#639, compliance wave 6). **Polecat has the identical defect, byte-for-byte** — the two implementations were duplicated rather than shared — filed as polecat#422 and fixed in its wave 6 adoption.

This PR is deliberately standalone rather than folded into the wave 6 adoption, so a data-protection fix does not wait on a package publish.

Closes #5199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde