### PR TITLE
Compliance wave 6: enroll stream compacting and event data masking

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -213,16 +213,23 @@
          jasperfx#630 follow-up — a duplicate ExtendedProgressionWriter on one database now logs a
          warning. It used to announce itself as lock contention; one-row-per-transaction writes made
          it harmless to correctness and therefore silent, while still meaning two daemons are
-         started for one database. Reported, never refused: the duplicate is the symptom. -->
-    <PackageVersion Include="JasperFx" Version="2.42.2" />
-    <PackageVersion Include="JasperFx.Events" Version="2.42.2" />
+         started for one database. Reported, never refused: the duplicate is the symptom.
+         JasperFx 2.43.0: jasperfx#639 — compliance wave 6 (#5153, #5154). The library gains
+         StreamCompactingCompliance and EventDataMaskingCompliance, taking it to 24 suites / 199
+         tests, plus the seam those needed (EventStoreComplianceFixture.ApplyEventDataMaskingAsync
+         and the two ComplianceStoreConfig.AddMaskingRule overloads). Compliance sources only —
+         nothing outside JasperFx.Events.ComplianceTests changed, so this bump is behaviourally
+         inert for the shipping libraries and only affects the test projects that enrol the
+         suites. -->
+    <PackageVersion Include="JasperFx" Version="2.43.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.43.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.42.2" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.43.0" />
     <!--
       Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
       the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
@@ -240,11 +247,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.42.2">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.43.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.42.2" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.43.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave6.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave6.cs
@@ -16,3 +16,9 @@ namespace EventSourcingTests.Compliance;
 
 public class strong_typed_identity_compliance
     : StrongTypedIdentityCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+public class stream_compacting_compliance
+    : StreamCompactingCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+public class event_data_masking_compliance
+    : EventDataMaskingCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;

--- a/src/Marten.Testing/Harness/MartenComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenComplianceFixture.cs
@@ -171,6 +171,13 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
         return rows;
     }
 
+    // IEventDataMasking is shared (lifted in jasperfx#635), but the entry point that hands one out
+    // is not: Marten spells it on IDocumentStore.Advanced, Polecat on its own, and the two share no
+    // interface. This member is the whole of that gap.
+    public override Task ApplyEventDataMaskingAsync(
+        Action<JasperFx.Events.Protected.IEventDataMasking> configure, CancellationToken token)
+        => _store.Advanced.ApplyEventDataMasking(configure, token);
+
     public override async ValueTask DisposeAsync()
     {
         foreach (var disposable in _disposables)
@@ -217,6 +224,12 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
         /// </summary>
         public void RegisterValueType<TValue>() where TValue : notnull
             => _options.RegisterValueType<TValue>();
+
+        public void AddMaskingRule<TEvent>(Action<TEvent> rule) where TEvent : notnull
+            => _options.Events.AddMaskingRuleForProtectedInformation(rule);
+
+        public void AddMaskingRule<TEvent>(Func<TEvent, TEvent> rule) where TEvent : notnull
+            => _options.Events.AddMaskingRuleForProtectedInformation(rule);
 
         public void AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle)
             => _options.Projections.Add((IProjectionSource<IDocumentOperations, IQuerySession>)projection, lifecycle);


### PR DESCRIPTION
**Draft — blocked on the JasperFx 2.43.0 publish (jasperfx#639).** Ready to go the moment the package is up; the only remaining change is the version pin.

Enrolls the two suites the 2.41.0 lifts existed to enable. **22 → 24 suites, 178 → 199 shared compliance tests**, still no capability gates. Polecat enrolls the same two in polecat#426.

| Suite | Tests | Seam cost |
|---|---|---|
| `StreamCompactingCompliance` | 11 | **none** |
| `EventDataMaskingCompliance` | 10 | 3 members |

## `StreamCompactingCompliance` — zero seam

`CompactStreamAsync<T>` comes through the shared `IEventStoreOperations`, so this costs nothing but the enrolment line. That is exactly what #5153's lift was for.

## `EventDataMaskingCompliance` — and #5154's framing corrected

Lifting `IEventDataMasking` made the **vocabulary** shared, not the **reach**. Both products hand one out through `Advanced.ApplyEventDataMasking(...)` on advanced-operations types that share no interface, and register rules through their own event options. Marten's half of the seam is `ApplyEventDataMaskingAsync` on the fixture plus the two `AddMaskingRule` overloads on the registrar. Corrected on #5154 itself.

## Not yet bumped

`Directory.Packages.props` still pins 2.42.2. Verified against the jasperfx working copy via `-p:ComplianceSourceDir=`.

## The bug this found

Already fixed on master in #5200 (#5199): `EventGraph.TryMask` short-circuited with `||`, so only the first matching masking rule ever ran while the operation reported success — protected data surviving a right-to-erasure pass. Polecat had it identically (polecat#422); the implementations were duplicated, not shared.

## Verification

Suites **21/21**; full `EventSourcingTests` **1765 / 0 / 7** on net9.0.

Closes #5153
Closes #5154

*(Separate `Closes` lines on purpose — GitHub only parses the first issue in a comma-separated clause.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde