### PR TITLE
Compliance wave 7: enroll projection rebuild/catch-up and dead letters

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -220,16 +220,23 @@
          and the two ComplianceStoreConfig.AddMaskingRule overloads). Compliance sources only —
          nothing outside JasperFx.Events.ComplianceTests changed, so this bump is behaviourally
          inert for the shipping libraries and only affects the test projects that enrol the
-         suites. -->
-    <PackageVersion Include="JasperFx" Version="2.43.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.43.0" />
+         suites.
+         JasperFx 2.44.0: jasperfx#641 — compliance wave 7 (#5149, #5150), the last two event
+         sourcing suites in the backlog. RebuildAndCatchUpCompliance and DeadLetterCompliance take
+         the library to 26 suites / 216 tests. Neither needed a seam addition: IProjectionDaemon
+         already declared the whole rebuild surface, and the error policy
+         (IEventStore<,>.ContinuousErrors) plus dead-letter reads (IEventStore.AllDatabases() ->
+         IEventDatabase.QueryDeadLetterEventsAsync) were already shared and already overridden here.
+         Compliance sources only, so again behaviourally inert for the shipping libraries. -->
+    <PackageVersion Include="JasperFx" Version="2.44.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.44.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.43.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.44.0" />
     <!--
       Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
       the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
@@ -247,11 +254,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.43.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.44.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.43.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.44.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave7.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave7.cs
@@ -1,0 +1,16 @@
+using JasperFx.Events.ComplianceTests;
+using Marten;
+using Marten.Testing.Harness;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * Wave 7 enrollments. Separate file only while the suites are in flight upstream; fold into the
+ * main enrollment file once the JasperFx package ships them.
+ */
+
+public class rebuild_and_catch_up_compliance
+    : RebuildAndCatchUpCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+public class dead_letter_compliance
+    : DeadLetterCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;


### PR DESCRIPTION
**Draft — blocked on the JasperFx 2.44.0 publish (jasperfx#641).** Ready otherwise; the only remaining change is the version pin.

Enrolls the last two event-sourcing suites in the backlog. **24 → 26 suites, 199 → 216 shared compliance tests**, still no capability gates. Polecat enrolls the same two in its wave 7 branch.

| Suite | Tests | Seam cost |
|---|---|---|
| `RebuildAndCatchUpCompliance` | 11 | **none** |
| `DeadLetterCompliance` | 6 | **none** |

## Both were misfiled as needing a seam

#5150 and #5149 sat in the "needs a seam addition" group. Checking the shared surfaces says otherwise:

- `IProjectionDaemon` already declares the entire rebuild surface — seven `RebuildProjectionAsync` overloads, both `CatchUpAsync` forms, `PrepareForRebuildsAsync` — and the fixture's `StartDaemonAsync()` already returns one.
- The error policy is `IEventStore<TOperations, TQuerySession>.ContinuousErrors`; dead letters come through `IEventStore.AllDatabases()` → `IEventDatabase.QueryDeadLetterEventsAsync`. Marten overrides both rather than inheriting the empty-array DIMs (`MartenDatabase.EventStorage.cs`, `DocumentStore.EventStore.cs:118`).

## What the rebuild suite actually pins

The valuable one is **teardown-before-replay**. A rebuild that replays onto surviving rows looks correct for every stream whose events still exist, and is wrong only for rows the replay can no longer produce — so it passes any ordinary state assertion. That divergence was a real product gap on the other store (polecat#415). The test plants a document the replay cannot possibly produce and requires the rebuild to remove it, and the by-name test plants it too so a named rebuild matching *no* projection fails instead of passing vacuously.

## Not yet bumped

`Directory.Packages.props` still pins 2.43.0; verified against the jasperfx working copy via `-p:ComplianceSourceDir=`.

## Verification

Suites **17/17**; full `EventSourcingTests` **1782 / 0 / 7** on net9.0.

Closes #5149
Closes #5150

*(Separate `Closes` lines on purpose — GitHub only parses the first issue in a comma-separated clause.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde