### PR TITLE
Compliance wave 8: enroll conjoined event tenancy and subscriptions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -227,16 +227,27 @@
          already declared the whole rebuild surface, and the error policy
          (IEventStore<,>.ContinuousErrors) plus dead-letter reads (IEventStore.AllDatabases() ->
          IEventDatabase.QueryDeadLetterEventsAsync) were already shared and already overridden here.
-         Compliance sources only, so again behaviourally inert for the shipping libraries. -->
-    <PackageVersion Include="JasperFx" Version="2.44.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.44.0" />
+         Compliance sources only, so again behaviourally inert for the shipping libraries.
+         JasperFx 2.45.0: jasperfx#642 — compliance wave 8 (#5148, #5151), the last two suites in
+         the event sourcing backlog. ConjoinedEventTenancyCompliance and SubscriptionCompliance take
+         the library to 28 suites / 230 tests, and with them the ES compliance backlog is empty.
+         Two additive seam members: ComplianceStoreConfig.ConjoinedEventTenancy and
+         IComplianceStoreRegistrar.Subscribe(ComplianceSubscription), the latter paired with a
+         per-consumer partial completing ComplianceSubscription against Marten's own ISubscription
+         (IChangeListener is per-product, so that signature cannot be written once upstream).
+         #5148 needed no tenant-scoped session seam after all — OpenSession(IEventDatabase,
+         tenantId) was already on the shared generic IEventStore<,> and TenancyStyle was already a
+         shared JasperFx.MultiTenancy enum. Compliance sources only; behaviourally inert for the
+         shipping libraries. -->
+    <PackageVersion Include="JasperFx" Version="2.45.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.45.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.44.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.45.0" />
     <!--
       Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
       the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
@@ -254,11 +265,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.44.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.45.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.44.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.45.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave8.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave8.cs
@@ -1,0 +1,27 @@
+using JasperFx.Events.ComplianceTests;
+using Marten;
+using Marten.Testing.Harness;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * Wave 8 enrollments -- the last two suites in the event sourcing compliance backlog, shipped in
+ * JasperFx 2.45.0 (jasperfx#642). Same shape as the earlier enrollment files: empty subclasses
+ * closing the shared suites over Marten's session pair.
+ *
+ * ConjoinedEventTenancyCompliance (#5148) needed no tenant-scoped session seam in the end --
+ * OpenSession(IEventDatabase, tenantId) is already on the shared generic IEventStore<,> and
+ * TenancyStyle is already a shared JasperFx.MultiTenancy enum, so the only seam addition was the
+ * ComplianceStoreConfig.ConjoinedEventTenancy switch MartenComplianceFixture reads.
+ *
+ * SubscriptionCompliance (#5151) is the one suite that cannot be closed by an empty subclass alone:
+ * ISubscription's ProcessEventsAsync returns a per-product IChangeListener, so the shared
+ * ComplianceSubscription is a partial class completed by ComplianceSubscription.Marten.cs beside
+ * MartenComplianceFixture.
+ */
+
+public class conjoined_event_tenancy_compliance
+    : ConjoinedEventTenancyCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+public class subscription_compliance
+    : SubscriptionCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;

--- a/src/EventSourcingTests/EventSourcingTests.csproj
+++ b/src/EventSourcingTests/EventSourcingTests.csproj
@@ -82,6 +82,9 @@
         <Compile Include="..\Marten.Testing\Harness\ComplianceFlatTableProjection.Marten.cs">
             <Link>Harness\ComplianceFlatTableProjection.Marten.cs</Link>
         </Compile>
+        <Compile Include="..\Marten.Testing\Harness\ComplianceSubscription.Marten.cs">
+            <Link>Harness\ComplianceSubscription.Marten.cs</Link>
+        </Compile>
         <Compile Include="..\Marten.Testing\Harness\MartenComplianceFixture.cs">
             <Link>Harness\MartenComplianceFixture.cs</Link>
         </Compile>

--- a/src/Marten.Testing/Harness/ComplianceSubscription.Marten.cs
+++ b/src/Marten.Testing/Harness/ComplianceSubscription.Marten.cs
@@ -1,0 +1,37 @@
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Subscriptions;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/*
+ * Marten's half of the shared compliance subscription.
+ *
+ * The compliance library owns the recording, the waiting and the subscription name; this partial
+ * supplies the one thing that cannot be portable. Both products declare ISubscription with an
+ * identical member -- Task<IChangeListener> ProcessEventsAsync(EventRange, ISubscriptionController,
+ * IDocumentOperations, CancellationToken) -- but IChangeListener is a per-product type, so the
+ * signature cannot be written once in the shared source.
+ *
+ * NullChangeListener.Instance is the documented "I do not need to be signalled" return on both
+ * products; it is spelled the same in each, but on each product's own type.
+ *
+ * Lives beside MartenComplianceFixture rather than in EventSourcingTests because both assemblies
+ * reference the source-only compliance package and therefore both compile the library's half of
+ * this partial, so both need this half to satisfy it.
+ */
+public partial class ComplianceSubscription: ISubscription
+{
+    public Task<IChangeListener> ProcessEventsAsync(EventRange page, ISubscriptionController controller,
+        IDocumentOperations operations, CancellationToken cancellationToken)
+    {
+        Record(page.Events);
+
+        return Task.FromResult(NullChangeListener.Instance);
+    }
+
+    public ValueTask DisposeAsync() => default;
+}

--- a/src/Marten.Testing/Harness/MartenComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenComplianceFixture.cs
@@ -55,6 +55,11 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
             options.Events.MetadataConfig.HeadersEnabled = true;
         }
 
+        if (config.ConjoinedEventTenancy)
+        {
+            options.Events.TenancyStyle = JasperFx.MultiTenancy.TenancyStyle.Conjoined;
+        }
+
         config.ApplyTo(new MartenComplianceRegistrar(options));
 
         _store = new DocumentStore(options);
@@ -230,6 +235,10 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
 
         public void AddMaskingRule<TEvent>(Func<TEvent, TEvent> rule) where TEvent : notnull
             => _options.Events.AddMaskingRuleForProtectedInformation(rule);
+
+        public void Subscribe(ComplianceSubscription subscription)
+            => _options.Projections.Subscribe(subscription,
+                x => x.Name = ComplianceSubscription.SubscriptionName);
 
         public void AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle)
             => _options.Projections.Add((IProjectionSource<IDocumentOperations, IQuerySession>)projection, lifecycle);


### PR DESCRIPTION
Adopts **JasperFx 2.45.0** ([jasperfx#642](https://github.com/jasperfx/jasperfx/pull/642)) and enrolls the last two suites in the event sourcing compliance backlog. The shared library goes to **28 suites / 230 tests**, both stores, still **zero capability gates** — and with these two, the ES backlog filed under #5118 is empty.

## The two suites

**`ConjoinedEventTenancyCompliance` (#5148)** — the issue priced this as needing a tenant-scoped session seam. It didn't. `OpenSession(IEventDatabase, tenantId)` is already on the shared generic `IEventStore<,>`, and `TenancyStyle` is already a shared `JasperFx.MultiTenancy` enum. The only seam addition is the `ComplianceStoreConfig.ConjoinedEventTenancy` switch, which `MartenComplianceFixture` maps onto `Events.TenancyStyle`.

**`SubscriptionCompliance` (#5151)** — the one suite an empty subclass cannot close by itself. Both products declare `ISubscription` with an identical member, but `ProcessEventsAsync` returns a **per-product `IChangeListener`**, so that signature cannot be written once upstream. The shared `ComplianceSubscription` is therefore a `partial class` that each consumer completes; Marten's half is `ComplianceSubscription.Marten.cs`.

That file lives in `Marten.Testing` beside `MartenComplianceFixture` rather than in `EventSourcingTests` on purpose: both assemblies reference the source-only compliance package, so both compile the library's half of the partial, and both need the completing half to satisfy it.

## Verification

Run against the **published 2.45.0 package**, not the `-p:ComplianceSourceDir=` dev loop.

- **230/230 compliance tests, zero skips** (was 216 at wave 7)
- **All 28 library suites confirmed enrolled** — diffed the package's suite files against the subclass declarations rather than trusting the test count. A bump that satisfies a new registrar member is *not* evidence the suite runs: that is exactly how `StrongTypedIdentityCompliance` shipped 11 tests unrun in wave 6 (#5198).
- **Full `EventSourcingTests`: 1796 passed / 0 failed / 7 skipped** on net9.0 — the 7 skips are the pre-existing baseline, unchanged.

## Notes for the reviewer

- The library changes in 2.45.0 are compliance sources only, so the bump is behaviourally inert for the shipping Marten libraries. The full ES run above is the regression check on that claim.
- Polecat is a wave behind again ([polecat#427](https://github.com/jasperfx/polecat/pull/427) merged wave 7 earlier today, leaving it at 216/26). Its wave-8 catch-up is separate work in that repo.

Closes #5148
Closes #5151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrQZYcL13PEek7FErj9PGx