### PR TITLE
Strip test ITestOutputHelper output and debug TestOutputMartenLogger injections

### DIFF
--- a/docs/schema/cleaning.md
+++ b/docs/schema/cleaning.md
@@ -94,7 +94,6 @@ using var host = await Host.CreateDefaultBuilder()
                     opts =>
                     {
                         opts.Connection(ConnectionSource.ConnectionString);
-                        opts.Logger(new TestOutputMartenLogger(_output));
                     }
                 )
                 .InitializeWith(new Users());
@@ -120,7 +119,6 @@ using var host = await Host.CreateDefaultBuilder()
                     opts =>
                     {
                         opts.Connection(ConnectionSource.ConnectionString);
-                        opts.Logger(new TestOutputMartenLogger(_output));
                     }
                 )
                 .InitializeWith(new Users());

--- a/src/CompiledQueryTests/PerfGate.cs
+++ b/src/CompiledQueryTests/PerfGate.cs
@@ -97,8 +97,6 @@ public class PerfGate: OneOffConfigurationsContext
             result!.UserName.ShouldBe("cold_b");
         }
 
-        _output.WriteLine($"Cold call — codegen: {codegenColdMs}ms; source-gen: {sourceGenColdMs}ms");
-
         // Source-gen should be at minimum no slower than codegen on cold call.
         // In practice it's expected to be dramatically faster because it skips
         // CompiledQuerySourceBuilder.AssembleTypes (Roslyn emit + Activator.CreateInstance).
@@ -163,10 +161,6 @@ public class PerfGate: OneOffConfigurationsContext
             sw.Stop();
             sourceGenSteadyMs = sw.ElapsedMilliseconds;
         }
-
-        var codegenPerCallUs = codegenSteadyMs * 1000.0 / InvocationCount;
-        var sourceGenPerCallUs = sourceGenSteadyMs * 1000.0 / InvocationCount;
-        _output.WriteLine($"Steady state — codegen: {codegenSteadyMs}ms over {InvocationCount} calls ({codegenPerCallUs:F1}us/call); source-gen: {sourceGenSteadyMs}ms ({sourceGenPerCallUs:F1}us/call)");
 
         // Steady-state is dominated by Postgres round-trip; CPU-side dispatch
         // differences are usually <1% of total. The observed signal across

--- a/src/ContainerScopedProjectionTests/projections_with_IoC_services.cs
+++ b/src/ContainerScopedProjectionTests/projections_with_IoC_services.cs
@@ -400,7 +400,7 @@ public class projections_with_IoC_services
         product.Name.ShouldBe("Ankle Socks");
 
         // Now rebuild
-        var daemon = await store.BuildProjectionDaemonAsync(logger:new TestOutputMartenLogger(_output));
+        var daemon = await store.BuildProjectionDaemonAsync();
         await daemon.RebuildProjectionAsync<Product>(CancellationToken.None);
 
         // Test again
@@ -471,7 +471,7 @@ public class projections_with_IoC_services
         product.Name.ShouldBe("Ankle Socks");
 
         // Now rebuild
-        var daemon = await store.BuildProjectionDaemonAsync(logger:new TestOutputMartenLogger(_output));
+        var daemon = await store.BuildProjectionDaemonAsync();
         await daemon.RebuildProjectionAsync<Product>(CancellationToken.None);
 
         // Test again

--- a/src/CoreTests/Bug_4874_coordinator_drain_ordering.cs
+++ b/src/CoreTests/Bug_4874_coordinator_drain_ordering.cs
@@ -118,11 +118,6 @@ public class Bug_4874_coordinator_drain_ordering
             AppDomain.CurrentDomain.FirstChanceException -= handler;
         }
 
-        foreach (var abort in aborts)
-        {
-            _output.WriteLine(abort);
-        }
-
         aborts.Count.ShouldBe(0,
             $"Expected no disposed-pool aborts on the leadership poll path, but saw {aborts.Count}. " +
             "The cold-node leadership poll opened a connection against an already-disposed data source " +

--- a/src/CoreTests/Bug_4915_coordinator_disposal_drain.cs
+++ b/src/CoreTests/Bug_4915_coordinator_disposal_drain.cs
@@ -99,11 +99,6 @@ public class Bug_4915_coordinator_disposal_drain
             AppDomain.CurrentDomain.FirstChanceException -= handler;
         }
 
-        foreach (var abort in aborts)
-        {
-            _output.WriteLine(abort);
-        }
-
         aborts.Count.ShouldBe(0,
             $"Expected no disposed-pool aborts on the AdvisoryLock poll path after disposing the cold node, but saw " +
             $"{aborts.Count}. The projection coordinator's leadership loop outlived the data source the " +
@@ -158,11 +153,6 @@ public class Bug_4915_coordinator_disposal_drain
         finally
         {
             AppDomain.CurrentDomain.FirstChanceException -= handler;
-        }
-
-        foreach (var abort in aborts)
-        {
-            _output.WriteLine(abort);
         }
 
         aborts.Count.ShouldBe(0,

--- a/src/CoreTests/Partitioning/Bug_4706_partitioned_table_idempotent_migration.cs
+++ b/src/CoreTests/Partitioning/Bug_4706_partitioned_table_idempotent_migration.cs
@@ -84,7 +84,6 @@ public class Bug_4706_partitioned_table_idempotent_migration: IAsyncLifetime
         await using (var store = BuildStore())
         {
             var migration = await store.Storage.CreateMigrationAsync();
-            _output.WriteLine($"Difference = {migration.Difference}");
 
             migration.Difference.ShouldBe(SchemaPatchDifference.None,
                 "Re-applying an unchanged ByList tenant-partitioned doc table must not diff as a change");

--- a/src/CoreTests/Partitioning/Bug_4924_hyphenated_tenant_id_sequence_name.cs
+++ b/src/CoreTests/Partitioning/Bug_4924_hyphenated_tenant_id_sequence_name.cs
@@ -113,7 +113,6 @@ public class Bug_4924_hyphenated_tenant_id_sequence_name: IAsyncLifetime
         // Created under the RAW name — anything else and the quick-append function's format('%I') lookup,
         // which reads partition_suffix straight from the tenants table, would miss it.
         (await SequenceCountAsync($"mt_events_sequence_{tenantId}")).ShouldBe(1L);
-        _output.WriteLine($"schema apply created \"{_schema}\".\"mt_events_sequence_{tenantId}\"");
     }
 
     /// <summary>
@@ -141,7 +140,6 @@ public class Bug_4924_hyphenated_tenant_id_sequence_name: IAsyncLifetime
         await reopened.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
         var after = await LastValueAsync(tenantId);
 
-        _output.WriteLine($"sequence last_value before={before} after={after}");
         after.ShouldBe(before, "re-applying schema must not recreate (and reset) a live tenant's sequence");
     }
 

--- a/src/CoreTests/Partitioning/sql_injection_via_tenant_id_partition_suffix.cs
+++ b/src/CoreTests/Partitioning/sql_injection_via_tenant_id_partition_suffix.cs
@@ -152,9 +152,8 @@ public class sql_injection_via_tenant_id_partition_suffix: IAsyncLifetime
         {
             await reopened.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
         }
-        catch (Exception e)
+        catch (Exception)
         {
-            _output.WriteLine($"schema apply threw (acceptable): {e.GetType().Name}: {e.Message}");
         }
 
         (await MarkerExistsAsync()).ShouldBeFalse(

--- a/src/DaemonTests.ManualOnly/Coordination/high_water_advances_past_dead_gaps_with_slow_transactions.cs
+++ b/src/DaemonTests.ManualOnly/Coordination/high_water_advances_past_dead_gaps_with_slow_transactions.cs
@@ -165,7 +165,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync(TestContext.Curr
             // mark — i.e. the only chance to establish the fence.
             var first = await StartDaemonInHotColdMode();
             await first.Daemon().Tracker.WaitForHighWaterMark(published, 30.Seconds());
-            _output.WriteLine($"First daemon generation caught up at {published}");
 
             // The deploy: the process holding that in-memory history goes away
             await first.StopAsync(TestContext.Current.CancellationToken);
@@ -173,11 +172,9 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync(TestContext.Curr
 
             // ...and a dead gap forms while no daemon is running
             var deadSeq = await createDeadGapAsync();
-            _output.WriteLine($"Dead sequence number: {deadSeq}");
 
             await commitEventsDirectlyAsync(3);
             var ceiling = await highestCommittedSequenceAsync();
-            _output.WriteLine($"Highest committed sequence above the gap: {ceiling}");
 
             // The replacement node starts up against a store that was already gapped
             using var second = await StartDaemonInHotColdMode();
@@ -223,7 +220,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync(TestContext.Curr
         NumberOfStreams = 4;
         await PublishSingleThreaded();
         var ceiling = await highestCommittedSequenceAsync();
-        _output.WriteLine($"Highest committed sequence above the poisoned range: {ceiling}");
 
         using var host = await StartDaemonInHotColdMode();
         await host.Daemon().Tracker.WaitForHighWaterMark(ceiling, 60.Seconds());

--- a/src/DaemonTests/Aggregations/build_aggregate_projection.cs
+++ b/src/DaemonTests/Aggregations/build_aggregate_projection.cs
@@ -83,14 +83,11 @@ public class build_aggregate_projection: DaemonContext
         StoreOptions(x =>
         {
             x.Projections.Add(new TripProjectionWithCustomName(), ProjectionLifecycle.Async);
-            x.Logger(new TestOutputMartenLogger(_output));
         });
 
 
 
         await PublishSingleThreaded();
-
-        _output.WriteLine("STARTING DAEMON---------------------------------");
 
         var agent = await StartDaemon();
 
@@ -115,7 +112,6 @@ public class build_aggregate_projection: DaemonContext
         {
             x.Projections.Add(new TripProjectionWithCustomName { Options = { CacheLimitPerTenant = 100 } },
                 ProjectionLifecycle.Async);
-            x.Logger(new TestOutputMartenLogger(_output));
         });
 
         var agent = await StartDaemon();
@@ -406,8 +402,6 @@ public class build_aggregate_projection: DaemonContext
         var shortTrip = new TripStream().TravelIsUnder(200);
         var longTrip = new TripStream().TravelIsOver(2000);
         var initialCount = shortTrip.Events.Count + longTrip.Events.Count;
-
-        _output.WriteLine($"Initially publishing {initialCount} events");
 
         var projection = new TestingSupport.TripProjection();
         projection.Name = "Trip";

--- a/src/DaemonTests/Aggregations/custom_aggregation_in_async_daemon.cs
+++ b/src/DaemonTests/Aggregations/custom_aggregation_in_async_daemon.cs
@@ -31,7 +31,6 @@ public class custom_aggregation_in_async_daemon : OneOffConfigurationsContext
         {
             var myCustomAggregation = new MyCustomProjection();
             opts.Projections.Add(myCustomAggregation, ProjectionLifecycle.Async);
-            opts.Logger(new TestOutputMartenLogger(_output));
         });
 
         await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
@@ -75,7 +74,6 @@ public class custom_aggregation_in_async_daemon : OneOffConfigurationsContext
         {
             var myCustomAggregation = new MyCustomProjection{Options = {CacheLimitPerTenant = 100}};
             opts.Projections.Add(myCustomAggregation, ProjectionLifecycle.Async);
-            opts.Logger(new TestOutputMartenLogger(_output));
         });
 
         await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);

--- a/src/DaemonTests/Aggregations/multi_stream_projections.cs
+++ b/src/DaemonTests/Aggregations/multi_stream_projections.cs
@@ -42,8 +42,6 @@ public partial class multi_stream_projections: DaemonContext
         NumberOfStreams = 10;
         await PublishSingleThreaded();
 
-        _output.WriteLine($"Expecting {NumberOfEvents} events");
-
         await agent.Tracker.WaitForShardState("Day:All", NumberOfEvents, 30.Seconds());
 
         var days = await theSession.Query<Day>().ToListAsync(TestContext.Current.CancellationToken);

--- a/src/DaemonTests/Aggregations/side_effects_in_aggregations.cs
+++ b/src/DaemonTests/Aggregations/side_effects_in_aggregations.cs
@@ -33,7 +33,6 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         StoreOptions(opts =>
         {
             opts.Projections.Add<Projection1>(ProjectionLifecycle.Async);
-            opts.Logger(new TestOutputMartenLogger(_output));
         });
 
         await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
@@ -90,7 +89,6 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         StoreOptions(opts =>
         {
             opts.Projections.Add<Projection1>(ProjectionLifecycle.Async);
-            opts.Logger(new TestOutputMartenLogger(_output));
             opts.Events.MessageOutbox = outbox;
         });
 
@@ -130,7 +128,6 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         StoreOptions(opts =>
         {
             opts.Projections.Add<Projection1>(ProjectionLifecycle.Async);
-            opts.Logger(new TestOutputMartenLogger(_output));
         });
 
         await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
@@ -175,7 +172,6 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         StoreOptions(opts =>
         {
             opts.Projections.Add<Projection2>(ProjectionLifecycle.Async);
-            opts.Logger(new TestOutputMartenLogger(_output));
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -222,7 +218,6 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         {
             opts.Events.StreamIdentity = StreamIdentity.AsString;
             opts.Projections.Add<Projection2>(ProjectionLifecycle.Async);
-            opts.Logger(new TestOutputMartenLogger(_output));
         });
 
         await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
@@ -277,7 +272,6 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         {
             opts.Events.StreamIdentity = StreamIdentity.AsString;
             opts.Projections.Add<Projection2>(ProjectionLifecycle.Async);
-            opts.Logger(new TestOutputMartenLogger(_output));
 
             opts.Events.AppendMode = EventAppendMode.Quick;
         });

--- a/src/DaemonTests/Bug_5024_extended_progression_survives_shutdown.cs
+++ b/src/DaemonTests/Bug_5024_extended_progression_survives_shutdown.cs
@@ -150,13 +150,6 @@ public class Bug_5024_extended_progression_survives_shutdown: DaemonContext
                 {
                     Exceptions.Add(exception);
                 }
-
-                _output.WriteLine($"{logLevel}: {formatter(state, exception)}");
-                _output.WriteLine(exception.ToString());
-            }
-            else
-            {
-                _output.WriteLine($"{logLevel}: {formatter(state, exception)}");
             }
         }
 

--- a/src/DaemonTests/Bug_5055_5056_coordinator_double_stop.cs
+++ b/src/DaemonTests/Bug_5055_5056_coordinator_double_stop.cs
@@ -197,12 +197,6 @@ public class Bug_5055_5056_coordinator_double_stop: DaemonContext
             {
                 Entries.Add((logLevel, message, exception));
             }
-
-            _output.WriteLine($"{logLevel}: {message}");
-            if (exception != null)
-            {
-                _output.WriteLine(exception.ToString());
-            }
         }
 
         private sealed class NullScope: IDisposable

--- a/src/DaemonTests/Bugs/Bug_2245_async_daemon_getting_stuck.cs
+++ b/src/DaemonTests/Bugs/Bug_2245_async_daemon_getting_stuck.cs
@@ -55,7 +55,6 @@ public partial class Bug_2245_async_daemon_getting_stuck : BugIntegrationContext
         catch (ApplyEventException e)
         {
             // this should fail on save as the sync projection does not handle an updated event correctly.
-            _testOutputHelper.WriteLine(e.ToString());
         }
 
         // should be happy, but gets stuck trying to reach highwater mark

--- a/src/DaemonTests/Bugs/Bug_4730_double_apply_with_out_of_order_stream.cs
+++ b/src/DaemonTests/Bugs/Bug_4730_double_apply_with_out_of_order_stream.cs
@@ -73,13 +73,10 @@ public class Bug_4730_double_apply_with_out_of_order_stream: OneOffConfiguration
         {
             // The out-of-order stream's poison event is skipped+dead-lettered; non-stale wait can still
             // time out in some runs. The assertion below is what matters.
-            _output.WriteLine($"WaitForNonStaleData threw: {e.GetType().Name}: {e.Message}");
         }
 
         await using var query = theStore.QuerySession();
         var control = await query.LoadAsync<AccountReadModel4730>(streamControl, TestContext.Current.CancellationToken);
-
-        _output.WriteLine($"cacheLimit={cacheLimitPerTenant} control TotalDelta actual={control?.TotalDelta} expected={delta}");
 
         control.ShouldNotBeNull();
         control.TotalDelta.ShouldBe(delta);

--- a/src/DaemonTests/Bugs/Bug_4953_idle_advisory_lock_sessions_do_not_block_gap_skips.cs
+++ b/src/DaemonTests/Bugs/Bug_4953_idle_advisory_lock_sessions_do_not_block_gap_skips.cs
@@ -149,7 +149,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
             // lock listener, which has provably executed nothing since before seq 9 was allocated.
             // The gap is dead: skip — with NO SkipStaleGapsDespiteLiveTransactionsAfter configured.
             var second = await detector.DetectInSafeZone(CancellationToken.None);
-            _output.WriteLine($"After threshold with idle listener present: CurrentMark={second.CurrentMark}");
             second.CurrentMark.ShouldBe(12);
             second.IncludesSkipping.ShouldBeTrue();
 
@@ -194,7 +193,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
 
                 await Task.Delay(700, TestContext.Current.CancellationToken);
                 var second = await detector.DetectInSafeZone(CancellationToken.None);
-                _output.WriteLine($"Past threshold with live reserver: CurrentMark={second.CurrentMark}");
                 second.CurrentMark.ShouldBe(8);
 
                 // The reserver dies — NOW the gap is provably dead and the skip proceeds
@@ -207,7 +205,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
 
             await Task.Delay(200, TestContext.Current.CancellationToken);
             var third = await detector.DetectInSafeZone(CancellationToken.None);
-            _output.WriteLine($"After reserver death: CurrentMark={third.CurrentMark}");
             third.CurrentMark.ShouldBe(12);
             third.IncludesSkipping.ShouldBeTrue();
         }
@@ -254,7 +251,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
 
             await Task.Delay(700, TestContext.Current.CancellationToken);
             var second = await detector.DetectInSafeZone(CancellationToken.None);
-            _output.WriteLine($"Past threshold, fenceless: CurrentMark={second.CurrentMark}");
             second.CurrentMark.ShouldBe(8);
 
             var persisted = await scalar(

--- a/src/DaemonTests/Bugs/Bug_4953_outstanding_sequence_gap_skips.cs
+++ b/src/DaemonTests/Bugs/Bug_4953_outstanding_sequence_gap_skips.cs
@@ -191,7 +191,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
             // is provably alive (RowExclusiveLock on mt_events + open transaction evidence)
             await Task.Delay(700, TestContext.Current.CancellationToken);
             var second = await detector.DetectInSafeZone(CancellationToken.None);
-            _output.WriteLine($"After threshold with live reserver: CurrentMark={second.CurrentMark}");
             second.CurrentMark.ShouldBe(8);
 
             var persisted = await scalar(
@@ -285,7 +284,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
 
             // Despite the ancient last_updated, the first sighting of this gap must hold
             var first = await detector.DetectInSafeZone(CancellationToken.None);
-            _output.WriteLine($"First sighting: CurrentMark={first.CurrentMark}");
             first.CurrentMark.ShouldBe(8);
 
             // Still holding while the reserving transaction lives, even past the threshold
@@ -298,7 +296,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
             await Task.Delay(700, TestContext.Current.CancellationToken);
 
             var third = await detector.DetectInSafeZone(CancellationToken.None);
-            _output.WriteLine($"After tail death: CurrentMark={third.CurrentMark} (ceiling {lastValue})");
             third.CurrentMark.ShouldBe(lastValue);
             third.IncludesSkipping.ShouldBeTrue();
         }
@@ -367,7 +364,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
             var views = await query.Query<Bug4953GapView>().ToListAsync(TestContext.Current.CancellationToken);
             var projectedSequences = views.SelectMany(x => x.Sequences).OrderBy(x => x).ToArray();
 
-            _output.WriteLine($"persisted={persisted}, projected=[{string.Join(",", projectedSequences)}]");
             projectedSequences.Length.ShouldBe((int)persisted);
             projectedSequences.ShouldContain(9);
         }
@@ -445,7 +441,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
             var views = await query.Query<Bug4953GapView>().ToListAsync(TestContext.Current.CancellationToken);
             var projected = views.SelectMany(x => x.Sequences).Count();
 
-            _output.WriteLine($"persisted={persisted}, projected={projected}");
             projected.ShouldBe((int)persisted);
         }
         finally

--- a/src/DaemonTests/Bugs/Bug_5091_allocation_fence_at_mark_zero.cs
+++ b/src/DaemonTests/Bugs/Bug_5091_allocation_fence_at_mark_zero.cs
@@ -123,7 +123,6 @@ public class Bug_5091_allocation_fence_at_mark_zero: DaemonContext
             // lock session, and it has provably executed nothing since before seq 1 was allocated, so
             // it cannot be the reserver. The gap is dead: skip.
             var second = await detector.DetectInSafeZone(CancellationToken.None);
-            _output.WriteLine($"Leading gap past threshold with idle listener: CurrentMark={second.CurrentMark}");
             second.CurrentMark.ShouldBe(4);
             second.IncludesSkipping.ShouldBeTrue();
 
@@ -169,7 +168,6 @@ public class Bug_5091_allocation_fence_at_mark_zero: DaemonContext
 
                 await Task.Delay(700, TestContext.Current.CancellationToken);
                 var held = await detector.DetectInSafeZone(CancellationToken.None);
-                _output.WriteLine($"Leading gap past threshold with LIVE reserver: CurrentMark={held.CurrentMark}");
                 held.CurrentMark.ShouldBe(0);
 
                 await tx.RollbackAsync(TestContext.Current.CancellationToken);
@@ -182,7 +180,6 @@ public class Bug_5091_allocation_fence_at_mark_zero: DaemonContext
             // The reserver died, so now the gap is provably dead.
             await Task.Delay(200, TestContext.Current.CancellationToken);
             var after = await detector.DetectInSafeZone(CancellationToken.None);
-            _output.WriteLine($"After reserver death: CurrentMark={after.CurrentMark}");
             after.CurrentMark.ShouldBe(4);
             after.IncludesSkipping.ShouldBeTrue();
         }
@@ -222,7 +219,6 @@ public class Bug_5091_allocation_fence_at_mark_zero: DaemonContext
 
             await Task.Delay(700, TestContext.Current.CancellationToken);
             var second = await detector.DetectInSafeZone(CancellationToken.None);
-            _output.WriteLine($"Fenceless leading gap past threshold: CurrentMark={second.CurrentMark}");
             second.CurrentMark.ShouldBe(0);
         }
         finally

--- a/src/DaemonTests/Bugs/Bug_5108_durable_allocation_fence.cs
+++ b/src/DaemonTests/Bugs/Bug_5108_durable_allocation_fence.cs
@@ -146,7 +146,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync(TestContext.Curr
             await Task.Delay(700, TestContext.Current.CancellationToken);
 
             var skipped = await second.DetectInSafeZone(CancellationToken.None);
-            _output.WriteLine($"Fresh detector past threshold: CurrentMark={skipped.CurrentMark}");
             skipped.CurrentMark.ShouldBe(12);
             skipped.IncludesSkipping.ShouldBeTrue();
         }
@@ -189,7 +188,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync(TestContext.Curr
 
                 await Task.Delay(700, TestContext.Current.CancellationToken);
                 var stillHeld = await second.DetectInSafeZone(CancellationToken.None);
-                _output.WriteLine($"Live reserver, persisted fence only: CurrentMark={stillHeld.CurrentMark}");
                 stillHeld.CurrentMark.ShouldBe(8);
 
                 await tx.RollbackAsync(TestContext.Current.CancellationToken);
@@ -247,7 +245,6 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync(TestContext.Curr
             await Task.Delay(700, TestContext.Current.CancellationToken);
 
             var skipped = await detector.DetectInSafeZone(CancellationToken.None);
-            _output.WriteLine($"Own daemon lock, no fence available: CurrentMark={skipped.CurrentMark}");
             skipped.CurrentMark.ShouldBe(12);
             skipped.IncludesSkipping.ShouldBeTrue();
         }

--- a/src/DaemonTests/Bugs/Bug_deletewhere_should_remove_inserted_item.cs
+++ b/src/DaemonTests/Bugs/Bug_deletewhere_should_remove_inserted_item.cs
@@ -28,8 +28,6 @@ public class Bug_DeleteWhere_Operations_Should_Respect_Tenancy : BugIntegrationC
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
             opts.Policies.AllDocumentsAreMultiTenanted();
 
-            opts.Logger(new TestOutputMartenLogger(_output));
-
             opts.Advanced.DefaultTenantUsageEnabled = false;
         });
 

--- a/src/DaemonTests/MultiTenancy/using_for_tenant_with_side_effects_and_subscriptions.cs
+++ b/src/DaemonTests/MultiTenancy/using_for_tenant_with_side_effects_and_subscriptions.cs
@@ -33,7 +33,6 @@ public class using_for_tenant_with_side_effects_and_subscriptions : OneOffConfig
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
             opts.Projections.Add(new NumbersSubscription(), ProjectionLifecycle.Async);
             opts.Projections.Errors.SkipApplyErrors = false;
-            opts.Logger(new TestOutputMartenLogger(_output));
         });
 
         using var session = theStore.LightweightSession("green");
@@ -56,7 +55,6 @@ public class using_for_tenant_with_side_effects_and_subscriptions : OneOffConfig
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
             opts.Events.Subscribe(new NumberBatchSubscription());
             opts.Projections.Errors.SkipApplyErrors = false;
-            opts.Logger(new TestOutputMartenLogger(_output));
         });
 
         using var session = theStore.LightweightSession("green");

--- a/src/DaemonTests/Resiliency/when_skipping_events_in_daemon.cs
+++ b/src/DaemonTests/Resiliency/when_skipping_events_in_daemon.cs
@@ -273,7 +273,6 @@ public class when_skipping_events_in_daemon_with_advanced_tracking : DaemonConte
         // Drain the dead letter events queued up
         await daemon.StopAllAsync();
 
-        theSession.Logger = new TestOutputMartenLogger(_output);
         var skipped = await theSession.Query<DeadLetterEvent>().ToListAsync(TestContext.Current.CancellationToken);
 
         skipped.Where(x => x.ProjectionName == "CollateNames" && x.ShardName == "All")

--- a/src/DaemonTests/TestingSupport/DaemonContext.cs
+++ b/src/DaemonTests/TestingSupport/DaemonContext.cs
@@ -61,7 +61,7 @@ public abstract class DaemonContext: OneOffConfigurationsContext, IAsyncLifetime
     internal async Task<IProjectionDaemon> StartDaemon()
     {
         var daemon = theStore.Tenancy.Default.Database.As<MartenDatabase>()
-            .StartProjectionDaemon(theStore, new TestOutputMartenLogger(_output));
+            .StartProjectionDaemon(theStore);
 
         await daemon.StartAllAsync();
 

--- a/src/DaemonTests/TestingSupport/TestLogger.cs
+++ b/src/DaemonTests/TestingSupport/TestLogger.cs
@@ -18,14 +18,14 @@ public class TestLogger<T>: ILogger<T>, IDisposable
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
         Func<TState, Exception, string> formatter)
     {
+        // Test output intentionally suppressed to keep CI fast; the ITestOutputHelper
+        // dependency is retained so existing call sites compile unchanged.
         var message = $"{typeof(T).NameInCode()}/{logLevel}: {formatter(state, exception)}";
         Debug.WriteLine(message);
-        _output.WriteLine(message);
 
         if (exception != null)
         {
             Debug.WriteLine(exception);
-            _output.WriteLine(exception.ToString());
         }
     }
 

--- a/src/DaemonTests/blue_green_side_effect_gate.cs
+++ b/src/DaemonTests/blue_green_side_effect_gate.cs
@@ -88,7 +88,6 @@ public class blue_green_side_effect_gate : IAsyncLifetime
                {
                    opts.Projections.Add(new GateTripProjection { Version = 2 }, ProjectionLifecycle.Async);
                    opts.Events.MessageOutbox = blueOutbox;
-                   opts.Logger(new TestOutputMartenLogger(_output));
                }))
         {
             await AppendSingleEventStreams(blue, N);
@@ -109,7 +108,6 @@ public class blue_green_side_effect_gate : IAsyncLifetime
             opts.Projections.Add(new GateTripProjection { Version = 3, GateSideEffectsBehindPriorVersion = true },
                 ProjectionLifecycle.Async);
             opts.Events.MessageOutbox = greenOutbox;
-            opts.Logger(new TestOutputMartenLogger(_output));
         });
 
         var tailIds = await AppendSingleEventStreams(green, M);

--- a/src/EventSourcingTests/Aggregation/using_guid_based_strong_typed_id_for_aggregate_identity.cs
+++ b/src/EventSourcingTests/Aggregation/using_guid_based_strong_typed_id_for_aggregate_identity.cs
@@ -209,14 +209,14 @@ public class TestLogger<T>: ILogger<T>, IDisposable
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
         Func<TState, Exception, string> formatter)
     {
+        // Test output intentionally suppressed to keep CI fast; the ITestOutputHelper
+        // dependency is retained so existing call sites compile unchanged.
         var message = $"{typeof(T).NameInCode()}/{logLevel}: {formatter(state, exception)}";
         Debug.WriteLine(message);
-        _output.WriteLine(message);
 
         if (exception != null)
         {
             Debug.WriteLine(exception);
-            _output.WriteLine(exception.ToString());
         }
     }
 

--- a/src/EventSourcingTests/Bugs/Bug_4749_query_for_non_stale_data_sequence_gap.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4749_query_for_non_stale_data_sequence_gap.cs
@@ -67,7 +67,6 @@ public class Bug_4749_query_for_non_stale_data_sequence_gap: OneOffConfiguration
         var ex = await Record.ExceptionAsync(() =>
             theSession.QueryForNonStaleData<SimpleAggregate>(2.Seconds()).ToListAsync());
 
-        _output.WriteLine(ex?.GetType().FullName ?? "<no exception>");
         ex.ShouldBeOfType<TimeoutException>();
     }
 

--- a/src/EventSourcingTests/Bugs/Bug_4765_quick_occ_no_sequence_gap.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4765_quick_occ_no_sequence_gap.cs
@@ -126,7 +126,6 @@ public class Bug_4765_quick_occ_no_sequence_gap: OneOffConfigurationsContext
 
         // Loser must throw a concurrency exception...
         var ex = await Record.ExceptionAsync(() => s2.SaveChangesAsync());
-        _output.WriteLine(ex?.GetType().FullName ?? "<no exception>");
         ex.ShouldNotBeNull();
         ex.ShouldBeAssignableTo<ConcurrencyException>();
 
@@ -284,18 +283,12 @@ public class Bug_4765_quick_occ_no_sequence_gap: OneOffConfigurationsContext
 
         var successes = Array.FindAll(exceptions, static e => e is null).Length;
         var failures = Array.FindAll(exceptions, static e => e is ConcurrencyException).Length;
-        _output.WriteLine($"successes={successes}, concurrency failures={failures}");
-        for (var i = 0; i < exceptions.Length; i++)
-            if (exceptions[i] != null)
-                _output.WriteLine($"  thread[{i}]: {exceptions[i]!.GetType().Name} — {exceptions[i]!.Message}");
-
         successes.ShouldBe(1, "exactly one concurrent writer should win");
         failures.ShouldBe(2, "the other two should get ConcurrencyException");
 
         // The critical assertion: sequence must equal the highest committed seq_id.
         // A gap means nextval() fired for a losing transaction — the daemon stalls.
         var (lastValue, maxSeq, rowCount) = await ReadSequenceStateAsync(store);
-        _output.WriteLine($"last_value={lastValue}, max seq_id={maxSeq}, rows={rowCount}");
         lastValue.ShouldBe(maxSeq, $"sequence gap: last_value={lastValue} > max committed seq_id={maxSeq}");
 
         // 2 seed + 1 winner; both losers must have rolled back cleanly.

--- a/src/EventSourcingTests/Dcb/Bug_4591_truly_concurrent_dcb_tag_appends_both_commit.cs
+++ b/src/EventSourcingTests/Dcb/Bug_4591_truly_concurrent_dcb_tag_appends_both_commit.cs
@@ -146,19 +146,6 @@ public class Bug_4591_truly_concurrent_dcb_tag_appends_both_commit: OneOffConfig
         var throws = results.Count(r => r.Exception is DcbConcurrencyException);
         var otherErrors = results.Where(r => r.Exception is not null and not DcbConcurrencyException).ToList();
 
-        _output.WriteLine($"DCB storage mode: {storageMode}");
-        _output.WriteLine($"Truly-concurrent racers: {Racers}");
-        _output.WriteLine($"  Committed:                {committed}");
-        _output.WriteLine($"  DcbConcurrencyException:  {throws}");
-        if (otherErrors.Count > 0)
-        {
-            _output.WriteLine($"  Other exceptions:         {otherErrors.Count}");
-            foreach (var er in otherErrors)
-            {
-                _output.WriteLine($"    Racer {er.Index}: {er.Exception}");
-            }
-        }
-
         // Exactly one racer should commit; everyone else must observe the
         // DCB concurrency violation.
         committed.ShouldBe(1,

--- a/src/StressTests/reset_all_data_usage_ihost.cs
+++ b/src/StressTests/reset_all_data_usage_ihost.cs
@@ -34,7 +34,6 @@ public class reset_all_data_usage_ihost
                             opts =>
                             {
                                 opts.Connection(ConnectionSource.ConnectionString);
-                                opts.Logger(new TestOutputMartenLogger(_output));
                             }
                         )
                         .InitializeWith(new Users());
@@ -60,7 +59,6 @@ public class reset_all_data_usage_ihost
                             opts =>
                             {
                                 opts.Connection(ConnectionSource.ConnectionString);
-                                opts.Logger(new TestOutputMartenLogger(_output));
                             }
                         )
                         .InitializeWith(new Users());

--- a/src/TenantPartitionedEventsTests/Daemon/dynamic_tenant_lifecycle_during_continuous_daemon.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/dynamic_tenant_lifecycle_during_continuous_daemon.cs
@@ -131,7 +131,6 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
             // jasperfx#491: the distributor expanded the store-global shard into per-tenant agents —
             // no store-global agent runs.
             var initialAgents = RunningAgents(daemon);
-            _output.WriteLine("agents after start: " + string.Join(", ", initialAgents));
             initialAgents.OrderBy(x => x).ShouldBe(new[]
             {
                 $"{DynLifeProjection.ProjectionName}:All:{tenantA}",
@@ -193,8 +192,6 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
                     x.Name.Identity == $"{DynLifeProjection.ProjectionName}:All:{tenantB}"),
                 15.Seconds(),
                 "tenant B's agent is reaped by coordinator reconciliation after removal");
-            _output.WriteLine("agents after removal: " +
-                              string.Join(", ", daemon.CurrentAgents().Select(x => x.Name.Identity)));
 
             // B's progression + high-water rows are gone and STAY gone across further polling
             // cycles: the reaped agent no longer advances a progression row, and StopAgentAsync's
@@ -265,11 +262,6 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
         await using var cmd = conn.CreateCommand(
             $"select tenant_id, count(*), max(seq_id) from {Schema}.mt_events group by tenant_id order by tenant_id");
         await using var reader = await cmd.ExecuteReaderAsync();
-        _output.WriteLine("=== mt_events by tenant ===");
-        while (await reader.ReadAsync())
-        {
-            _output.WriteLine($"{reader.GetString(0)} | count={reader.GetInt64(1)} | max_seq={reader.GetInt64(2)}");
-        }
     }
 
     private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout, string what)
@@ -290,11 +282,6 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
 
     private void DumpRows(string label, List<(string Name, long Seq)> rows)
     {
-        _output.WriteLine($"=== {label} ===");
-        foreach (var (name, seq) in rows.OrderBy(r => r.Name))
-        {
-            _output.WriteLine($"{seq,6} | {name}");
-        }
     }
 
     private static long SeqOf(List<(string Name, long Seq)> rows, string name) =>

--- a/src/TenantPartitionedEventsTests/Daemon/multi_node_hotcold_single_database_partitioned_events.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/multi_node_hotcold_single_database_partitioned_events.cs
@@ -155,8 +155,6 @@ public partial class multi_node_hotcold_single_database_partitioned_events
             // ---- Placement: which node runs what ----
             var agentsA = AgentIdentities(nodeA);
             var agentsB = AgentIdentities(nodeB);
-            _output.WriteLine($"node A agents: [{string.Join(", ", agentsA)}]");
-            _output.WriteLine($"node B agents: [{string.Join(", ", agentsB)}]");
 
             var projections = new[] { HcTripProjection.ProjectionName, HcTallyProjection.ProjectionName };
             var perTenantIdentities = projections
@@ -270,11 +268,6 @@ public partial class multi_node_hotcold_single_database_partitioned_events
 
     private void DumpRows(string label, List<(string Name, long Seq)> rows)
     {
-        _output.WriteLine($"=== {label} ===");
-        foreach (var (name, seq) in rows.OrderBy(r => r.Name))
-        {
-            _output.WriteLine($"{seq,6} | {name}");
-        }
     }
 
     private static long SeqOf(List<(string Name, long Seq)> rows, string name) =>

--- a/src/TenantPartitionedEventsTests/Dcb/dcb_concurrency_replay_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Dcb/dcb_concurrency_replay_under_partitioning.cs
@@ -157,19 +157,6 @@ public class dcb_concurrency_replay_under_partitioning
         var throws = results.Count(r => r.Exception is DcbConcurrencyException);
         var otherErrors = results.Where(r => r.Exception is not null and not DcbConcurrencyException).ToList();
 
-        _output.WriteLine($"DCB storage mode under partitioning: {storageMode}");
-        _output.WriteLine($"Truly-concurrent racers: {Racers}");
-        _output.WriteLine($"  Committed:                {committed}");
-        _output.WriteLine($"  DcbConcurrencyException:  {throws}");
-        if (otherErrors.Count > 0)
-        {
-            _output.WriteLine($"  Other exceptions:         {otherErrors.Count}");
-            foreach (var er in otherErrors)
-            {
-                _output.WriteLine($"    Racer {er.Index}: {er.Exception}");
-            }
-        }
-
         // Exactly one racer commits; everyone else observes the DCB violation.
         // No other exception type — if partitioning had introduced a deadlock
         // or a different concurrency surface, this would surface here.

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4679_catch_up_per_tenant_23505.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4679_catch_up_per_tenant_23505.cs
@@ -197,12 +197,6 @@ public partial class Bug_4679_catch_up_per_tenant_23505
 
         // Headline: no 23505 anywhere in the exception chain. Drill into
         // AggregateException so the per-shard exceptions surface.
-        if (thrown != null)
-        {
-            var allMessages = string.Join("\n", Flatten(thrown).Select(x => $"  {x.GetType().Name}: {x.Message}"));
-            _output.WriteLine("CatchUpAsync threw:\n" + allMessages);
-        }
-
         Flatten(thrown).ShouldNotContain(
             x => x.Message.Contains("23505", StringComparison.Ordinal)
                  || x.Message.Contains("pk_mt_event_progression", StringComparison.Ordinal),

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4705_versioned_composite_per_tenant.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4705_versioned_composite_per_tenant.cs
@@ -163,10 +163,6 @@ public partial class Bug_4705_versioned_composite_per_tenant
 
         await daemon.StopAllAsync();
 
-        _output.WriteLine($"=== Version {version}: appended {appended} events, highWater={highWater}, " +
-                          $"standalone={standalone}, composite(min)={composite} ===");
-        foreach (var (name, seq) in rows) _output.WriteLine($"{seq,6} | {name}");
-
         // Control sanity: the standalone projection should always reach the high-water.
         standalone.ShouldBe(highWater, $"[v{version}] standalone projection should reach high-water {highWater}");
 

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4712_safe_harbor_high_water.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4712_safe_harbor_high_water.cs
@@ -93,9 +93,6 @@ public partial class Bug_4712_safe_harbor_high_water
 
         var statistics = await detector.Detect(CancellationToken.None);
 
-        _output.WriteLine($"appended={appended}, HighestSequence={statistics.HighestSequence}, " +
-                          $"CurrentMark={statistics.CurrentMark}, Timestamp={statistics.Timestamp:O}");
-
         // The high-water detector must see the real sequence height. Without the fix this reads 1
         // (the never-advanced store-global mt_events_sequence) and the store-global agent loops
         // forever in the Stale branch.

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4717_per_tenant_progression.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4717_per_tenant_progression.cs
@@ -131,9 +131,6 @@ public partial class Bug_4717_per_tenant_progression
 
         await daemon.StopAllAsync();
 
-        _output.WriteLine("=== mt_event_progression ===");
-        foreach (var (name, seq) in rows.OrderBy(r => r.Name)) _output.WriteLine($"{seq,6} | {name}");
-
         // Per-tenant PROJECTION progress: each (projection, tenant) tracked independently at the
         // tenant's own height. Today only store-global "<Projection>:All" rows are written (#4717).
         foreach (var projection in new[] { "Bug4717Standalone", "Bug4717Trip", "Bug4717Count" })

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4679_sharded_catch_up_23505.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4679_sharded_catch_up_23505.cs
@@ -178,7 +178,6 @@ public partial class Bug_4679_sharded_catch_up_23505: ShardedPartitionedContext
         catch (Exception e)
         {
             thrown = e;
-            _output.WriteLine(e.ToString());
         }
 
         // If the regression reproduced, this would throw 23505 on pk_mt_event_progression for a
@@ -271,13 +270,9 @@ public partial class Bug_4679_sharded_catch_up_23505: ShardedPartitionedContext
         catch (Exception e)
         {
             thrown = e;
-            _output.WriteLine("=== CatchUpAsync threw ===");
-            _output.WriteLine(e.ToString());
         }
 
         var names = await progressionNamesAsync(Fixture.ConnectionStrings[shardAssignment["tA"]]);
-        _output.WriteLine("=== mt_event_progression rows on shard_a ===");
-        foreach (var n in names) _output.WriteLine(n);
 
         // OBSERVE: does the composite write store-global (tenant-less) progression names? If the
         // composite execution doesn't honor the per-tenant ShardName, these bare :All rows appear

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4706_sharded_partitioned_doc_rebuild.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4706_sharded_partitioned_doc_rebuild.cs
@@ -105,11 +105,6 @@ public class Bug_4706_sharded_partitioned_doc_rebuild: ShardedPartitionedContext
             var ex = await Record.ExceptionAsync(() =>
                 store.Storage.ApplyAllConfiguredChangesToDatabaseAsync());
 
-            if (ex != null)
-            {
-                _output.WriteLine(ex.ToString());
-            }
-
             ex.ShouldBeNull("Re-applying an unchanged sharded ByList tenant-partitioned doc table " +
                             "must not rebuild it / must not fail with 23514");
         }

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4713_sharded_reapply_same_store.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4713_sharded_reapply_same_store.cs
@@ -115,7 +115,6 @@ public class Bug_4713_sharded_reapply_same_store: ShardedPartitionedContext
         foreach (var shard in shards)
         {
             before[shard] = await partitionsOf(Fixture.ConnectionStrings[shard], "mt_doc_bug4713doc");
-            _output.WriteLine($"[before][{shard}] {string.Join(", ", before[shard])}");
         }
 
         // Re-apply over the SAME store after provisioning. #4713: pre-fix the additive path had cleared
@@ -126,11 +125,6 @@ public class Bug_4713_sharded_reapply_same_store: ShardedPartitionedContext
         var ex = await Record.ExceptionAsync(() =>
             store.Storage.ApplyAllConfiguredChangesToDatabaseAsync());
 
-        if (ex != null)
-        {
-            _output.WriteLine(ex.ToString());
-        }
-
         ex.ShouldBeNull("Re-applying on the same store after tenant provisioning must be idempotent " +
                         "(no 42P07 / no destructive rebuild)");
 
@@ -139,7 +133,6 @@ public class Bug_4713_sharded_reapply_same_store: ShardedPartitionedContext
         foreach (var shard in shards)
         {
             var after = await partitionsOf(Fixture.ConnectionStrings[shard], "mt_doc_bug4713doc");
-            _output.WriteLine($"[after][{shard}] {string.Join(", ", after)}");
             after.ShouldBe(before[shard],
                 $"re-applying the schema must not change shard {shard}'s per-tenant partitions (#4713)");
         }

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4751_composite_catchup_under_sharded.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4751_composite_catchup_under_sharded.cs
@@ -127,7 +127,6 @@ public class Bug_4751_composite_catchup_under_sharded: ShardedPartitionedContext
         await using var query = _store.QuerySession("tenant_a");
         var stage1 = await query.Query<CmpTrip>().CountAsync(TestContext.Current.CancellationToken);
         var stage2 = await query.Query<CmpTripCount>().CountAsync(TestContext.Current.CancellationToken);
-        _output.WriteLine($"stage1 (CmpTrip) = {stage1}, stage2 (CmpTripCount) = {stage2}, expected {streams}");
 
         stage1.ShouldBe(streams, "stage-1 of the composite must be caught up by the async daemon");
         stage2.ShouldBe(streams, "stage-2 of the composite must be caught up by the async daemon");

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4753_sharded_partitioned_event_rebuild.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4753_sharded_partitioned_event_rebuild.cs
@@ -103,11 +103,6 @@ public class Bug_4753_sharded_partitioned_event_rebuild: ShardedPartitionedConte
             var ex = await Record.ExceptionAsync(() =>
                 store.Storage.ApplyAllConfiguredChangesToDatabaseAsync());
 
-            if (ex != null)
-            {
-                _output.WriteLine(ex.ToString());
-            }
-
             ex.ShouldBeNull("Re-applying an unchanged sharded ByList tenant-partitioned event store " +
                             "must not rebuild mt_streams / mt_events / must not fail with 23514");
         }

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4763_reassign_count_divergence.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4763_reassign_count_divergence.cs
@@ -68,9 +68,6 @@ public class Bug_4763_reassign_count_divergence: ShardedPartitionedContext
         await _store.Advanced.AddTenantToShardAsync("mover", shardB, CancellationToken.None);
 
         var counts = await ReadPoolCountsAsync();
-        _output.WriteLine("pool tenant_count per database_id: " +
-                          string.Join(", ", counts.Count == 0 ? new[] { "(none)" } : Array.Empty<string>()));
-        foreach (var (db, count) in counts) _output.WriteLine($"  {db} = {count}");
 
         // The tenant now lives on B, so A has 0 active tenants and B has 1.
         counts.ShouldContainKey(shardB);

--- a/src/TenantPartitionedEventsTests/Sharded/composite_side_effects_rebuild_under_sharded_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/composite_side_effects_rebuild_under_sharded_partitioning.cs
@@ -167,7 +167,6 @@ public partial class composite_side_effects_rebuild_under_sharded_partitioning: 
         catch (Exception e)
         {
             thrown = e;
-            _output.WriteLine(e.ToString());
         }
 
         thrown.ShouldBeNull(

--- a/src/TenantPartitionedEventsTests/Sharded/dynamic_tenant_lifecycle_on_shard_during_daemon.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/dynamic_tenant_lifecycle_on_shard_during_daemon.cs
@@ -211,7 +211,6 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
                 .Select(x => x.Name.Identity)
                 .OrderBy(x => x)
                 .ToList();
-            _output.WriteLine($"shard A agents: [{string.Join(", ", agents)}]");
             agents.ShouldContain($"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}",
                 "the coordinator's polling cycle must have started the new tenant's agent");
 
@@ -265,8 +264,6 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
                     x.Name.Identity != $"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}"),
                 30.Seconds(),
                 "tenant 2's agent is reaped by coordinator reconciliation after removal");
-            _output.WriteLine("shard A agents after removal: " +
-                              string.Join(", ", daemon.CurrentAgents().Select(x => x.Name.Identity)));
 
             // Progression-row contract on REMOVE (pinned by #4880): the tenant's per-tenant
             // progression + high-water rows are CLEANED (#4683 semantics), and nothing
@@ -395,11 +392,6 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
 
     private void DumpRows(string label, List<(string Name, long Seq)> rows)
     {
-        _output.WriteLine($"=== {label} ===");
-        foreach (var (name, seq) in rows.OrderBy(r => r.Name))
-        {
-            _output.WriteLine($"{seq,6} | {name}");
-        }
     }
 
     private static long SeqOf(List<(string Name, long Seq)> rows, string name) =>

--- a/src/TenantPartitionedEventsTests/Sharded/multi_node_hotcold_sharded_partitioned_events.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/multi_node_hotcold_sharded_partitioned_events.cs
@@ -223,8 +223,6 @@ public partial class multi_node_hotcold_sharded_partitioned_events: IAsyncLifeti
 
                 var onA = await AgentIdentitiesAsync(nodeA, shard);
                 var onB = await AgentIdentitiesAsync(nodeB, shard);
-                _output.WriteLine($"{shard}: node A runs [{string.Join(", ", onA)}], " +
-                                  $"node B runs [{string.Join(", ", onB)}]");
 
                 // Only tenant-bearing agents run, and only for THIS shard's tenants — the
                 // expansion never leaks another shard database's tenants into this set.
@@ -335,11 +333,6 @@ public partial class multi_node_hotcold_sharded_partitioned_events: IAsyncLifeti
 
     private void DumpRows(string label, List<(string Name, long Seq)> rows)
     {
-        _output.WriteLine($"=== {label} ===");
-        foreach (var (name, seq) in rows.OrderBy(r => r.Name))
-        {
-            _output.WriteLine($"{seq,6} | {name}");
-        }
     }
 
     private static long SeqOf(List<(string Name, long Seq)> rows, string name) =>


### PR DESCRIPTION
## What

Pure housekeeping to **speed up CI** by eliminating the runtime console/output spew produced by test debugging aids — while leaving the `ITestOutputHelper` dependencies themselves in place (no signatures or fixtures changed).

## Why

`TestOutputMartenLogger` was typically injected for one-off debugging; it pipes Marten's *entire* SQL log into xUnit output. Across the daemon/partitioning suites that's a large amount of console output that costs CI wall-clock for no lasting value. Same story for stray `_output.WriteLine(...)` calls left behind after debugging.

## Changes

- **Drop every `TestOutputMartenLogger` debug injection** — `opts.Logger(...)`, `x.Logger(...)`, `session.Logger = ...`, and the optional `logger:` args on `BuildProjectionDaemonAsync(...)` / `StartProjectionDaemon(...)` (both take optional loggers, so the args simply drop).
- **Neuter both `TestLogger<T>` definitions** (DaemonTests + EventSourcingTests) — the `ILogger` variant that also wrote every log line to `ITestOutputHelper`. Output suppressed; the constructor dependency is retained so all call sites compile unchanged.
- **Remove direct `_output.WriteLine(...)`** calls from test bodies across CoreTests, EventSourcingTests, DaemonTests(.ManualOnly), TenantPartitionedEventsTests, and CompiledQueryTests. Output-only loops/`catch` blocks were collapsed and a few `Dump*` helper bodies gutted where deleting just the print would orphan a keyword. `ITestOutputHelper` fields/params/assignments were left in place.

## Deliberately kept

- **`sample_replacing_logger_per_session`** (`when_skipping_events_in_daemon.cs`) — a *documented* example embedded in `docs/diagnostics.md` showing `TestOutputMartenLogger` as a per-session logger. Only the non-sample duplicate in that file was removed.
- The **LINQ acceptance harness** (`TestOutputMartenLogger(null)` + `ExecutedSql()`) — passes `null` (no output) and captures SQL for assertions; functional, not debugging.
- `docs/schema/cleaning.md` updated so the mirrored `sample_reset_all_data_ihost` snippet stays in parity with its source (no mdsnippets drift).

## Verification

- **48 files changed · 209 deletions / 8 insertions.**
- All affected test projects compile with **0 errors** (net9.0): CoreTests, EventSourcingTests, DaemonTests, DaemonTests.ManualOnly, TenantPartitionedEventsTests, CompiledQueryTests, ContainerScopedProjectionTests, StressTests.
- Confirmed no edits fall inside any `#region sample_*` block other than the one mirrored above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)