### PR TITLE
Fix #5210: UseListenNotifyForEventAppends breaks inline projections / revisioned docs in the same transaction

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_5210_listen_notify_with_inline_projection.cs
+++ b/src/EventSourcingTests/Bugs/Bug_5210_listen_notify_with_inline_projection.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Events.Daemon.HighWater;
+using Marten.Events.Operations;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+// Regression guard for https://github.com/JasperFx/marten/issues/5210.
+//
+// NotifyEventAppendedOperation is marked with the Weasel.Storage.NoDataReturnedCall
+// marker, which tells OperationPage.ApplyCallbacksAsync to skip both PostprocessAsync
+// AND reader.NextResultAsync() for that operation. But its SQL was
+// `select pg_notify('mt_events_appended', '')` — a SELECT that DOES produce a
+// one-row, one-void-column result set. The batched reader's cursor then fell one
+// result set behind for every data-returning operation after it in the same
+// SaveChanges. UnitOfWork.AllOperations puts the event operations (including the
+// notify) ahead of the document operations, so any inline projection upsert or
+// revisioned document update in the same transaction read the pg_notify row and
+// blew up with:
+//
+//   System.InvalidCastException: Reading as 'System.Int64' is not supported for
+//   fields having DataTypeName 'void'
+//     at Weasel.Storage.NumericClosedShapeUpsertOperation`2.PostprocessAsync(...)
+public class Bug_5210_listen_notify_with_inline_projection: BugIntegrationContext
+{
+    public record CounterIncremented(Guid CounterId);
+
+    public class Counter
+    {
+        public Guid Id { get; set; }
+        public int Count { get; set; }
+
+        public static Counter Create(CounterIncremented e) => new() { Id = e.CounterId, Count = 1 };
+        public void Apply(CounterIncremented e) => Count++;
+    }
+
+    public class VersionedDoc
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int Version { get; set; }
+    }
+
+    [Fact]
+    public async Task inline_projection_in_same_transaction_as_listen_notify_append()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.UseListenNotifyForEventAppends = true;
+            opts.Projections.Snapshot<Counter>(SnapshotLifecycle.Inline);
+        });
+
+        var counterId = Guid.NewGuid();
+        theSession.Events.StartStream<Counter>(counterId, new CounterIncremented(counterId),
+            new CounterIncremented(counterId));
+
+        // Blew up here with the void-column InvalidCastException before the fix
+        await theSession.SaveChangesAsync();
+
+        var counter = await theSession.LoadAsync<Counter>(counterId);
+        counter.ShouldNotBeNull();
+        counter.Count.ShouldBe(2);
+
+        // And again on a pure append to the existing stream (the aggregate upsert
+        // still shares the batch with the notify)
+        theSession.Events.Append(counterId, new CounterIncremented(counterId));
+        await theSession.SaveChangesAsync();
+
+        counter = await theSession.LoadAsync<Counter>(counterId);
+        counter!.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task revisioned_document_updated_in_same_unit_of_work_as_listen_notify_append()
+    {
+        // The reporter's second symptom: updating a numeric-revisioned document in
+        // the same unit of work as an event append also read the pg_notify row.
+        StoreOptions(opts =>
+        {
+            opts.Events.UseListenNotifyForEventAppends = true;
+            opts.Schema.For<VersionedDoc>().UseNumericRevisions(true);
+        });
+
+        var doc = new VersionedDoc { Id = Guid.NewGuid(), Name = "initial" };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        doc.Name = "updated";
+        theSession.Store(doc);
+        theSession.Events.StartStream<Counter>(Guid.NewGuid(), new CounterIncremented(Guid.NewGuid()));
+
+        // Blew up here with the void-column InvalidCastException before the fix
+        await theSession.SaveChangesAsync();
+
+        var reloaded = await theSession.LoadAsync<VersionedDoc>(doc.Id);
+        reloaded.ShouldNotBeNull();
+        reloaded.Name.ShouldBe("updated");
+    }
+
+    // Pins the NoDataReturnedCall contract for the notify statement itself: the SQL
+    // must produce NO result set (so the skipped reader stays aligned), while still
+    // actually delivering the NOTIFY to a listener.
+    [Fact]
+    public async Task notify_statement_produces_no_result_set_but_still_notifies()
+    {
+        var notificationReceived = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var listener = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await listener.OpenAsync();
+        listener.Notification += (_, args) => notificationReceived.TrySetResult(args.Channel);
+
+        await using (var listen = listener.CreateCommand())
+        {
+            listen.CommandText = $"LISTEN {PostgresqlListenWakeup.DefaultChannel}";
+            await listen.ExecuteNonQueryAsync();
+        }
+
+        await using var notifier = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await notifier.OpenAsync();
+        await using (var cmd = notifier.CreateCommand())
+        {
+            cmd.CommandText = NotifyEventAppendedOperation.Sql;
+            await using var reader = await cmd.ExecuteReaderAsync();
+
+            // The whole point of #5210: no result set may come back from this statement
+            reader.FieldCount.ShouldBe(0);
+            (await reader.ReadAsync()).ShouldBeFalse();
+            (await reader.NextResultAsync()).ShouldBeFalse();
+        }
+
+        // ... and the NOTIFY still goes out
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var wait = listener.WaitAsync(cts.Token);
+        var channel = await notificationReceived.Task.WaitAsync(cts.Token);
+        channel.ShouldBe(PostgresqlListenWakeup.DefaultChannel);
+    }
+}

--- a/src/Marten/Events/Operations/NotifyEventAppendedOperation.cs
+++ b/src/Marten/Events/Operations/NotifyEventAppendedOperation.cs
@@ -14,7 +14,15 @@ namespace Marten.Events.Operations;
 
 internal class NotifyEventAppendedOperation: IStorageOperation, NoDataReturnedCall
 {
-    private static readonly string Sql = $"select pg_notify('{PostgresqlListenWakeup.DefaultChannel}', '')";
+    // #5210 — this operation is a NoDataReturnedCall, so OperationPage.ApplyCallbacksAsync
+    // never advances the batched reader past it. The SQL therefore MUST NOT produce a
+    // result set. The original `select pg_notify(...)` form returned a one-row result set
+    // (a single `void` column), which left the reader one result set behind and made any
+    // data-returning operation later in the same batch (an inline projection upsert, a
+    // revisioned document update, ...) read the pg_notify row instead of its own RETURNING
+    // row. The DO/PERFORM form fires the identical NOTIFY without returning anything.
+    internal static readonly string Sql =
+        $"DO $$ BEGIN PERFORM pg_notify('{PostgresqlListenWakeup.DefaultChannel}', ''); END $$";
 
     public void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
     {


### PR DESCRIPTION
Fixes #5210.

## Root cause

`NotifyEventAppendedOperation` (queued by `UseListenNotifyForEventAppends` at the end of event processing) implements the `Weasel.Storage.NoDataReturnedCall` marker, which tells `OperationPage.ApplyCallbacksAsync` to skip **both** `PostprocessAsync` **and** `reader.NextResultAsync()` for that operation. But its SQL was

```sql
select pg_notify('mt_events_appended', '')
```

— a SELECT that *does* produce a result set: one row with a single `void` column. The batched reader's cursor therefore fell one result set behind for every operation after it. `UnitOfWork.AllOperations` orders the event operations (including the notify) ahead of the document operations, so the first data-returning document operation in the same `SaveChanges` — an inline projection's aggregate upsert, or a numeric-revisioned document update — read the `pg_notify` row instead of its own `RETURNING` row and died with:

```
System.InvalidCastException: Reading as 'System.Int64' is not supported for fields having DataTypeName 'void'
   at Weasel.Storage.NumericClosedShapeUpsertOperation`2.PostprocessAsync(...)
```

This also explains the reporter's second symptom (updating a versioned document in the same unit of work throws the same way) — same misalignment, different victim.

## Layer verdict + exposure

- **Marten-level defect.** Weasel's `NumericClosedShapeUpsertOperation` correctly reads the current result set; the `NoDataReturnedCall` contract ("SQL returns no result set") is documented on the marker and Marten's notify operation violated it. No Weasel change is needed or made.
- **Polecat / Fisher: not exposed.** Neither has a LISTEN/NOTIFY-on-append feature, and neither composes a `NoDataReturnedCall`-skipping walker around a notify statement. `NotifyEventAppendedOperation` is Marten-only.
- Audited every other `NoDataReturnedCall` implementation in Marten — none builds SELECT SQL; this was the single offender. (`ExecuteSqlStorageOperation` carries arbitrary user SQL from `QueueSqlCommand`, which is already documented as non-result-returning — unchanged.)

## Fix

Make the notify statement genuinely result-set-free so the marker stays truthful and the executor's skip fast-path is preserved:

```sql
DO $$ BEGIN PERFORM pg_notify('mt_events_appended', ''); END $$
```

Identical NOTIFY semantics (same channel, same transactional delivery at commit), zero result sets.

## Tests

New `EventSourcingTests/Bugs/Bug_5210_listen_notify_with_inline_projection.cs`:

- `inline_projection_in_same_transaction_as_listen_notify_append` — the reporter's shape: `UseListenNotifyForEventAppends = true` + `Snapshot<T>(SnapshotLifecycle.Inline)`, start-stream and subsequent-append both covered. Failed before the fix with the exact reported exception; passes after.
- `revisioned_document_updated_in_same_unit_of_work_as_listen_notify_append` — the reporter's second symptom (`UseNumericRevisions` document updated alongside an event append). Same before/after behavior.
- `notify_statement_produces_no_result_set_but_still_notifies` — pins the `NoDataReturnedCall` contract for the notify SQL itself: asserts `ExecuteReader` yields no result set **and** that a LISTENing connection still receives the NOTIFY on `mt_events_appended`.

Test evidence:

- All 3 new tests pass on net9.0 and net10.0 (and reproduce the reported `InvalidCastException` verbatim when run against the unfixed operation).
- `EventSourcingTests.Daemon.postgres_listen_notify_wakeup_tests` (4/4) — includes the end-to-end test that boots a store with `UseListenNotifyForEventAppends = true` and asserts the daemon is woken by the append-side NOTIFY, i.e. the new DO/PERFORM statement batches cleanly and still fires in production shape.
- Full `EventSourcingTests` suite run on net9.0: **Failed: 0, Passed: 1799, Skipped: 7** (2m 43s; the 7 skips are the pre-existing Dcb hstore skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
