### PR TITLE
fix: let HardDeleteWhere reach already soft-deleted rows

### DIFF
--- a/src/DocumentDbTests/Deleting/soft_deletes.cs
+++ b/src/DocumentDbTests/Deleting/soft_deletes.cs
@@ -132,6 +132,102 @@ public class soft_deletes: StoreContext<SoftDeletedFixture>, IClassFixture<SoftD
         count.ShouldBe(0);
     }
 
+    private void plantDeletedAt<T>(IDocumentSession session, object id, DateTimeOffset instant)
+    {
+        var mapping = theStore.Options.Storage.MappingFor(typeof(T));
+
+        var cmd = session.Connection
+            .CreateCommand($"update {mapping.TableName} set mt_deleted_at = :at where id = :id")
+            .With("at", instant.UtcDateTime)
+            .With("id", id);
+
+        cmd.ExecuteNonQuery();
+    }
+
+    private DateTimeOffset? readDeletedAt<T>(IDocumentSession session, object id)
+    {
+        var mapping = theStore.Options.Storage.MappingFor(typeof(T));
+
+        var cmd = session.Connection
+            .CreateCommand($"select mt_deleted_at from {mapping.TableName} where id = :id")
+            .With("id", id);
+
+        var raw = cmd.ExecuteScalar();
+        if (raw == null || raw == DBNull.Value)
+        {
+            return null;
+        }
+
+        // Npgsql surfaces timestamptz as a UTC DateTime, not a DateTimeOffset.
+        return raw is DateTimeOffset offset ? offset : new DateTimeOffset((DateTime)raw, TimeSpan.Zero);
+    }
+
+    /// <summary>
+    ///     Ports polecat#419. A soft <c>DeleteWhere</c> must not re-stamp <c>mt_deleted_at</c> on rows
+    ///     that were already deleted, or every question about *when* a document was deleted
+    ///     (DeletedSince, DeletedBefore, an audit, a retention sweep) silently reads the later bulk
+    ///     call instead of the deletion, and the real value is unrecoverable.
+    ///     <para>
+    ///     Two deletes in the same millisecond agree either way, so calling DeleteWhere twice proves
+    ///     nothing on its own. This plants a known instant far in the past on the already-deleted row
+    ///     and asserts the second call leaves it alone.
+    ///     </para>
+    /// </summary>
+    [Fact]
+    public async Task delete_where_does_not_restamp_deleted_at_on_already_deleted_rows()
+    {
+        var planted = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var alreadyDeleted = new StringDoc { Id = "restamp-old", Size = "big" };
+        var stillLive = new StringDoc { Id = "restamp-new", Size = "big" };
+
+        theSession.Store(alreadyDeleted, stillLive);
+        await theSession.SaveChangesAsync();
+
+        theSession.Delete(alreadyDeleted);
+        await theSession.SaveChangesAsync();
+
+        // Plant a deletion instant well in the past, so a re-stamp is unmistakable.
+        plantDeletedAt<StringDoc>(theSession, alreadyDeleted.Id, planted);
+
+        // A later bulk delete whose predicate still matches the already-deleted row.
+        theSession.DeleteWhere<StringDoc>(x => x.Size == "big");
+        await theSession.SaveChangesAsync();
+
+        // The already-deleted row keeps the instant it was actually deleted.
+        var untouched = readDeletedAt<StringDoc>(theSession, alreadyDeleted.Id);
+        untouched.ShouldNotBeNull();
+        untouched.Value.ToUniversalTime().ShouldBe(planted.ToUniversalTime());
+
+        // ... and the row that was still live is deleted now, with a real (recent) timestamp.
+        var freshlyDeleted = readDeletedAt<StringDoc>(theSession, stillLive.Id);
+        freshlyDeleted.ShouldNotBeNull();
+        freshlyDeleted.Value.ShouldBeGreaterThan(planted);
+    }
+
+    /// <summary>
+    ///     Ports polecat#419, the other half. <c>HardDeleteWhere</c> must NOT inherit the soft-delete
+    ///     exclusion filter: a hard delete of an already-soft-deleted row is a real delete and has to
+    ///     proceed, or soft-deleted rows are stranded permanently beyond the reach of the purge that
+    ///     is supposed to remove them.
+    /// </summary>
+    [Fact]
+    public async Task hard_delete_where_still_removes_already_soft_deleted_rows()
+    {
+        var doc = new StringDoc { Id = "purge-me", Size = "big" };
+
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        theSession.Delete(doc);
+        await theSession.SaveChangesAsync();
+
+        theSession.HardDeleteWhere<StringDoc>(x => x.Size == "big");
+        await theSession.SaveChangesAsync();
+
+        assertDocumentIsHardDeleted<StringDoc>(theSession, doc.Id);
+    }
+
     [Fact]
     public async Task soft_delete_a_document_row_state()
     {

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.HardDeletes.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.HardDeletes.cs
@@ -81,9 +81,31 @@ public abstract partial class DocumentSessionBase
 
         var documentStorage = StorageFor<T>();
         var deletion = new StatementOperation(documentStorage, documentStorage.HardDeleteFragment);
-        deletion.ApplyFiltering(this, expression);
+        var where = deletion.ApplyFiltering(this, expression);
+
+        // A hard delete has to reach rows that are already soft-deleted, because removing them
+        // is the entire point of a purge. Leaving the filter on makes HardDeleteWhere silently
+        // skip exactly the rows it exists to remove, while HardDelete by id still works.
+        removeExcludeSoftDeletedFilter(where);
 
         _workTracker.Add(deletion);
+    }
+
+    /// <summary>
+    ///     The soft-deleted exclusion filter is applied to every operation built through
+    ///     <see cref="StatementOperation.ApplyFiltering{T}" />. Operations whose whole purpose is to
+    ///     act on already-deleted rows have to take it back off again.
+    /// </summary>
+    private static void removeExcludeSoftDeletedFilter(ISqlFragment? where)
+    {
+        if (where is CompoundWhereFragment compound)
+        {
+            var filter = compound.Children.OfType<ExcludeSoftDeletedFilter>().FirstOrDefault();
+            if (filter != null)
+            {
+                compound.Remove(filter);
+            }
+        }
     }
 
     /// <summary>
@@ -110,18 +132,9 @@ public abstract partial class DocumentSessionBase
 
         var where = deletion.ApplyFiltering(this, expression);
 
-        // This is hokey, but you need to remove the normally applied filter
-        // to exclude soft-deleted documents because that's exactly what you do want
-        // here
-        if (where is CompoundWhereFragment compound)
-        {
-            var filter = compound.Children.OfType<ExcludeSoftDeletedFilter>().FirstOrDefault();
-            if (filter != null)
-            {
-                compound.Remove(filter);
-            }
-        }
-
+        // Un-deleting is only meaningful against rows that are already soft-deleted, so the
+        // normally applied exclusion filter has to come back off.
+        removeExcludeSoftDeletedFilter(where);
 
         _workTracker.Add(deletion);
     }


### PR DESCRIPTION
## The bug

`HardDeleteWhere<T>` cannot remove a row that is already soft-deleted. `HardDelete` by id can.

A retention or purge sweep built on `HardDeleteWhere` returns cleanly and leaves behind exactly the rows it exists to remove, and nothing reports a failure. Because the by-id path works, spot-checking the API looks correct.

## Root cause

`HardDeleteWhere` builds its operation through `StatementOperation.ApplyFiltering`, which routes to `Statement.ParseWhereClause` and then `IDocumentStorage.FilterDocuments`. For any type configured `DeleteStyle.SoftDelete`, `DocumentStorage.extraFilters` appends the exclusion filter:

```csharp
// src/Marten/Internal/Storage/DocumentStorage.cs:446
if (_deleteStyle == DeleteStyle.SoftDelete && !query.ContainsAny<ISoftDeletedFilter>())
{
    yield return ExcludeSoftDeletedFilter.Instance;
}
```

So the generated hard `DELETE` carries `mt_deleted = false`.

`UndoDeleteWhere` hits the same filter and strips it back off explicitly. `HardDeleteWhere` has the identical need and never got the same treatment.

## Fix

Remove the filter in `HardDeleteWhere` the same way `UndoDeleteWhere` already does, and pull the step into one private method now that two call sites need it.

## The alternative I did not take

There are four call sites for `ApplyFiltering`, and they split evenly:

| Call site | Wants `ExcludeSoftDeletedFilter` |
|---|---|
| `DeleteWhere` | yes |
| `PatchExpression` | yes |
| `UndoDeleteWhere` | no, strips it |
| `HardDeleteWhere` | no, this PR |

So the filter is not simply applied at the wrong layer, it is right for half the callers and wrong for the other half. That points at the operation declaring whether it acts on deleted rows, rather than every caller undoing the default afterwards. The original comment on `UndoDeleteWhere` calling the removal "hokey" reads the same way.

I did not take that route because it changes `FilterDocuments` behaviour for every operation type, and that is a call for you rather than me. Happy to redo it that way if you prefer.

## Tests

Ports the two soft-delete regression tests from polecat#419, as asked in #5212:

- **`delete_where_does_not_restamp_deleted_at_on_already_deleted_rows`** passes on master already, so this is the pin you were after. It plants an `mt_deleted_at` of 2020-01-01 before the second `DeleteWhere`, because two deletes in the same millisecond agree either way and prove nothing.
- **`hard_delete_where_still_removes_already_soft_deleted_rows`** fails on master and passes with this change.

`DocumentDbTests` is green: 1091 passed, 1 skipped, 0 failed.

The polecat#394 half of #5212, a lone `DcbConcurrencyException` surfacing unwrapped, is not in this PR.

Refs #5212.
