### PR TITLE
Fix #5159: make UseOptimisticConcurrency and UseNumericRevisions symmetric

### DIFF
--- a/src/EventSourcingTests/Bugs/optimistic_concurrency_on_projection_target_fails_fast.cs
+++ b/src/EventSourcingTests/Bugs/optimistic_concurrency_on_projection_target_fails_fast.cs
@@ -3,6 +3,7 @@ using EventSourcingTests.Aggregation;
 using JasperFx.Events.Projections;
 using Marten.Exceptions;
 using Marten.Metadata;
+using Marten.Schema;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
@@ -15,62 +16,116 @@ namespace EventSourcingTests.Bugs;
 /// two flavors of the same physical <c>mt_version</c> column, so a mapping that ends up with
 /// both enabled used to surface as a raw duplicate-key <c>ArgumentException</c> (or invalid
 /// DDL with two <c>mt_version</c> columns) instead of an actionable configuration error.
+///
+/// <para>
+/// #5159 narrowed that guard. <c>UseOptimisticConcurrency(true)</c> now clears the competing
+/// numeric-revision metadata the same way <c>UseNumericRevisions(true)</c> has always cleared
+/// the Guid version, so for a plain document the fluent pair is order-independent and the last
+/// call wins. The guard is kept — with a message that says which case it is — only where the
+/// override genuinely cannot work: a projection target, or a revision bound to a member on the
+/// user's own type.
+/// </para>
 /// </summary>
 public class optimistic_concurrency_on_projection_target_fails_fast: BugIntegrationContext
 {
     [Fact]
     public void use_optimistic_concurrency_on_projected_document_throws_invalid_document_exception()
     {
-        // ProjectionDocumentPolicy forces MyAggregate onto numeric revisions, then the fluent
-        // override runs after the policies and re-enables the Guid version — leaving both
-        // flavors on. That combination can never work and must fail fast — here already at
-        // store bootstrap, because the projection's ValidateConfiguration materializes the
-        // aggregate mapping.
+        // ProjectionDocumentPolicy forces MyAggregate onto numeric revisions because it is the
+        // target of a projection, and the projection machinery writes the aggregate version into
+        // that column. Pushing it onto Guid concurrency can never work, so this must still fail
+        // fast — here already at store bootstrap, because the projection's ValidateConfiguration
+        // materializes the aggregate mapping.
         var ex = Should.Throw<InvalidDocumentException>(() => StoreOptions(opts =>
         {
             opts.Projections.Add<AllGood>(ProjectionLifecycle.Inline);
             opts.Schema.For<MyAggregate>().UseOptimisticConcurrency(true);
         }));
 
-        ex.Message.ShouldContain("UseOptimisticConcurrency");
-        ex.Message.ShouldContain("UseNumericRevisions");
         ex.Message.ShouldContain(nameof(MyAggregate));
+        ex.Message.ShouldContain("projection");
+        ex.Message.ShouldContain("UseOptimisticConcurrency");
     }
 
     [Fact]
-    public void switching_a_plain_document_from_numeric_revisions_to_optimistic_concurrency_also_fails_fast()
+    public void plain_document_numeric_revisions_then_optimistic_concurrency_is_last_wins()
     {
-        // Without any projection involved, stacking the two fluent calls leaves the revision
-        // metadata enabled from the first call while the second re-enables the Guid version.
+        // #5159: this order used to throw while the reverse order quietly worked. Nothing about
+        // Target says "numeric revisions" other than the first call, so the second call overriding
+        // it is exactly what the fluent API reads like it should do.
         StoreOptions(opts =>
         {
             opts.Schema.For<Target>().UseNumericRevisions(true);
             opts.Schema.For<Target>().UseOptimisticConcurrency(true);
         });
 
-        Should.Throw<InvalidDocumentException>(
-            () => theStore.Options.Storage.MappingFor(typeof(Target)));
+        var mapping = theStore.Options.Storage.MappingFor(typeof(Target));
+
+        mapping.UseOptimisticConcurrency.ShouldBeTrue();
+        mapping.UseNumericRevisions.ShouldBeFalse();
+        mapping.Metadata.Version.Enabled.ShouldBeTrue();
+        mapping.Metadata.Revision.Enabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void plain_document_optimistic_concurrency_then_numeric_revisions_is_last_wins()
+    {
+        // The mirror image, which has always worked. Pinned so the two orders cannot drift apart
+        // again — the asymmetry between them is the whole of #5159.
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>().UseOptimisticConcurrency(true);
+            opts.Schema.For<Target>().UseNumericRevisions(true);
+        });
+
+        var mapping = theStore.Options.Storage.MappingFor(typeof(Target));
+
+        mapping.UseNumericRevisions.ShouldBeTrue();
+        mapping.UseOptimisticConcurrency.ShouldBeFalse();
+        mapping.Metadata.Revision.Enabled.ShouldBeTrue();
+        mapping.Metadata.Version.Enabled.ShouldBeFalse();
     }
 
     [Fact]
     public void interface_driven_revisions_plus_optimistic_concurrency_fails_fast()
     {
-        // The likeliest real-world route into the invalid state, and the one neither test above
-        // covers: nothing in the configuration says "numeric revisions" — VersionedPolicy turns
-        // them on because the document implements IRevisioned, and the fluent call then re-enables
-        // the Guid version on top. Before the guard this reached the database as DDL with two
-        // mt_version columns.
+        // Still an error, and deliberately so. IRevisioned is a declaration on the user's own
+        // type rather than something Marten inferred: honoring the override would leave
+        // RevisionedDoc.Version unmapped and silently never populated. The message has to name
+        // the member so that is obvious.
         StoreOptions(opts => opts.Schema.For<RevisionedDoc>().UseOptimisticConcurrency(true));
 
         var ex = Should.Throw<InvalidDocumentException>(
             () => theStore.Options.Storage.MappingFor(typeof(RevisionedDoc)));
 
         ex.Message.ShouldContain(nameof(RevisionedDoc));
+        ex.Message.ShouldContain(nameof(IRevisioned.Version));
+    }
+
+    [Fact]
+    public void long_version_member_plus_optimistic_concurrency_fails_fast()
+    {
+        // Same rule by the other route onto Metadata.Revision.Member: a long [Version] member
+        // declares the revision on the document type just as IRevisioned does.
+        StoreOptions(opts => opts.Schema.For<LongVersionedDoc>().UseOptimisticConcurrency(true));
+
+        var ex = Should.Throw<InvalidDocumentException>(
+            () => theStore.Options.Storage.MappingFor(typeof(LongVersionedDoc)));
+
+        ex.Message.ShouldContain(nameof(LongVersionedDoc));
+        ex.Message.ShouldContain(nameof(LongVersionedDoc.Version));
     }
 
     public class RevisionedDoc: IRevisioned
     {
         public Guid Id { get; set; }
         public int Version { get; set; }
+    }
+
+    public class LongVersionedDoc
+    {
+        public Guid Id { get; set; }
+
+        [Version] public long Version { get; set; }
     }
 }

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -713,8 +713,18 @@ public class MartenRegistry
 
                 if (enabled)
                 {
+                    m.OptimisticConcurrencyRequestedExplicitly = true;
                     m.UseNumericRevisions = false;
                     m.Metadata.Version.Enabled = true;
+
+                    // #5159: mirror UseNumericRevisions, which has always cleared the competing
+                    // flavor. Without this the two calls are order-dependent -- numeric-then-guid
+                    // threw at bootstrap while guid-then-numeric quietly worked -- because both
+                    // metadata flags ended up enabled and they map to the same mt_version column.
+                    // The cases where clearing this is the wrong answer (projection targets,
+                    // revisions declared by IRevisioned/ILongVersioned/[Version]) are caught in
+                    // DocumentMapping.CompileAndValidate instead, where the error can name them.
+                    m.Metadata.Revision.Enabled = false;
                 }
             };
             return this;

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -284,6 +284,16 @@ public partial class DocumentMapping: IDocumentMapping, IDocumentType
 
     public bool UseNumericRevisions { get; set; }
 
+    /// <summary>
+    ///     Set only by an explicit <c>Schema.For&lt;T&gt;().UseOptimisticConcurrency(true)</c> fluent call,
+    ///     as opposed to the same flag being inferred by a policy, an interface, or a [Version] member.
+    ///     That call clears the competing numeric-revision metadata so the two orders of the fluent
+    ///     pair behave the same (#5159), which means <see cref="CompileAndValidate" /> can no longer
+    ///     see the conflict in the metadata itself and needs this to report the cases where the
+    ///     override genuinely cannot work.
+    /// </summary>
+    internal bool OptimisticConcurrencyRequestedExplicitly { get; set; }
+
     public IList<IndexDefinition> Indexes { get; } = new List<IndexDefinition>();
 
     public IList<ForeignKey> ForeignKeys { get; } = new List<ForeignKey>();
@@ -898,17 +908,45 @@ public partial class DocumentMapping: IDocumentMapping, IDocumentType
                 $"{DocumentType.FullNameInCode()} cannot be configured with UseNumericRevision and UseOptimisticConcurrency. Choose one or the other");
         }
 
-        // The check above only sees the two mode flags, but the metadata Enabled bits are what
-        // actually emit columns — and the Guid version and numeric revision flavors compete for
-        // the same physical mt_version column, so both enabled means a duplicate column: a raw
-        // duplicate-key ArgumentException from projection storage or invalid DDL at migration
-        // time. The usual route here is Schema.For<T>().UseOptimisticConcurrency(true) on a
-        // projection-target document that ProjectionDocumentPolicy already forced onto numeric
-        // revisions (fluent overrides run after the policies). Fail fast with the fix instead.
+        // #5159: an explicit UseOptimisticConcurrency(true) now clears the numeric-revision
+        // metadata so the fluent pair is order-independent (last call wins), which is what the
+        // API reads like it should do. That override is right for a plain document, where the
+        // revision was only ever Marten's inference. It is wrong in two cases, and those are
+        // worth distinct, actionable errors rather than one "both flags are set" message:
+        //
+        //   1. a projection-target document, where numeric revisions are load-bearing for the
+        //      projection machinery itself (#2978), and
+        //   2. a revision bound to a real member on the user's own type -- IRevisioned,
+        //      ILongVersioned, or a long [Version] member -- where honoring the override would
+        //      leave that property permanently unmapped and silently never populated.
+        //
+        // In both, the user's configuration cannot work as written, so say which one it is.
+        if (OptimisticConcurrencyRequestedExplicitly)
+        {
+            if (StoreOptions.Projections != null &&
+                StoreOptions.Projections.TryFindAggregate(DocumentType, out _))
+            {
+                throw new InvalidDocumentException(
+                    $"{DocumentType.FullNameInCode()} is the target document of a projection, and projection targets always use numeric revisions -- the projection machinery writes the aggregate version into that column. It cannot also be configured with UseOptimisticConcurrency(true). Remove that call for this document type.");
+            }
+
+            if (Metadata.Revision.Member != null)
+            {
+                throw new InvalidDocumentException(
+                    $"{DocumentType.FullNameInCode()} declares numeric revisions through its own type -- the member '{Metadata.Revision.Member.Name}' (from IRevisioned, ILongVersioned, or a long [Version] member) -- so UseOptimisticConcurrency(true) cannot be honored: the Guid version and the numeric revision map to the same mt_version column, and taking the Guid flavor would leave '{Metadata.Revision.Member.Name}' unmapped and never populated. Either drop the UseOptimisticConcurrency(true) call, or stop declaring the revision member on the document type.");
+            }
+        }
+
+        // Backstop. The metadata Enabled bits are what actually emit columns, and the Guid
+        // version and numeric revision flavors compete for the same physical mt_version column,
+        // so both enabled means a duplicate column: a raw duplicate-key ArgumentException from
+        // projection storage, or invalid DDL at migration time. The fluent path above can no
+        // longer reach this state, but a hand-rolled IDocumentPolicy or direct mapping mutation
+        // still can.
         if (Metadata.Version.Enabled && Metadata.Revision.Enabled)
         {
             throw new InvalidDocumentException(
-                $"{DocumentType.FullNameInCode()} has both the Guid version metadata (Metadata.Version, from UseOptimisticConcurrency) and the numeric revision metadata (Metadata.Revision, from UseNumericRevisions) enabled, but they map to the same mt_version column. Choose one or the other — fluent configuration calls accumulate rather than override each other, so remove the call for the mode you do not want. Note that projection-target documents always use numeric revisions and cannot opt into UseOptimisticConcurrency.");
+                $"{DocumentType.FullNameInCode()} has both the Guid version metadata (Metadata.Version, from UseOptimisticConcurrency) and the numeric revision metadata (Metadata.Revision, from UseNumericRevisions) enabled, but they map to the same mt_version column. Choose one or the other. Note that projection-target documents always use numeric revisions and cannot opt into UseOptimisticConcurrency.");
         }
 
         IQueryableMember idField;


### PR DESCRIPTION
Fixes #5159.

## The bug

`UseNumericRevisions(true)` has always cleared the competing Guid version metadata. `UseOptimisticConcurrency(true)` never cleared the numeric revision metadata. So the order of the two fluent calls decided the outcome:

```csharp
// Order A -- works
opts.Schema.For<Foo>().UseOptimisticConcurrency(true);
opts.Schema.For<Foo>().UseNumericRevisions(true);

// Order B -- InvalidDocumentException at bootstrap
opts.Schema.For<Foo>().UseNumericRevisions(true);
opts.Schema.For<Foo>().UseOptimisticConcurrency(true);
```

Both metadata flags ended up enabled, and they map to the same physical `mt_version` column, so #5121's guard fired.

The same asymmetry meant `UseOptimisticConcurrency(true)` threw on any type that already had numeric revisions from a *policy* rather than an explicit call — an aggregate-projection target, for instance — where nothing in the user's configuration said "numeric revisions" and the error read as though Marten invented the conflict.

## The fix

**Half 1.** `UseOptimisticConcurrency(true)` now clears `Metadata.Revision.Enabled`, mirroring `UseNumericRevisions`. Both orders become last-wins, which is what the fluent API reads like it should do.

**Half 2.** Clearing it unconditionally would silently paper over two cases where the override genuinely cannot work, so the #5121 guard is narrowed rather than dropped, and split into two errors that name which case it is:

| case | detected via | outcome |
|---|---|---|
| projection-target document | `Projections.TryFindAggregate` | throws — numeric revisions are load-bearing for the projection machinery (#2978) |
| revision declared on the type (`IRevisioned`, `ILongVersioned`, long `[Version]`) | `Metadata.Revision.Member != null` | throws, naming the member |
| anything else (plain documents, blanket policies) | — | last-wins, no throw |

The line being drawn: **Marten's inference yields to an explicit fluent call; the user's own declaration does not.** Honoring the override on an `IRevisioned` document would leave that property unmapped and silently never populated, and the user cannot plausibly have meant that. `Metadata.Revision.Member` is set by exactly three places — `VersionAttribute` (long), `IRevisioned`, `ILongVersioned` — all of them declarations on the document type, which is what makes it the right detector.

The original `Version.Enabled && Revision.Enabled` check stays as a backstop, since a hand-rolled `IDocumentPolicy` or direct mapping mutation can still reach that state even though the fluent path no longer can.

An internal `OptimisticConcurrencyRequestedExplicitly` flag distinguishes "the user asked for this" from "a policy or interface inferred it" — needed because half 1 removes the conflict from the metadata before `CompileAndValidate` can see it.

## Behavior change

Strictly permissive, plus better messages. Order A worked before and still works; order B threw before and now works. Nothing that previously worked begins failing.

`switching_a_plain_document_from_numeric_revisions_to_optimistic_concurrency_also_fails_fast` asserted exactly the behavior this issue says is wrong, so it is replaced by a pair pinning last-wins in both orders.

## Tests

`optimistic_concurrency_on_projection_target_fails_fast`, 5 tests, all green:

- projection target + `UseOptimisticConcurrency(true)` still fails fast, message names the projection
- plain document, numeric-then-optimistic → last-wins **(new; fails on master)**
- plain document, optimistic-then-numeric → last-wins (new; pins the mirror image so the two orders cannot drift apart again)
- `IRevisioned` + `UseOptimisticConcurrency(true)` still fails fast, message now names the member
- long `[Version]` member + `UseOptimisticConcurrency(true)` fails fast **(new; the other route onto `Metadata.Revision.Member`)**

CoreTests is unchanged against master: 4 failed / 515 passed on master at `86508beab`, 3 failed / 516 passed on this branch — the same order-dependent codegen flakes in `jasper_fx_mechanics`, none related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01549KpXyFuCbdD6qeNVfK2b