### PR TITLE
Bump JasperFx and JasperFx.Events 2.46.0 -> 2.47.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -246,15 +246,15 @@
          tenantId) was already on the shared generic IEventStore<,> and TenancyStyle was already a
          shared JasperFx.MultiTenancy enum. Compliance sources only; behaviourally inert for the
          shipping libraries. -->
-    <PackageVersion Include="JasperFx" Version="2.46.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.46.0" />
+    <PackageVersion Include="JasperFx" Version="2.47.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.47.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.46.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.47.0" />
     <!--
       Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
       the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
@@ -272,11 +272,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.46.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.47.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.46.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.47.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Takes the dependency on JasperFx / JasperFx.Events / JasperFx.Events.ComplianceTests / the source generators at **2.47.0**. Release-gating for 9.23.0.

## What 2.47.0 brings

A new `JasperFx.Events.Documents` namespace — the store-agnostic document session abstractions that #5216 implements over Marten. Seven new public types, and nothing else changed in the surface (`JasperFx` itself is unchanged at 173 public types; `JasperFx.Events` goes 168 → 175):

| type | operations |
|---|---|
| `IDocumentReadOperations` | `LoadAsync<T>(Guid/string)`, `Query<T>()` |
| `IDocumentWriteOperations` | `Store<T>(params)`, `Delete<T>(doc/Guid/string)`, `DeleteWhere<T>(expr)` |
| `IDocumentSessionOperations` | `SaveChangesAsync` |
| `IDocumentSessionFactory` / `IDocumentSessionFactory<,>` | `LightweightSession()`, `QuerySession()` |
| `IDocumentQueryExecutor` | `ExecuteToListAsync` / `FirstOrDefault` / `Count` / `Any` |
| `DocumentQueryableExtensions` | the store-agnostic async terminators over `IQueryable<T>` |

**This PR only takes the dependency.** No Marten type implements the new contracts yet — that is #5216, and it is a separate piece of work.

## Verification

- `src/Marten.slnx` builds clean, whole solution, 0 errors
- `EventSourcingTests` on net9.0: **1799 passed, 0 failed, 7 skipped**

Refs #5216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01549KpXyFuCbdD6qeNVfK2b