### PR TITLE
#5216: implement the JasperFx document persistence abstractions over Marten

### DIFF
--- a/src/EventSourcingTests/Compliance/marten_document_storage_compliance.cs
+++ b/src/EventSourcingTests/Compliance/marten_document_storage_compliance.cs
@@ -1,0 +1,45 @@
+using JasperFx.Events.ComplianceTests;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * Document storage compliance (#5216, jasperfx#647). Same shape as the event store enrollments --
+ * empty subclasses closing the shared suites over Marten's fixture -- but notably NOT generic over
+ * Marten's session pair, because the document contract is reachable entirely through
+ * IDocumentSessionFactory and the three session interfaces.
+ *
+ * These live alongside the event enrollments rather than in DocumentDbTests because this is the
+ * project that compiles the compliance sources (and carries the -p:ComplianceSourceDir dev-loop
+ * switch for validating in-flight upstream suites before a JasperFx release).
+ *
+ * All four share one xUnit collection, and that is load-bearing rather than tidiness. Every one of
+ * these suites pins its DocumentComplianceConfig.SchemaName to "compliance_documents", so they all
+ * resolve to the same physical schema -- and DocumentStorageComplianceSuite calls
+ * CleanDocumentDataAsync in InitializeAsync, before every test. Run the classes in parallel and one
+ * class's per-test wipe lands in the middle of another's test. A collection serializes them.
+ * (CI sets DISABLE_TEST_PARALLELIZATION, so this only bites locally -- which is exactly where a
+ * green run matters most while working.)
+ */
+
+[Collection(DocumentComplianceCollection.Name)]
+public class document_load_and_store_compliance
+    : DocumentLoadAndStoreCompliance<MartenDocumentComplianceFixture>;
+
+[Collection(DocumentComplianceCollection.Name)]
+public class document_query_compliance
+    : DocumentQueryCompliance<MartenDocumentComplianceFixture>;
+
+[Collection(DocumentComplianceCollection.Name)]
+public class document_delete_compliance
+    : DocumentDeleteCompliance<MartenDocumentComplianceFixture>;
+
+[Collection(DocumentComplianceCollection.Name)]
+public class document_session_compliance
+    : DocumentSessionCompliance<MartenDocumentComplianceFixture>;
+
+public static class DocumentComplianceCollection
+{
+    public const string Name = "document storage compliance";
+}

--- a/src/EventSourcingTests/EventSourcingTests.csproj
+++ b/src/EventSourcingTests/EventSourcingTests.csproj
@@ -88,6 +88,9 @@
         <Compile Include="..\Marten.Testing\Harness\MartenComplianceFixture.cs">
             <Link>Harness\MartenComplianceFixture.cs</Link>
         </Compile>
+        <Compile Include="..\Marten.Testing\Harness\MartenDocumentComplianceFixture.cs">
+            <Link>Harness\MartenDocumentComplianceFixture.cs</Link>
+        </Compile>
         <Compile Include="..\Marten.Testing\Harness\BugIntegrationContext.cs">
             <Link>Harness\BugIntegrationContext.cs</Link>
         </Compile>

--- a/src/Marten.Testing/Harness/MartenDocumentComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenDocumentComplianceFixture.cs
@@ -1,0 +1,70 @@
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events.ComplianceTests;
+using JasperFx.Events.Documents;
+
+namespace Marten.Testing.Harness;
+
+/// <summary>
+/// Marten's implementation of the cross-store <em>document</em> compliance seam (#5216,
+/// jasperfx#647).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three members wide, against the nine-plus of <see cref="MartenComplianceFixture" />, and unlike
+/// that one it is not generic over Marten's session pair. Both differences are the point rather
+/// than an inconsistency: the event surface is largely only reachable through a product's own
+/// session type, whereas everything the document suites do runs through
+/// <see cref="IDocumentSessionFactory" /> and the three session contracts — which Marten's
+/// <c>IDocumentStore</c>, <c>IQuerySession</c>, <c>IDocumentOperations</c> and <c>IDocumentSession</c>
+/// now implement directly.
+/// </para>
+/// <para>
+/// <see cref="Sessions" /> being typed as the bare <see cref="IDocumentSessionFactory" /> is what
+/// makes that claim load-bearing: if any of these suites ever needed to reach past the contract
+/// onto a Marten type, it would not compile.
+/// </para>
+/// </remarks>
+public class MartenDocumentComplianceFixture: DocumentStorageComplianceFixture
+{
+    private DocumentStore _store = null!;
+
+    public override IDocumentSessionFactory Sessions => _store;
+
+    protected override async Task BuildStoreAsync(DocumentComplianceConfig config)
+    {
+        var options = new StoreOptions();
+        options.Connection(ConnectionSource.ConnectionString);
+        options.AutoCreateSchemaObjects = AutoCreate.All;
+        options.DisableNpgsqlLogging = true;
+        options.NameDataLength = 100;
+        options.DatabaseSchemaName = (config.SchemaName ?? "doc_compliance").ToLowerInvariant();
+
+        // Marten creates document storage on demand, so DocumentTypes is not strictly required
+        // here. Registering it anyway means ApplyAllConfiguredChangesToDatabaseAsync below actually
+        // builds the tables up front, which keeps the first test of each suite off the lazy-DDL
+        // path and makes CleanDocumentDataAsync a plain delete rather than a no-op against nothing.
+        foreach (var documentType in config.DocumentTypes)
+        {
+            options.Storage.MappingFor(documentType);
+        }
+
+        _store = new DocumentStore(options);
+
+        await _store.Storage.ApplyAllConfiguredChangesToDatabaseAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Wiping a store is administration rather than part of the document contract, so this is
+    /// spelled on Marten's own Advanced surface — exactly the asymmetry the seam exists to absorb.
+    /// </summary>
+    public override Task CleanDocumentDataAsync() => _store.Advanced.Clean.DeleteAllDocumentsAsync();
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_store != null)
+        {
+            await _store.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Marten/IDocumentOperations.cs
+++ b/src/Marten/IDocumentOperations.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using JasperFx.Events;
+using JasperFx.Events.Documents;
 using Marten.Events;
 using Marten.Internal.Operations;
 
@@ -11,7 +12,13 @@ namespace Marten;
 /// <summary>
 ///     Basic storage operations for document types, but cannot initiate any actual writes
 /// </summary>
-public interface IDocumentOperations: IQuerySession, IStorageOperations
+/// <remarks>
+///     #5216: this is the level the store-agnostic <see cref="IDocumentWriteOperations" /> binds to,
+///     not <see cref="IDocumentSession" /> — enlisting into the unit of work and committing it are
+///     separate concerns in JasperFx's contract too, and Marten already draws the line in the same
+///     place. Every member the contract asks for already exists here with a matching signature.
+/// </remarks>
+public interface IDocumentOperations: IQuerySession, IStorageOperations, IDocumentWriteOperations
 {
     new Marten.Events.IEventStoreOperations Events { get; }
 

--- a/src/Marten/IDocumentSession.cs
+++ b/src/Marten/IDocumentSession.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using JasperFx.Events.Documents;
 using Marten.Events;
 using Marten.Internal.Sessions;
 using Marten.Services;
@@ -12,7 +13,12 @@ namespace Marten;
 /// <summary>
 ///     Interface for querying a document database and unit of work updates
 /// </summary>
-public interface IDocumentSession: IDocumentOperations
+/// <remarks>
+///     #5216: adds the transaction boundary on top of <see cref="IDocumentOperations" />, which is
+///     exactly the split <see cref="IDocumentSessionOperations" /> draws. SaveChangesAsync already
+///     matches, so the contract binds with no new members.
+/// </remarks>
+public interface IDocumentSession: IDocumentOperations, IDocumentSessionOperations
 {
     /// <summary>
     /// Force this session to start a connection and transaction. This will make the session do consistent reads through the transaction. Is

--- a/src/Marten/IDocumentStore.cs
+++ b/src/Marten/IDocumentStore.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Transactions;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.Documents;
 using Marten.Events;
 using Marten.Events.Daemon;
 using Marten.Services;
@@ -19,8 +20,21 @@ namespace Marten;
 ///     The core abstraction for a Marten document and event store. This should probably be scoped as a
 ///     singleton in your system
 /// </summary>
-public interface IDocumentStore: IDisposable, IAsyncDisposable
+public interface IDocumentStore: IDisposable, IAsyncDisposable,
+    IDocumentSessionFactory<IDocumentSession, IQuerySession>
 {
+    // #5216: Marten's LightweightSession() is an overload with a defaulted IsolationLevel rather
+    // than a genuinely parameterless method, so it does not bind to the contract on its own.
+    // QuerySession() is parameterless and already satisfies the generic form. Default interface
+    // implementations forward both, and the non-generic form is forwarded separately because it
+    // differs from the generic one only by return type.
+    IDocumentSession IDocumentSessionFactory<IDocumentSession, IQuerySession>.LightweightSession()
+        => LightweightSession();
+
+    IDocumentSessionOperations IDocumentSessionFactory.LightweightSession() => LightweightSession();
+
+    IDocumentReadOperations IDocumentSessionFactory.QuerySession() => QuerySession();
+
     /// <summary>
     ///     Information about the current configuration of this IDocumentStore
     /// </summary>

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -5,6 +5,8 @@ using System.Data.Common;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Linq;
+using JasperFx.Events.Documents;
 using Marten.Events;
 using Marten.Internal.Sessions;
 using Marten.Linq;
@@ -18,8 +20,16 @@ using Weasel.Postgresql.Tables.Indexes;
 
 namespace Marten;
 
-public interface IQuerySession: IDisposable, IAsyncDisposable
+public interface IQuerySession: IDisposable, IAsyncDisposable, IDocumentReadOperations
 {
+    // #5216: IQuerySession already carries LoadAsync(Guid)/LoadAsync(string) with matching
+    // signatures, so the read half of the store-agnostic contract binds implicitly. Query<T>()
+    // is the one member that cannot: Marten returns IMartenQueryable<T> where the contract asks
+    // for IQueryable<T>, and C# has no return-type covariance for interface implementation. A
+    // default interface implementation forwards it here rather than making every concrete
+    // session class carry the same one-liner.
+    IQueryable<T> IDocumentReadOperations.Query<T>() => Query<T>();
+
     /// <summary>
     ///     The underlying Marten database for this session
     /// </summary>
@@ -176,7 +186,7 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    IMartenQueryable<T> Query<T>() where T : notnull;
+    new IMartenQueryable<T> Query<T>() where T : notnull;
 
     #endregion
 

--- a/src/Marten/Linq/MartenLinqQueryProvider.cs
+++ b/src/Marten/Linq/MartenLinqQueryProvider.cs
@@ -7,6 +7,7 @@ using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using JasperFx.Events.Documents;
 using Marten.Events;
 using Marten.Exceptions;
 using Marten.Internal.Sessions;
@@ -39,7 +40,7 @@ internal record WaitForAggregate(TimeSpan Timeout, NonStaleDataTimeoutMode Timeo
 /// </summary>
 internal readonly record struct StreamOneJsonResult(bool Found, Guid? Version, long? Revision, bool BodyWritten);
 
-internal class MartenLinqQueryProvider: IQueryProvider
+internal class MartenLinqQueryProvider: IQueryProvider, IDocumentQueryExecutor
 {
     private readonly QuerySession _session;
 
@@ -99,6 +100,55 @@ internal class MartenLinqQueryProvider: IQueryProvider
         }
     }
 
+
+    #region IDocumentQueryExecutor -- #5216
+
+    // The store-agnostic async terminators behind JasperFx's DocumentQueryableExtensions. They take
+    // the queryable rather than closing over one, because the extension methods may have composed a
+    // predicate onto it first -- so every one of these reads queryable.Expression rather than any
+    // expression this provider was built with.
+
+    public async Task<IReadOnlyList<T>> ExecuteToListAsync<T>(IQueryable<T> queryable, CancellationToken token)
+    {
+        try
+        {
+            var parser = new LinqQueryParser(this, _session, queryable.Expression);
+            var handler = parser.BuildListHandler<T>();
+
+            await EnsureStorageExistsAsync(parser, token).ConfigureAwait(false);
+
+            var result = await ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+            return result ?? Array.Empty<T>();
+        }
+        catch (Exception e)
+        {
+            MartenExceptionTransformer.WrapAndThrow(e);
+            throw;
+        }
+    }
+
+    public Task<T> ExecuteFirstOrDefaultAsync<T>(IQueryable<T> queryable, CancellationToken token)
+    {
+        // ExecuteAsync constrains TResult to notnull, and the contract deliberately leaves T
+        // unconstrained so a store can return null for "or default". notnull is a nullable-analysis
+        // constraint that the CLR does not enforce, so this is a compile-time annotation mismatch
+        // and nothing more -- the returned value is exactly what FirstOrDefaultAsync<T> gives today.
+#pragma warning disable CS8714
+        return ExecuteAsync<T>(queryable.Expression, token, SingleValueMode.FirstOrDefault)!;
+#pragma warning restore CS8714
+    }
+
+    public Task<int> ExecuteCountAsync<T>(IQueryable<T> queryable, CancellationToken token)
+    {
+        return ExecuteAsync<int>(queryable.Expression, token, SingleValueMode.Count);
+    }
+
+    public Task<bool> ExecuteAnyAsync<T>(IQueryable<T> queryable, CancellationToken token)
+    {
+        return ExecuteAsync<bool>(queryable.Expression, token, SingleValueMode.Any);
+    }
+
+    #endregion
 
     public async Task<TResult?> ExecuteAsync<TResult>(Expression expression, CancellationToken token,
         SingleValueMode valueMode) where TResult : notnull


### PR DESCRIPTION
Part 1 of #5216. Part 2 (the Wolverine drift) is analysed at the bottom — it turns out to be entirely Wolverine-side work, with **no Marten-side bug**.

## Implementing the abstractions

JasperFx.Events 2.47.0 added `JasperFx.Events.Documents`, the store-agnostic document session contract behind the Wolverine aggregate-handler unification (wolverine#3907, jasperfx#647). Marten already had every operation it asks for with matching signatures, so this is mostly declaring relationships rather than writing behavior:

| Marten | JasperFx contract | how |
|---|---|---|
| `IQuerySession` | `IDocumentReadOperations` | implicit, + 1 DIM |
| `IDocumentOperations` | `IDocumentWriteOperations` | implicit, no new members |
| `IDocumentSession` | `IDocumentSessionOperations` | implicit, no new members |
| `IDocumentStore` | `IDocumentSessionFactory<IDocumentSession, IQuerySession>` | 3 DIMs |
| `MartenLinqQueryProvider` | `IDocumentQueryExecutor` | new, 4 methods |

Worth noting how well the shapes line up: the contract's operations/session split lands exactly where Marten already draws it — enlisting into the unit of work is `IDocumentWriteOperations` on `IDocumentOperations`, and the transaction boundary is `IDocumentSessionOperations` on `IDocumentSession`. That is the same split `JasperFxSingleStreamProjectionBase<TDoc,TId,TOperations,TQuerySession>` models, which is why `IDocumentSessionFactory`'s `TOperations : TQuerySession` constraint is satisfied with no reshaping at all.

### The two members that could not bind implicitly

Both are forwarded by default interface implementations rather than pushed onto every concrete session class:

- **`Query<T>()`** — Marten returns `IMartenQueryable<T>` where the contract asks for `IQueryable<T>`, and C# has no return-type covariance for interface implementation. Marten's declaration becomes `new`, deliberately narrowing the contract's return type.
- **`LightweightSession()`** — Marten's is an overload with a defaulted `IsolationLevel`, not a genuinely parameterless method.

One deliberate suppression: `ExecuteFirstOrDefaultAsync<T>` calls Marten's `ExecuteAsync<TResult>`, which constrains `TResult : notnull`, while the contract leaves `T` unconstrained so a store can return null for "or default". `notnull` is a nullable-analysis constraint the CLR does not enforce, so this is an annotation mismatch and nothing more — the value returned is exactly what `FirstOrDefaultAsync<T>` gives today. Scoped `#pragma` with the reasoning inline.

## Compliance enrollment

All four shipped suites, via `MartenDocumentComplianceFixture` — **42 tests, all passing.**

The fixture is three members wide and, unlike `MartenComplianceFixture`, is *not* generic over Marten's session pair. `Sessions` is typed as the bare `IDocumentSessionFactory`, which makes the claim load-bearing: if any suite ever needed to reach past the contract onto a Marten type, it would not compile.

The four enrollments share one xUnit collection, and that is not tidiness. Every suite pins `SchemaName` to `"compliance_documents"`, and the base suite calls `CleanDocumentDataAsync` before *every* test — so run in parallel, one class's wipe lands in the middle of another's test. That is precisely what happened first time round: 5 failures that all vanished when each class ran alone. CI sets `DISABLE_TEST_PARALLELIZATION`, so this only bites locally, which is where a green run matters most while working.

## Verification

- full solution builds clean — notable, since this touches four core public interfaces and nothing implementing them broke
- **EventSourcingTests 1843 passed / 0 failed** (+44 vs the 2.47.0 bump: the 42 new compliance tests plus 2 from #5218)
- **LinqTests 1421 passed / 0 failed**
- **DocumentDbTests 1091 passed / 0 failed**
- CoreTests: 3 failures, a strict *subset* of master's 4 at `feb0a460d` (`Bug_4185`, `Bug_4187`, `rolling_range_partitioning`, `jasper_fx_mechanics`) — the pre-existing order-dependent codegen/assembly-reuse and partition-window flakes. Nothing introduced.

## Part 2: the AggregateHandling drift — no Marten-side bug

I diffed `Wolverine.Marten/AggregateHandling.cs` against `Wolverine.Polecat/AggregateHandling.cs`. Every divergence is Wolverine-repo work; per this repo's convention I am handing it off rather than editing a sibling repo. Recording the calls here so wolverine#3907 does not have to re-derive them:

| divergence | which side is right | note |
|---|---|---|
| `required` on `AggregateType`/`AggregateId` vs `= null!` | **Polecat** | |
| `[NotNullWhen(true)] out AggregateHandling?` on both `TryLoad` overloads | **Polecat** | |
| Marten's null guard in `declareAggregateIdRouteParameter` | **Polecat** (drop it) | not an independent call — the guard only exists *because* Marten uses `= null!`. Take `required` and it becomes provably dead code. These two rows are one decision. |
| `DetermineVersionMember` returning `MemberInfo?` vs `MemberInfo` with `!` | **Polecat** | Marten's `!` masks a real null from `IAggregateVersioning.VersionMember` |
| `[UnconditionalSuppressMessage]` on `RelayAggregateToHandlerMethod` | **Marten** | Marten supports AOT (`Marten.AotSmoke`); Polecat dropped the annotations and should regain them |
| explanatory comments (e.g. why capturing the version cannot work) | **Marten** | Polecat stripped several; the unified copy should keep them |
| `ImTools.IndexOf` vs `Array.FindIndex` | **Polecat** | drops an `ImTools` dependency for a BCL call |

The interesting one is **`DetermineAggregateIdMember`**, which looks like a Marten gap and is not. Polecat's version honors both its own `[Identity]` *and* `JasperFx.IdentityAttribute`; Marten's checks only a bare `IdentityAttribute`. But the Marten repo defines **no** `IdentityAttribute` at all — with `using JasperFx;` in that file, the bare name already resolves to `JasperFx.IdentityAttribute`. Polecat needs the two-attribute check only because `Polecat.IdentityAttribute` shadows the shared one. Marten is already correct and needs no change; the unified implementation just has to keep honoring both names for Polecat's sake.

So: nothing to fix in this repo for part 2.

Refs #5216, wolverine#3907, jasperfx#647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01549KpXyFuCbdD6qeNVfK2b