### PR TITLE
Make StoreOptions.Projections.FetchPlanners public

### DIFF
--- a/docs/events/projections/read-aggregates.md
+++ b/docs/events/projections/read-aggregates.md
@@ -180,6 +180,74 @@ In all cases, the `FetchForWriting` + `FetchLatest` combination is working toget
 the correct information in the most efficient way possible by eliminating extra trips to the
 database.
 
+## Custom Fetch Plans <Badge type="tip" text="9.24" />
+
+Everything above is Marten choosing a *fetch plan* for you. A fetch plan is the strategy behind a single
+`FetchForWriting()` or `FetchLatest()` call: which SQL gets built, which events come back, and what the
+aggregate is folded onto. Marten ships four, and picks between them by looking at how the aggregate type
+is registered — natural key, `Inline`, `Async`, and `Live`, in that order.
+
+If none of those four fit your aggregate, you can supply your own:
+
+```cs
+builder.Services.AddMarten(opts =>
+{
+    opts.Connection(connectionString);
+
+    // Consulted before Marten's four built-in planners
+    opts.Projections.FetchPlanners.Add(new MyFetchPlanner());
+});
+```
+
+Marten asks each planner in `FetchPlanners` — in registration order — for a plan, then falls back to the
+built-ins. The first planner whose `TryMatch<TDoc, TId>()` returns `true` wins:
+
+```cs
+public class MyFetchPlanner: IFetchPlanner
+{
+    public bool TryMatch<TDoc, TId>(IEventIdentityStrategy<TId> identity, StoreOptions options,
+        [NotNullWhen(true)] out IAggregateFetchPlan<TDoc, TId>? plan)
+        where TDoc : class where TId : notnull
+    {
+        if (typeof(TDoc) != typeof(Invoice))
+        {
+            // Everything you decline stays on Marten's default behavior
+            plan = default;
+            return false;
+        }
+
+        plan = new MyFetchPlan<TDoc, TId>(identity, options);
+        return true;
+    }
+}
+```
+
+Returning `false` is the important half of that contract: a planner that only claims the aggregate types
+it knows about leaves every other type resolving exactly as it would without your planner registered.
+
+Two things are worth knowing before you write one:
+
+* **The resolved plan is cached per `(TDoc, TId)` pair**, so `TryMatch()` runs once per aggregate type
+  rather than once per fetch. Register planners while configuring the store; adding one afterwards will
+  not affect types that have already been resolved.
+* **Your plan owns the concurrency story.** `IAggregateFetchPlan<TDoc, TId>` is responsible for reading
+  the current stream version and handing it to `IEventIdentityStrategy<TId>.AppendToStream()`, which is
+  what makes Marten's optimistic concurrency check on `SaveChangesAsync()` work. Read a version you did
+  not verify against the database and you silently lose that check.
+
+Everything a custom plan needs is public: `IEventIdentityStrategy<TId>` gives you
+`BuildCommandForReadingVersionForStream()`, `BuildEventQueryHandler()` (which accepts an optional
+`ISqlFragment` filter, so a plan can narrow which events it reads back) and `StartStream()` /
+`AppendToStream()`, and `StoreOptions.Projections.AggregatorFor<TDoc>()` gives you the same aggregator the
+built-in plans fold with.
+
+::: tip
+Marten's own `FetchLivePlan`, `FetchInlinedPlan` and `FetchAsyncPlan` are the reference implementations —
+they are short, and reading them is by far the fastest way to understand the shape a plan has to take.
+`FetchAsyncPlan` in particular shows the "start from a snapshot at version N, read only the events after
+it, fold" pattern.
+:::
+
 ## Live Aggregation
 
 Also see [Live Aggregations](/events/projections/live-aggregates)

--- a/src/EventSourcingTests/FetchForWriting/custom_fetch_planners.cs
+++ b/src/EventSourcingTests/FetchForWriting/custom_fetch_planners.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
+using Marten.Testing.Harness;
+using Marten.Testing.OtherAssembly.CustomFetchPlanners;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.FetchForWriting;
+
+/// <summary>
+/// Covers StoreOptions.Projections.FetchPlanners as a supported extension point: an application
+/// can register its own IFetchPlanner to take over FetchForWriting() for the aggregate types it
+/// recognises, and everything it declines keeps Marten's built-in behavior.
+///
+/// ExternalFetchPlanner deliberately lives in Marten.Testing.OtherAssembly, which is *not* granted
+/// InternalsVisibleTo — see the note on that type.
+/// </summary>
+public class custom_fetch_planners: OneOffConfigurationsContext
+{
+    private ExternalFetchPlanner thePlanner = null!;
+
+    public custom_fetch_planners()
+    {
+        // UseExternalFetchPlanner does the FetchPlanners.Add(...) from an assembly that cannot
+        // see Marten's internals, so the registration itself is part of what this covers.
+        StoreOptions(opts => thePlanner = opts.UseExternalFetchPlanner(typeof(SimpleAggregate)));
+    }
+
+    [Fact]
+    public async Task custom_planner_wins_for_the_aggregate_type_it_matches()
+    {
+        // The built-in LiveFetchPlanner would happily resolve SimpleAggregate, so reaching the
+        // external plan at all proves custom planners run ahead of the built-ins.
+        await Should.ThrowAsync<ExternalFetchPlanWasUsedException>(async () =>
+            await theSession.Events.FetchForWriting<SimpleAggregate>(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public async Task custom_planner_wins_for_fetch_latest_too()
+    {
+        await Should.ThrowAsync<ExternalFetchPlanWasUsedException>(async () =>
+            await theSession.Events.FetchLatest<SimpleAggregate>(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public async Task declining_a_type_falls_through_to_the_built_in_planners()
+    {
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate2>(streamId, new AEvent(), new BEvent(), new BEvent());
+        await theSession.SaveChangesAsync();
+
+        // SimpleAggregate2 is not the type the planner matches, so Marten falls back to live
+        // aggregation and nothing about the default behavior changes.
+        var stream = await theSession.Events.FetchForWriting<SimpleAggregate2>(streamId);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.ACount.ShouldBe(1);
+        stream.Aggregate.BCount.ShouldBe(2);
+        stream.CurrentVersion.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task the_planner_is_consulted_for_every_aggregate_type()
+    {
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate2>(streamId, new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await theSession.Events.FetchForWriting<SimpleAggregate2>(streamId);
+
+        thePlanner.TryMatchCount.ShouldBeGreaterThan(0);
+    }
+}

--- a/src/Marten.Testing.OtherAssembly/CustomFetchPlanners/ExternalFetchPlanner.cs
+++ b/src/Marten.Testing.OtherAssembly/CustomFetchPlanners/ExternalFetchPlanner.cs
@@ -1,0 +1,117 @@
+#nullable enable
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Fetching;
+using Marten.Internal.Sessions;
+using Marten.Linq.QueryHandlers;
+
+namespace Marten.Testing.OtherAssembly.CustomFetchPlanners;
+
+/// <summary>
+/// Registers <see cref="ExternalFetchPlanner" /> the way an application would. The
+/// <c>FetchPlanners.Add(...)</c> call below is the actual subject of this assembly: it only
+/// compiles while <c>StoreOptions.Projections.FetchPlanners</c> is public, and this assembly is
+/// deliberately *not* in Marten's InternalsVisibleTo list.
+/// </summary>
+public static class ExternalFetchPlannerExtensions
+{
+    public static ExternalFetchPlanner UseExternalFetchPlanner(this StoreOptions options, Type aggregateType)
+    {
+        var planner = new ExternalFetchPlanner(aggregateType);
+        options.Projections.FetchPlanners.Add(planner);
+        return planner;
+    }
+}
+
+/// <summary>
+/// Lives in this assembly on purpose. Marten does *not* grant InternalsVisibleTo to
+/// Marten.Testing.OtherAssembly, so this file only compiles while every type an
+/// application needs to write its own fetch plan is genuinely public:
+/// StoreOptions.Projections.FetchPlanners, IFetchPlanner, IAggregateFetchPlan&lt;TDoc, TId&gt;,
+/// IEventIdentityStrategy&lt;TId&gt;, DocumentSessionBase, QuerySession and IQueryHandler&lt;T&gt;.
+/// Narrow any of those back to internal and the build breaks here rather than silently
+/// removing the extension point.
+/// </summary>
+public class ExternalFetchPlanner: IFetchPlanner
+{
+    private readonly Type _aggregateType;
+
+    public ExternalFetchPlanner(Type aggregateType)
+    {
+        _aggregateType = aggregateType;
+    }
+
+    /// <summary>
+    /// Incremented every time Marten asks this planner for a plan, so a test can prove the
+    /// planner is consulted at all — including for aggregate types it declines.
+    /// </summary>
+    public int TryMatchCount { get; private set; }
+
+    public bool TryMatch<TDoc, TId>(IEventIdentityStrategy<TId> identity, StoreOptions options,
+        [NotNullWhen(true)] out IAggregateFetchPlan<TDoc, TId>? plan) where TDoc : class where TId : notnull
+    {
+        TryMatchCount++;
+
+        if (typeof(TDoc) != _aggregateType)
+        {
+            // Declining leaves Marten's built-in planners to resolve this aggregate type
+            // exactly as they would without this planner registered.
+            plan = default;
+            return false;
+        }
+
+        plan = new ExternalFetchPlan<TDoc, TId>();
+        return true;
+    }
+}
+
+/// <summary>
+/// A deliberately inert plan: every entry point throws <see cref="ExternalFetchPlanWasUsedException" />
+/// so a test can assert which plan Marten actually resolved. A real custom plan would use the
+/// public primitives on <see cref="IEventIdentityStrategy{TId}" /> — BuildCommandForReadingVersionForStream,
+/// BuildEventQueryHandler (which takes an optional ISqlFragment filter) and StartStream/AppendToStream —
+/// against <see cref="DocumentSessionBase.ExecuteReaderAsync(Npgsql.NpgsqlBatch, CancellationToken)" />.
+/// Marten's own FetchLivePlan / FetchInlinedPlan / FetchAsyncPlan are the reference implementations.
+/// </summary>
+public class ExternalFetchPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> where TDoc : class
+{
+    public ProjectionLifecycle Lifecycle => ProjectionLifecycle.Live;
+
+    public Task<IEventStream<TDoc>> FetchForWriting(DocumentSessionBase session, TId id, bool forUpdate,
+        CancellationToken cancellation = default) => throw new ExternalFetchPlanWasUsedException();
+
+    public Task<IEventStream<TDoc>> FetchForWriting(DocumentSessionBase session, TId id, long expectedStartingVersion,
+        CancellationToken cancellation = default) => throw new ExternalFetchPlanWasUsedException();
+
+    public ValueTask<TDoc?> FetchForReading(DocumentSessionBase session, TId id, CancellationToken cancellation)
+        => throw new ExternalFetchPlanWasUsedException();
+
+    public ValueTask<TDoc?> ProjectLatest(DocumentSessionBase session, TId id, CancellationToken cancellation)
+        => throw new ExternalFetchPlanWasUsedException();
+
+    public Task<bool> StreamForReading(DocumentSessionBase session, TId id, Stream destination,
+        CancellationToken cancellation) => throw new ExternalFetchPlanWasUsedException();
+
+    public IQueryHandler<IEventStream<TDoc>> BuildQueryHandler(QuerySession session, TId id,
+        long expectedStartingVersion) => throw new ExternalFetchPlanWasUsedException();
+
+    public IQueryHandler<IEventStream<TDoc>> BuildQueryHandler(QuerySession session, TId id, bool forUpdate)
+        => throw new ExternalFetchPlanWasUsedException();
+
+    public IQueryHandler<TDoc?> BuildQueryHandler(QuerySession session, TId id)
+        => throw new ExternalFetchPlanWasUsedException();
+}
+
+public class ExternalFetchPlanWasUsedException: Exception
+{
+    public ExternalFetchPlanWasUsedException(): base("The externally registered fetch plan was used")
+    {
+    }
+}

--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -47,9 +47,26 @@ public class ProjectionOptions: ProjectionGraph<IProjection, IDocumentOperations
     }
 
     /// <summary>
-    ///     Any custom or extended IFetchPlanner strategies for customizing FetchForWriting() behavior
+    ///     Any custom or extended <see cref="IFetchPlanner" /> strategies for customizing
+    ///     <c>FetchForWriting()</c> / <c>FetchLatest()</c> behavior.
     /// </summary>
-    internal List<IFetchPlanner> FetchPlanners { get; } = new();
+    /// <remarks>
+    ///     <para>
+    ///     Marten asks every planner in this list — in registration order — for a plan before falling back to
+    ///     its four built-in planners (natural key, <c>Inline</c>, <c>Async</c>, <c>Live</c>). The first planner
+    ///     whose <see cref="IFetchPlanner.TryMatch{TDoc,TId}" /> returns <see langword="true" /> wins, so a
+    ///     custom planner can either handle an aggregate type the built-ins would not, or take one over from
+    ///     them. Returning <see langword="false" /> for everything you do not recognize leaves Marten's
+    ///     behavior completely unchanged.
+    ///     </para>
+    ///     <para>
+    ///     The resolved plan is cached per <c>(TDoc, TId)</c> pair, so <see cref="IFetchPlanner.TryMatch{TDoc,TId}" />
+    ///     is called once per aggregate type rather than once per fetch. Register planners during
+    ///     <c>AddMarten()</c> configuration; adding one after the store is built has no effect on types that
+    ///     have already been resolved.
+    ///     </para>
+    /// </remarks>
+    public List<IFetchPlanner> FetchPlanners { get; } = new();
 
     /// <summary>
     ///     #4953: when true (the default), the async daemon's high water detection consults PostgreSQL


### PR DESCRIPTION
Part of #5225.

`ProjectionOptions.FetchPlanners` already carries the doc comment *"Any custom or extended IFetchPlanner
strategies for customizing FetchForWriting() behavior"*, but the list itself is `internal`, so there is
currently no way to supply one.

Everything else needed is already public — `IFetchPlanner`, `IAggregateFetchPlan<TDoc, TId>`,
`IEventIdentityStrategy<TId>` (including the `BuildEventQueryHandler` overload that takes an
`ISqlFragment` filter), `DocumentSessionBase`, `QuerySession`, `IQueryHandler<T>` and
`StoreOptions.Projections.AggregatorFor<TDoc>()`. This widens the one member that was holding the
extension point shut.

### Why

Applications whose command handlers repeatedly fetch the same stream — a chain of cascading commands over
one aggregate — want to experiment with their own loading strategies without forking Marten. #5225 has the
full motivation; this PR is just the enabler.

### Non-breaking

`internal` → `public` only. With no custom planner registered, `allPlanners()` yields exactly the four
built-ins it always did, in the same order. Source- and binary-compatible.

### On the test placement

`ExternalFetchPlanner` deliberately lives in `Marten.Testing.OtherAssembly`, which is **not** in Marten's
`InternalsVisibleTo` list. The `FetchPlanners.Add(...)` call sits in that assembly too, so if this member
is ever narrowed again the build breaks there rather than silently removing the extension point.

Tests cover: the custom planner winning over the built-in `LiveFetchPlanner` for the type it matches (both
`FetchForWriting` and `FetchLatest`), declining a type falling through to live aggregation unchanged, and
the planner being consulted at all.

Also adds a "Custom Fetch Plans" section to `docs/events/projections/read-aggregates.md` covering the
ordering rules, the per-`(TDoc, TId)` plan caching, and the fact that a custom plan owns the concurrency
story — it has to read the real stream version and hand it to `AppendToStream`, or the optimistic
concurrency check on `SaveChangesAsync` is silently lost.
