### PR TITLE
Add an opt-in marten.fetch_for_writing.events_replayed histogram

### DIFF
--- a/docs/otel.md
+++ b/docs/otel.md
@@ -140,7 +140,7 @@ named `marten.fetch_for_writing.events_replayed`, recorded once per `FetchForWri
 Reading it is straightforward, because each plan has a characteristic shape:
 
 | `fetch.plan` | What the histogram shows |
-|---|---|
+| --- | --- |
 | `Live` | The full stream length, every single time — the aggregate is rebuilt from scratch on each fetch |
 | `Async` | Only the events the async daemon has not projected yet, so this doubles as a per-fetch view of daemon lag |
 | `Inline` | Always zero — the stored snapshot is current by construction |

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -114,6 +114,47 @@ This metric has tags for:
 * `event_type` - the Marten name for the type of the event within its configuration
 * `tenant.id` - the tenant id for which the event was captured. If you are not using multi-tenancy, this value will be "*DEFAULT*" and can be just ignored
 
+## FetchForWriting Metrics <Badge type="tip" text="9.24" />
+
+The cost of a command handler that uses [`FetchForWriting`](/scenarios/command_handler_workflow) is
+mostly the cost of rebuilding the aggregate, and that in turn is however many events Marten had to read
+back and fold. How many that is depends entirely on the aggregate's projection lifecycle, and it is not
+something you can see from the outside. Opt into measuring it with:
+
+```cs
+using var store = DocumentStore.For(opts =>
+{
+    opts.Connection("some connection string");
+
+    // How many events does each FetchForWriting() call actually replay?
+    opts.OpenTelemetry.TrackFetchForWritingMetrics();
+});
+```
+
+This adds a [Histogram](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-instrumentation)
+named `marten.fetch_for_writing.events_replayed`, recorded once per `FetchForWriting()` call, with tags for:
+
+* `aggregate.type` - the .NET type name of the aggregate that was fetched
+* `fetch.plan` - which plan served the call: `Live`, `Inline` or `Async`
+
+Reading it is straightforward, because each plan has a characteristic shape:
+
+| `fetch.plan` | What the histogram shows |
+|---|---|
+| `Live` | The full stream length, every single time — the aggregate is rebuilt from scratch on each fetch |
+| `Async` | Only the events the async daemon has not projected yet, so this doubles as a per-fetch view of daemon lag |
+| `Inline` | Always zero — the stored snapshot is current by construction |
+
+The histogram's own count gives you fetch frequency for free, so a `sum by (aggregate.type)` tells you
+which aggregates dominate your event replay, and the `Live` percentiles tell you what switching one of
+them to `Inline` would actually save before you commit to that migration.
+
+::: tip
+Nothing is created until `TrackFetchForWritingMetrics()` is called, so leaving it off costs a null check
+on the fetch path and nothing more. Both tag values are cached per aggregate type, so a recorded fetch
+allocates nothing on the heap either.
+:::
+
 ## Async Daemon Metrics and Spans
 
 See [Open Telemetry and Metrics within the Async Daemon documentation](/events/projections/async-daemon.html#open-telemetry-and-metrics).

--- a/src/EventSourcingTests/FetchForWriting/fetch_for_writing_metrics.cs
+++ b/src/EventSourcingTests/FetchForWriting/fetch_for_writing_metrics.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
+using JasperFx;
+using JasperFx.Core.Reflection;
+using JasperFx.Events.Projections;
+using Marten.Services;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.FetchForWriting;
+
+/// <summary>
+/// Covers the opt-in marten.fetch_for_writing.events_replayed histogram: how many events a single
+/// FetchForWriting() call had to read back and fold, tagged by aggregate type and fetch plan.
+/// </summary>
+public class fetch_for_writing_metrics: OneOffConfigurationsContext
+{
+    private const string MetricName = "marten.fetch_for_writing.events_replayed";
+
+    [Fact]
+    public async Task a_live_aggregate_replays_its_whole_stream_on_every_fetch()
+    {
+        StoreOptions(opts => opts.OpenTelemetry.TrackFetchForWritingMetrics());
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<MeteredAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        using var recorder = new EventsReplayedRecorder(MetricName);
+
+        await using var session = theStore.LightweightSession();
+        await session.Events.FetchForWriting<MeteredAggregate>(streamId);
+
+        var measurement = recorder.Measurements.ShouldHaveSingleItem();
+        measurement.Value.ShouldBe(3);
+        measurement.FetchPlan.ShouldBe("Live");
+        measurement.AggregateType.ShouldBe(typeof(MeteredAggregate).FullNameInCode());
+
+        // ...and again on the very next fetch, which is the whole point of measuring this
+        await using var second = theStore.LightweightSession();
+        await second.Events.FetchForWriting<MeteredAggregate>(streamId);
+
+        recorder.Measurements.Select(x => x.Value).ShouldBe([3, 3]);
+    }
+
+    [Fact]
+    public async Task an_inline_aggregate_replays_nothing()
+    {
+        StoreOptions(opts =>
+        {
+            opts.OpenTelemetry.TrackFetchForWritingMetrics();
+            opts.Projections.Snapshot<MeteredAggregate>(SnapshotLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<MeteredAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        using var recorder = new EventsReplayedRecorder(MetricName);
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<MeteredAggregate>(streamId);
+
+        // The snapshot is current by construction, so the aggregate arrives fully built with
+        // zero events read back
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.ACount.ShouldBe(3);
+
+        var measurement = recorder.Measurements.ShouldHaveSingleItem();
+        measurement.Value.ShouldBe(0);
+        measurement.FetchPlan.ShouldBe("Inline");
+    }
+
+    [Fact]
+    public async Task nothing_is_recorded_without_the_opt_in()
+    {
+        // Note the absence of TrackFetchForWritingMetrics()
+        StoreOptions(_ => { });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<MeteredAggregate>(streamId, new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        using var recorder = new EventsReplayedRecorder(MetricName);
+
+        await using var session = theStore.LightweightSession();
+        await session.Events.FetchForWriting<MeteredAggregate>(streamId);
+
+        recorder.Measurements.ShouldBeEmpty();
+    }
+}
+
+public class MeteredAggregate: IRevisioned
+{
+    public Guid Id { get; set; }
+    public int Version { get; set; }
+    public int ACount { get; set; }
+
+    public void Apply(AEvent _)
+    {
+        ACount++;
+    }
+}
+
+/// <summary>
+/// Captures every measurement published to the named histogram on Marten's meter. MeterListener.Start()
+/// also replays instruments that were published before it started, so the store can be built first.
+/// </summary>
+internal sealed class EventsReplayedRecorder: IDisposable
+{
+    private readonly MeterListener _listener;
+
+    public EventsReplayedRecorder(string instrumentName)
+    {
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == "Marten" && instrument.Name == instrumentName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        _listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            // tags is a ReadOnlySpan, so it has to be read here rather than in a local function
+            string? aggregateType = null;
+            string? fetchPlan = null;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == OpenTelemetryOptions.AggregateTypeTag)
+                {
+                    aggregateType = tag.Value?.ToString();
+                }
+                else if (tag.Key == OpenTelemetryOptions.FetchPlanTag)
+                {
+                    fetchPlan = tag.Value?.ToString();
+                }
+            }
+
+            lock (Measurements)
+            {
+                Measurements.Add(new Measurement(value, aggregateType, fetchPlan));
+            }
+        });
+
+        _listener.Start();
+    }
+
+    public List<Measurement> Measurements { get; } = new();
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+    }
+
+    public record Measurement(long Value, string? AggregateType, string? FetchPlan);
+}

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.ExpectedVersion.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.ExpectedVersion.cs
@@ -11,6 +11,7 @@ using Marten.Exceptions;
 using Marten.Internal;
 using Marten.Internal.Sessions;
 using Marten.Linq.QueryHandlers;
+using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
 
@@ -75,6 +76,9 @@ internal partial class FetchAsyncPlan<TDoc, TId>
             // Read in any events from after the current state of the aggregate
             await reader.NextResultAsync(cancellation).ConfigureAwait(false);
             var events = await new ListQueryHandler<IEvent>(null, selector).HandleAsync(reader, session, cancellation).ConfigureAwait(false);
+            _events.Options.OpenTelemetry
+                .RecordEventsReplayed(events.Count, _aggregateTypeName, OpenTelemetryOptions.AsyncPlan);
+
             if (events.Any())
             {
                 document = await _aggregator.BuildAsync(events, session, document, id, _storage, cancellation).ConfigureAwait(false);

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.ForUpdate.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.ForUpdate.cs
@@ -11,6 +11,7 @@ using Marten.Exceptions;
 using Marten.Internal;
 using Marten.Internal.Sessions;
 using Marten.Linq.QueryHandlers;
+using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
 
@@ -108,6 +109,9 @@ internal partial class FetchAsyncPlan<TDoc, TId>
             // Read in any events from after the current state of the aggregate
             await reader.NextResultAsync(cancellation).ConfigureAwait(false);
             var events = await new ListQueryHandler<IEvent>(null, selector).HandleAsync(reader, session, cancellation).ConfigureAwait(false);
+            _events.Options.OpenTelemetry
+                .RecordEventsReplayed(events.Count, _aggregateTypeName, OpenTelemetryOptions.AsyncPlan);
+
             if (events.Any())
             {
                 document = await _aggregator.BuildAsync(events, session, document, id, _storage, cancellation).ConfigureAwait(false);

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.cs
@@ -19,6 +19,7 @@ internal partial class FetchAsyncPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId>
     private readonly IEventIdentityStrategy<TId> _identityStrategy;
     private readonly IDocumentStorage<TDoc, TId> _storage;
     private readonly string _versionSelectionSql;
+    private readonly string _aggregateTypeName = typeof(TDoc).FullNameInCode();
     private string? _initialSql;
 
     public FetchAsyncPlan(EventGraph events, IEventIdentityStrategy<TId> identityStrategy,

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.ExpectedVersion.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.ExpectedVersion.cs
@@ -10,6 +10,7 @@ using Marten.Internal;
 using Marten.Internal.Sessions;
 using Marten.Internal.Storage;
 using Marten.Linq.QueryHandlers;
+using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
 
@@ -61,6 +62,9 @@ internal partial class FetchInlinedPlan<TDoc, TId>
 
             await reader.NextResultAsync(cancellation).ConfigureAwait(false);
             var document = await handler.HandleAsync(reader, session, cancellation).ConfigureAwait(false);
+
+            _events.Options.OpenTelemetry
+                .RecordEventsReplayed(0, _aggregateTypeName, OpenTelemetryOptions.InlinePlan);
 
             // As an optimization, put the document in the identity map for later
             if (document != null && ((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.ForUpdate.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.ForUpdate.cs
@@ -9,6 +9,7 @@ using Marten.Internal;
 using Marten.Internal.Sessions;
 using Marten.Internal.Storage;
 using Marten.Linq.QueryHandlers;
+using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
 
@@ -85,6 +86,11 @@ internal partial class FetchInlinedPlan<TDoc, TId>
 
             await reader.NextResultAsync(cancellation).ConfigureAwait(false);
             var document = await handler.HandleAsync(reader, session, cancellation).ConfigureAwait(false);
+
+            // Always zero -- an Inline snapshot is up to date by construction, so nothing is replayed.
+            // Recorded anyway so the histogram can be compared across lifecycles.
+            _events.Options.OpenTelemetry
+                .RecordEventsReplayed(0, _aggregateTypeName, OpenTelemetryOptions.InlinePlan);
 
             // As an optimization, put the document in the identity map for later
             if (document != null && ((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.cs
@@ -22,6 +22,7 @@ internal partial class FetchInlinedPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TI
 {
     private readonly EventGraph _events;
     private readonly IEventIdentityStrategy<TId> _identityStrategy;
+    private readonly string _aggregateTypeName = typeof(TDoc).FullNameInCode();
 
     internal FetchInlinedPlan(EventGraph events, IEventIdentityStrategy<TId> identityStrategy)
     {

--- a/src/Marten/Events/Fetching/FetchLivePlan.ExpectedVersion.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.ExpectedVersion.cs
@@ -10,6 +10,7 @@ using Marten.Exceptions;
 using Marten.Internal;
 using Marten.Internal.Sessions;
 using Marten.Linq.QueryHandlers;
+using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
 
@@ -59,6 +60,8 @@ internal partial class FetchLivePlan<TDoc, TId>
 
             await reader.NextResultAsync(cancellation).ConfigureAwait(false);
             var events = await handler.HandleAsync(reader, session, cancellation).ConfigureAwait(false);
+            _telemetry.RecordEventsReplayed(events.Count, _aggregateTypeName, OpenTelemetryOptions.LivePlan);
+
             var document = await _aggregator.BuildAsync(events, session, default, id, _documentStorage, cancellation).ConfigureAwait(false);
 
             var stream = version == 0

--- a/src/Marten/Events/Fetching/FetchLivePlan.ForUpdate.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.ForUpdate.cs
@@ -9,6 +9,7 @@ using Marten.Exceptions;
 using Marten.Internal;
 using Marten.Internal.Sessions;
 using Marten.Linq.QueryHandlers;
+using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
 
@@ -71,6 +72,8 @@ internal partial class FetchLivePlan<TDoc, TId>
 
             await reader.NextResultAsync(cancellation).ConfigureAwait(false);
             var events = await handler.HandleAsync(reader, session, cancellation).ConfigureAwait(false);
+            _telemetry.RecordEventsReplayed(events.Count, _aggregateTypeName, OpenTelemetryOptions.LivePlan);
+
             var document = await _aggregator.BuildAsync(events, session, default, id, _documentStorage, cancellation).ConfigureAwait(false);
             if (document != null)
             {

--- a/src/Marten/Events/Fetching/FetchLivePlan.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.cs
@@ -10,6 +10,7 @@ using Marten.Exceptions;
 using Marten.Internal.Sessions;
 using Marten.Internal.Storage;
 using Marten.Linq.QueryHandlers;
+using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
 using System.Diagnostics.CodeAnalysis;
@@ -25,6 +26,8 @@ internal partial class FetchLivePlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> 
     private readonly IAggregator<TDoc, TId, IQuerySession> _aggregator;
     private readonly IIdentitySetter<TDoc, TId> _documentStorage;
     private readonly IEventIdentityStrategy<TId> _identityStrategy;
+    private readonly OpenTelemetryOptions _telemetry;
+    private readonly string _aggregateTypeName = typeof(TDoc).FullNameInCode();
 
     public FetchLivePlan(EventGraph events, IEventIdentityStrategy<TId> identityStrategy,
         IIdentitySetter<TDoc, TId> documentStorage)
@@ -33,6 +36,7 @@ internal partial class FetchLivePlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> 
 
         _identityStrategy = identityStrategy;
         _documentStorage = documentStorage;
+        _telemetry = events.Options.OpenTelemetry;
 
         var raw = events.Options.Projections.AggregatorFor<TDoc>();
 

--- a/src/Marten/Services/OpenTelemetryOptions.cs
+++ b/src/Marten/Services/OpenTelemetryOptions.cs
@@ -17,7 +17,62 @@ public sealed class OpenTelemetryOptions: JasperFx.OpenTelemetry.OpenTelemetryOp
     {
     }
 
+    /// <summary>
+    /// Tag carrying the .NET type name of the aggregate a fetch was for.
+    /// </summary>
+    internal const string AggregateTypeTag = "aggregate.type";
+
+    /// <summary>
+    /// Tag carrying which fetch plan served the call: Live, Inline or Async.
+    /// </summary>
+    internal const string FetchPlanTag = "fetch.plan";
+
+    internal const string LivePlan = "Live";
+    internal const string InlinePlan = "Inline";
+    internal const string AsyncPlan = "Async";
+
+    // Null until TrackFetchForWritingMetrics() opts in, so an application that never asks for these
+    // metrics pays a null check on the fetch path and nothing else.
+    private Histogram<long>? _eventsReplayed;
+
     internal List<Action<IChangeSet>> Applications { get; } = new();
+
+    /// <summary>
+    ///     Opt into the <c>marten.fetch_for_writing.events_replayed</c> histogram: how many events a
+    ///     single <c>FetchForWriting()</c> call had to read back and fold to reconstruct the aggregate,
+    ///     tagged by aggregate type and by which fetch plan served it.
+    /// </summary>
+    /// <remarks>
+    ///     This is the number behind the cost of the command handler workflow. A <c>Live</c> aggregate
+    ///     replays its whole stream on every fetch, an <c>Async</c> one replays only what the daemon has
+    ///     not caught up on yet, and an <c>Inline</c> one always replays zero. Recording all three lets you
+    ///     see what a lifecycle change would actually buy before making it.
+    /// </remarks>
+    public void TrackFetchForWritingMetrics()
+    {
+        _eventsReplayed ??= Meter.CreateHistogram<long>(
+            "marten.fetch_for_writing.events_replayed",
+            "events",
+            "Events read back and folded into the aggregate by a single FetchForWriting() call");
+    }
+
+    /// <summary>
+    ///     Called from the fetch plans. Both tag values are cached per plan instance by the caller, so a
+    ///     recorded fetch allocates nothing beyond the stack-based <see cref="TagList" />.
+    /// </summary>
+    internal void RecordEventsReplayed(int count, string aggregateTypeName, string fetchPlan)
+    {
+        var histogram = _eventsReplayed;
+        if (histogram is null || !histogram.Enabled)
+        {
+            return;
+        }
+
+        histogram.Record(count, new TagList
+        {
+            { AggregateTypeTag, aggregateTypeName }, { FetchPlanTag, fetchPlan }
+        });
+    }
 
     /// <summary>
     /// Add a custom counter that will be applied after a DocumentSession is committed


### PR DESCRIPTION
Part of #5225, but useful on its own.

`FetchForWriting()` costs whatever it takes to rebuild the aggregate, and that is however many events
Marten reads back and folds. That number is entirely determined by the aggregate's projection lifecycle
and is invisible from outside Marten today — there is no way to answer *"what would moving this aggregate
from Live to Inline actually save me?"* without guessing.

This adds a `Histogram<long>` named `marten.fetch_for_writing.events_replayed`, recorded once per
`FetchForWriting()` call, tagged with `aggregate.type` and `fetch.plan`.

Each plan has a characteristic shape, which is what makes one histogram enough:

| `fetch.plan` | What it records |
|---|---|
| `Live` | The full stream length, every time |
| `Async` | Only what the daemon has not projected yet — so it doubles as a per-fetch view of daemon lag |
| `Inline` | Always zero |

Recording the zeroes is deliberate: it is what makes the three lifecycles directly comparable on one
instrument, and the histogram's own count gives fetch frequency for free.

### Opt-in and non-breaking

- The instrument is not created at all until `OpenTelemetry.TrackFetchForWritingMetrics()` is called,
  mirroring the existing `TrackEventCounters()`. Leaving it off costs one null field read per fetch.
- When on, both tag values are cached per plan instance (and the plan is already cached per
  `(TDoc, TId)` pair), so a recorded fetch allocates nothing beyond the stack-based `TagList`.
- No behavior changes: recording sits next to the existing fold, never before a throw, and no existing
  signature moved.

### Coverage

The `ForUpdate` and expected-version paths of all three lifecycle plans. The read paths (`FetchLatest`)
and `FetchNaturalKeyPlan` are deliberately left out so the metric keeps meaning exactly what its name
says — happy to widen it (and rename) if you'd rather it covered every aggregate fetch.

### Tests

Three tests using a `MeterListener`: a `Live` aggregate recording its full stream length on every fetch, an
`Inline` one recording zero, and nothing at all being recorded without the opt-in. There was no existing
`MeterListener` pattern in the test suite, so the small recorder helper is new — happy to move it somewhere
more shared if you have a preference.

Also ran the full `EventSourcingTests.FetchForWriting` namespace as a regression check: 218/218 green.
