### PR TITLE
Log dead letter persistence failures instead of swallowing them

### DIFF
--- a/src/DaemonTests/Resiliency/Bug_5229_dead_letter_storage_failures.cs
+++ b/src/DaemonTests/Resiliency/Bug_5229_dead_letter_storage_failures.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using Marten;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.Resiliency;
+
+/// <summary>
+/// marten#5229: MartenDatabase's explicit IEventDatabase.StoreDeadLetterEventAsync() used to wrap its
+/// whole body in `catch (Exception) { }` with a "TODO -- something to log this?". That made two
+/// different failures indistinguishable from success:
+///
+/// 1. A wrong `storage` argument. The parameter is typed `object` because each store reads it
+///    differently, so nothing catches it at compile time -- and the cast exception went into the
+///    swallow, leaving a caller with a method that returned normally having written nothing.
+/// 2. A genuine write failure. The dead letter -- the only record that a projection skipped an
+///    event -- was dropped with no exception, no log line and nothing to grep for.
+/// </summary>
+public class Bug_5229_dead_letter_storage_failures: OneOffConfigurationsContext
+{
+    private static DeadLetterEvent aDeadLetter() =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            ProjectionName = "Trip",
+            ShardName = "All",
+            EventSequence = 42,
+            TenantId = "*DEFAULT*",
+            Timestamp = DateTimeOffset.UtcNow,
+            ExceptionType = "InvalidOperationException",
+            ExceptionMessage = "boom"
+        };
+
+    [Fact]
+    public async Task passing_something_other_than_the_document_store_throws()
+    {
+        var database = (IEventDatabase)theStore.Tenancy.Default.Database;
+
+        // An IDocumentSession is a perfectly plausible reading of a parameter called "storage" on a
+        // method that writes a row. Before #5229 this was a silent no-op.
+        var ex = await Should.ThrowAsync<ArgumentException>(async () =>
+            await database.StoreDeadLetterEventAsync(theSession, aDeadLetter(), CancellationToken.None));
+
+        ex.ParamName.ShouldBe("storage");
+        ex.Message.ShouldContain(nameof(DocumentStore));
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await database.StoreDeadLetterEventAsync(null, aDeadLetter(), CancellationToken.None));
+
+        // ...and, the actual symptom that made this so hard to find, nothing was written.
+        await using var query = theStore.QuerySession();
+        (await query.Query<DeadLetterEvent>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task the_document_store_is_what_the_method_actually_wants()
+    {
+        var database = (IEventDatabase)theStore.Tenancy.Default.Database;
+        var deadLetter = aDeadLetter();
+
+        await database.StoreDeadLetterEventAsync(theStore, deadLetter, CancellationToken.None);
+
+        await using var query = theStore.QuerySession();
+        var all = await query.Query<DeadLetterEvent>().ToListAsync(TestContext.Current.CancellationToken);
+
+        all.ShouldHaveSingleItem().EventSequence.ShouldBe(deadLetter.EventSequence);
+    }
+
+    [Fact]
+    public async Task a_failure_to_persist_is_logged_instead_of_being_swallowed()
+    {
+        var logger = new CapturingLogger();
+
+        // AutoCreate.None against a schema that was never built: the dead letter table does not
+        // exist, so SaveChangesAsync() fails. This stands in for the real cases -- a connection
+        // failure, or the table not having been created yet -- where a dead letter is genuinely lost.
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "dead_letters_5229_never_created";
+            opts.AutoCreateSchemaObjects = AutoCreate.None;
+            opts.DotNetLogger = logger;
+        });
+
+        var database = (IEventDatabase)store.Tenancy.Default.Database;
+        var deadLetter = aDeadLetter();
+
+        // Still does not throw -- the daemon must not fall over because it could not record a
+        // dead letter, and the RetryBlock around this call site has already had its say.
+        await database.StoreDeadLetterEventAsync(store, deadLetter, CancellationToken.None);
+
+        var error = logger.Errors.ShouldHaveSingleItem();
+
+        error.Exception.ShouldNotBeNull();
+        error.Message.ShouldContain("dead letter");
+        error.Message.ShouldContain(deadLetter.ProjectionName);
+        error.Message.ShouldContain(deadLetter.ShardName);
+        error.Message.ShouldContain(deadLetter.EventSequence.ToString());
+    }
+
+    /// <summary>
+    /// Only keeps what the assertions above need: the formatted message and the exception of every
+    /// Error-level entry.
+    /// </summary>
+    internal class CapturingLogger: ILogger
+    {
+        public List<(string Message, Exception? Exception)> Errors { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NoopScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel < LogLevel.Error) return;
+
+            lock (Errors)
+            {
+                Errors.Add((formatter(state, exception), exception));
+            }
+        }
+
+        private class NoopScope: IDisposable
+        {
+            public static readonly NoopScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -793,15 +793,37 @@ select count(*) from {Options.Events.DatabaseSchemaName}.mt_streams;
     async Task IEventDatabase.StoreDeadLetterEventAsync(object storage, DeadLetterEvent deadLetterEvent,
         CancellationToken token)
     {
+        // #5229: IEventDatabase types this parameter as `object` because each store reads it
+        // differently, so the compiler cannot check it and a wrong argument used to land in the
+        // catch below -- the method returned successfully having written nothing. A wrong `storage`
+        // is a programming error, not a transient storage failure: it is the one thing here that can
+        // never succeed on retry, so it must fail loudly at the first call.
+        if (storage is not DocumentStore store)
+        {
+            throw new ArgumentException(
+                $"Marten requires the {nameof(DocumentStore)} that owns this database, but was given {storage?.GetType().FullNameInCode() ?? "null"}.",
+                nameof(storage));
+        }
+
         try
         {
-            using var session = storage.As<DocumentStore>().LightweightSession(SessionOptions.ForDatabase(this));
+            await using var session = store.LightweightSession(SessionOptions.ForDatabase(this));
             session.Store(deadLetterEvent);
             await session.SaveChangesAsync(token).ConfigureAwait(false);
         }
-        catch (Exception)
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
         {
-            // TODO -- something to log this?
+            // Shutting down -- the daemon's dead letter block already gave up on this write.
+        }
+        catch (Exception e)
+        {
+            // #5229: the daemon must not fail because it could not record a dead letter, but losing
+            // one silently leaves an operator with a skipped event, no log line, and nothing to grep
+            // for. The projection has already advanced past the event by the time we get here.
+            Logger.LogError(e,
+                "Unable to persist a dead letter event for projection shard {ProjectionName}:{ShardName} at event sequence {EventSequence} of tenant {TenantId} in database {Database}. The record of this skipped event has been lost.",
+                deadLetterEvent.ProjectionName, deadLetterEvent.ShardName, deadLetterEvent.EventSequence,
+                deadLetterEvent.TenantId, Identifier);
         }
     }
 

--- a/src/Marten/Storage/MartenDatabase.cs
+++ b/src/Marten/Storage/MartenDatabase.cs
@@ -25,6 +25,7 @@ public partial class MartenDatabase: PostgresqlDatabase, IMartenDatabase, IProje
     private readonly StorageFeatures _features;
 
     private Lazy<SequenceFactory> _sequences;
+    private ILogger? _logger;
 
     public MartenDatabase(
         StoreOptions options,
@@ -64,6 +65,15 @@ public partial class MartenDatabase: PostgresqlDatabase, IMartenDatabase, IProje
     }
 
     public StoreOptions Options { get; }
+
+    /// <summary>
+    ///     #5229: the logger this database writes its own diagnostics to. Resolved on first use rather
+    ///     than in the constructor, because <see cref="StoreOptions.DotNetLogger" /> can still be assigned
+    ///     after the databases are built, and every current caller is a cold path well after that.
+    /// </summary>
+    internal ILogger Logger => _logger ??= Options.LogFactory?.CreateLogger<MartenDatabase>()
+        ?? Options.DotNetLogger
+        ?? NullLogger<MartenDatabase>.Instance;
 
     // #4500-family dedupe: IProjectionDatabase contract for the lifted JasperFx.Events
     // projection distributors. Identifier comes from the Weasel DatabaseBase; the URI is


### PR DESCRIPTION
Closes #5229.

`MartenDatabase`'s explicit `IEventDatabase.StoreDeadLetterEventAsync()` wrapped its whole body in `catch (Exception) { }` with a `// TODO -- something to log this?`. That made two different failures indistinguishable from success.

## A wrong `storage` argument

`IEventDatabase` types the parameter as `object` because each store reads it differently — Marten casts it to `DocumentStore`, Fisher ignores it and opens its own connection — so nothing catches a wrong one at compile time. Passing an `IDocumentSession`, a perfectly plausible reading of a parameter called "storage" on a method that writes a row, made `As<DocumentStore>()` throw straight into the swallow: the method returned successfully having written nothing, with no exception and no log line to grep for.

Now validated up front, with an `ArgumentException` that names what was actually passed. A wrong argument is a programming error, not a transient storage failure — it is the one thing in this method that can never succeed on retry, so it should be loud at the first call rather than silent forever.

## A genuine write failure

If `SaveChangesAsync` fails for any reason — the connection, the schema, the table not existing yet — the projection's only record that it skipped an event was dropped while the shard advanced as though it had been written. That is the case the `TODO` was about, and the more serious half.

Now logged at `Error` with the projection name, shard, event sequence and tenant. The write still does not throw: the daemon must not fall over because it could not record a dead letter.

`OperationCanceledException` during shutdown is separated out, so a normal stop does not log an error.

## Incidental

`MartenDatabase` gains an `internal ILogger Logger` resolved on first use rather than in the constructor, because `StoreOptions.DotNetLogger` can still be assigned after the databases are built and every caller of it is a cold path well after that.

## Tests

`src/DaemonTests/Resiliency/Bug_5229_dead_letter_storage_failures.cs` — three tests. Verified that the two covering new behavior fail against `master` and pass with the fix; the third (the `DocumentStore` happy path) documents the contract the reporter's helper got wrong and passes either way.

The full `DaemonTests` Resiliency folder (18 tests, including `when_skipping_events_in_daemon` and `dead_letter_count_read_tests`, which drive the real daemon dead-letter path end to end) is green.

## Not addressed here

The daemon's call site wraps this in a `RetryBlock<DeadLetterEvent>`, so the old blanket swallow also defeated the retry that would have saved a transient failure. Letting storage exceptions propagate into that retry instead of logging and returning is a larger behavioral decision than this issue asked for, so it is left alone — as is the tighter `storage` contract upstream in `JasperFx.Events`, which would fix the class of problem rather than this instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)