### PR TITLE
Bump JasperFx 2.47.0 -> 2.48.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -245,16 +245,23 @@
          #5148 needed no tenant-scoped session seam after all — OpenSession(IEventDatabase,
          tenantId) was already on the shared generic IEventStore<,> and TenancyStyle was already a
          shared JasperFx.MultiTenancy enum. Compliance sources only; behaviourally inert for the
-         shipping libraries. -->
-    <PackageVersion Include="JasperFx" Version="2.47.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.47.0" />
+         shipping libraries.
+         JasperFx 2.48.0: jasperfx#664 (#663) stamps stream identity on string-keyed appends, plus a
+         batch of source generator projection-dispatch fixes (jasperfx#652-#656): ShouldDelete now
+         composes with Create/Apply for the same event type, a genuine override of the dispatch
+         virtuals is told apart from a `new` hiding member, the evolver is handed the registered
+         projection instead of a shadow instance, `partial` is only required where the dispatcher
+         actually lives, and unregistered published types are reported rather than skipped in
+         silence. The dead opt-out for the removed lambda registration APIs is gone. -->
+    <PackageVersion Include="JasperFx" Version="2.48.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.48.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.47.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.48.0" />
     <!--
       Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
       the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
@@ -272,11 +279,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.47.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.48.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.47.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.48.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Moves all five pinned packages together: `JasperFx`, `JasperFx.Events`, `JasperFx.Events.ComplianceTests`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator`.

## What 2.48.0 carries

- **jasperfx#664 (#663)** — stream identity is stamped on string-keyed appends.
- **jasperfx#652–#656**, a batch of source generator projection-dispatch fixes:
  - `ShouldDelete` composes with `Create`/`Apply` for the same event type
  - a genuine override of the dispatch virtuals is told apart from a `new` hiding member
  - the evolver is handed the registered projection instead of a shadow instance
  - `partial` is only required where the dispatcher actually lives
  - unregistered published types are **reported** rather than skipped in silence
- The dead opt-out for the removed lambda registration APIs is gone.

## This is a pure bump

Unlike the 2.38.0 chain — which carried compliance wave 3 and did not compile without Marten adopting new fixture members and config knobs — 2.48.0 needed **no consumer adoption**. The full solution builds with **0 errors** across both TFMs and no new warnings, on the version pins alone.

`JasperFx 2.48.0` declares no Weasel dependency, so this stays Marten-only against Weasel 9.24.0. No cross-repo chain.

## Verification

`dotnet nuget locals http-cache --clear` before restoring, since a freshly published version otherwise resolves stale.

| Suite | Result |
|---|---|
| Full solution build (both TFMs) | 0 errors |
| EventSourcingTests (net9.0) | 1850 passed, 7 skipped, **0 failed** |
| DaemonTests (net9.0) | 304 passed, **0 failed** |
| CoreTests (net9.0) | 531 passed, 4 failed |

The 4 CoreTests failures are **not regressions**. I ran the same suite in the same environment against an unbumped `master` worktree and got an identical result — same 531 passes, same four failures by name:

- `Bug_4185_codegen_conflict_projection_with_secondary_store_dependency`
- `Bug_4187_ancillary_store_isolation`
- `rolling_range_partitioning.the_host_startup_pass_rolls_the_window_forward_and_retires_the_aged_partitions`
- `jasper_fx_mechanics.divergent_application_assembly_reuse_warning_is_buffered_and_logged`

These are the same four known environmental failures seen on the 2.38.0 bump. CI runs these projects in isolation and should be green.

The source-generator changes are the part of this bump most likely to surface something, which is why EventSourcingTests (1850 tests, including the 28 compliance suites) and DaemonTests were both run in full rather than sampled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)