### PR TITLE
Scope event masking and stream compaction to the calling tenant

### DIFF
--- a/docs/events/protection.md
+++ b/docs/events/protection.md
@@ -131,6 +131,23 @@ public static Task apply_masking_by_tenant(IDocumentStore store, string tenantId
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/removing_protected_information.cs#L556-L572' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_apply_masking_with_multi_tenancy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+::: warning
+`ForTenant()` scopes both the read and the write, but that was only true of the read before the
+fix for [#5234](https://github.com/JasperFx/marten/issues/5234).
+
+Under `Events.UseTenantPartitionedEvents` each tenant draws from its own event sequence, so
+`seq_id` is not unique across tenants. Masking and stream compaction keyed their `UPDATE` and
+`DELETE` on `seq_id` alone, which meant masking one tenant also overwrote the same-numbered event
+in every other tenant, and compacting one tenant's stream deleted the other tenants' events and
+left the calling tenant's `Compacted<T>` snapshot in their place. Nothing threw.
+
+If you ran masking or stream compaction against a store with `UseTenantPartitionedEvents` enabled
+on an affected version, the damage is already written and no code change can reverse it — restore
+the affected tenants' events from a backup or your archival storage. Stores that never enabled
+`UseTenantPartitionedEvents` are unaffected, because a single global sequence makes `seq_id`
+store-unique there.
+:::
+
 Here's a couple more facts you might need to know:
 
 * The masking rules can only be done at configuration time (as of right now)

--- a/src/Marten/Events/EventStore.StreamCompacting.cs
+++ b/src/Marten/Events/EventStore.StreamCompacting.cs
@@ -10,6 +10,7 @@ using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using JasperFx.Events.Aggregation;
 using JasperFx.Events.Protected;
+using Marten.Events.Operations;
 using Marten.Events.Protected;
 using Marten.Internal;
 using Marten.Internal.Operations;
@@ -199,6 +200,10 @@ internal class DeleteEventsOperation: IStorageOperation, NoDataReturnedCall
         builder.Append($"delete from {((IMartenSession)session).Options.Events.DatabaseSchemaName}.mt_events where seq_id = ANY(");
         builder.AppendParameter(_sequences);
         builder.Append(")");
+
+        // #5234: without this, compacting one tenant's stream permanently deletes the
+        // same-numbered events out of every other tenant's partition.
+        builder.AppendConjoinedTenantFilter(session);
     }
 
     public Type DocumentType => typeof(IEvent);

--- a/src/Marten/Events/Operations/ConjoinedEventFilter.cs
+++ b/src/Marten/Events/Operations/ConjoinedEventFilter.cs
@@ -1,0 +1,46 @@
+#nullable enable
+using JasperFx;
+using Marten.Internal;
+using Weasel.Postgresql;
+
+namespace Marten.Events.Operations;
+
+/// <summary>
+/// #5234: the tenant predicate every operation that keys an <c>mt_events</c> rewrite on
+/// <c>seq_id</c> has to carry.
+///
+/// <para>
+/// Under <see cref="EventGraph.UseTenantPartitionedEvents" /> each tenant draws from its own
+/// <c>mt_events_sequence_{suffix}</c>, so <c>seq_id</c> is NOT unique across tenants —
+/// <c>seq_id = 1</c> exists in every tenant's partition. A <c>where seq_id = ?</c> with no tenant
+/// predicate therefore rewrites, or deletes, the same-numbered event in every other tenant too.
+/// The read side of masking and compaction is correctly tenant-scoped, so the sequences collected
+/// belong to the calling tenant; only the write escaped.
+/// </para>
+///
+/// <para>
+/// Gated on <see cref="TenancyStyle.Conjoined" /> rather than on
+/// <c>UseTenantPartitionedEvents</c>, matching <see cref="SetEventTagsHstoreOperation" />, which is
+/// the one operation of this shape that already guarded itself. Conjoined-without-partitioning
+/// keeps a single global sequence, so there the predicate is a no-op that filters nothing — but one
+/// shape across every call site is worth more than the narrower condition, and it means a future
+/// mode that makes <c>seq_id</c> ambiguous is covered by construction.
+/// </para>
+/// </summary>
+internal static class ConjoinedEventFilter
+{
+    /// <summary>
+    ///     Appends <c>and tenant_id = ?</c> when the event store is conjoined. Call immediately after
+    ///     writing the <c>seq_id</c> predicate.
+    /// </summary>
+    public static void AppendConjoinedTenantFilter(this ICommandBuilder builder, IStorageSession session)
+    {
+        if (((IMartenSession)session).Options.Events.TenancyStyle != TenancyStyle.Conjoined)
+        {
+            return;
+        }
+
+        builder.Append(" and tenant_id = ");
+        builder.AppendParameter(session.TenantId);
+    }
+}

--- a/src/Marten/Events/Protected/OverwriteEventOperation.cs
+++ b/src/Marten/Events/Protected/OverwriteEventOperation.cs
@@ -4,6 +4,7 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Events;
+using Marten.Events.Operations;
 using Marten.Events.Schema;
 using Marten.Internal;
 using Marten.Internal.Operations;
@@ -36,6 +37,9 @@ internal class OverwriteEventOperation : IStorageOperation, NoDataReturnedCall
             session.Serializer.WriteToParameter(parameters[1], _e.Headers);
             parameters[2].NpgsqlDbType = NpgsqlDbType.Bigint;
             parameters[2].Value = _e.Sequence;
+
+            // #5234: seq_id alone is not unique across tenants under UseTenantPartitionedEvents
+            builder.AppendConjoinedTenantFilter(session);
         }
         else
         {
@@ -43,6 +47,9 @@ internal class OverwriteEventOperation : IStorageOperation, NoDataReturnedCall
             session.Serializer.WriteToParameter(parameters[0], _e.Data);
             parameters[1].NpgsqlDbType = NpgsqlDbType.Bigint;
             parameters[1].Value = _e.Sequence;
+
+            // #5234: seq_id alone is not unique across tenants under UseTenantPartitionedEvents
+            builder.AppendConjoinedTenantFilter(session);
         }
     }
 

--- a/src/Marten/Events/Protected/ReplaceEventOperation.cs
+++ b/src/Marten/Events/Protected/ReplaceEventOperation.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core;
 using JasperFx.Events;
+using Marten.Events.Operations;
 using Marten.Internal;
 using Marten.Internal.Operations;
 using NpgsqlTypes;
@@ -73,6 +74,10 @@ internal class ReplaceEventOperation<T> : IStorageOperation, NoDataReturnedCall 
 
         builder.Append(" where seq_id = ");
         builder.AppendParameter(_sequence);
+
+        // #5234: without this the Compacted<T> snapshot -- the calling tenant's whole aggregate
+        // state -- is written into every other tenant's same-numbered event.
+        builder.AppendConjoinedTenantFilter(session);
     }
 
     public Type DocumentType => typeof(IEvent);

--- a/src/Marten/Events/Schema/EventsTable.cs
+++ b/src/Marten/Events/Schema/EventsTable.cs
@@ -35,8 +35,16 @@ internal class EventsTable: Table
         // #4596 Session 1: PostgreSQL requires the partition column in every
         // unique constraint on a partitioned table, PK included. When
         // UseTenantPartitionedEvents is on, mark tenant_id as part of the PK
-        // alongside seq_id (which alone is already store-unique via the
-        // sequence — adding tenant_id is purely about satisfying the PG rule).
+        // alongside seq_id.
+        //
+        // #5234: tenant_id here is NOT merely about satisfying the PG rule, which is what this
+        // comment used to claim. Under UseTenantPartitionedEvents every tenant draws from its own
+        // mt_events_sequence_{suffix} (QuickAppendEventFunction), so seq_id is genuinely
+        // NON-unique across tenants — seq_id = 1 exists in every tenant's partition, and the
+        // composite (seq_id, tenant_id) is what actually identifies an event. Any query or
+        // rewrite of mt_events that keys on seq_id alone is a cross-tenant operation in this
+        // mode; that stale claim is the likely reason three of them shipped without a tenant
+        // predicate. See ConjoinedEventFilter.
         var tenantIdColumn = AddColumn<TenantIdColumn>();
         if (events.UseTenantPartitionedEvents)
         {

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_5234_cross_tenant_event_rewrites.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_5234_cross_tenant_event_rewrites.cs
@@ -1,0 +1,197 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Events.Projections;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Regressions;
+
+/// <summary>
+/// #5234: under <c>UseTenantPartitionedEvents</c> every tenant draws from its own
+/// <c>mt_events_sequence_{suffix}</c>, so <c>seq_id = 1</c> exists in EVERY tenant's partition.
+/// Three operations that rewrite <c>mt_events</c> keyed their WHERE on <c>seq_id</c> alone, so the
+/// write escaped the tenant the read had correctly scoped to:
+///
+/// <list type="bullet">
+/// <item>masking (<c>OverwriteEventOperation</c>) destroyed another tenant's payload and replaced
+/// it with the calling tenant's masked JSON — a cross-tenant write AND disclosure, in the feature
+/// that exists to prevent exactly that;</item>
+/// <item>compaction's delete (<c>DeleteEventsOperation</c>) permanently removed another tenant's
+/// events;</item>
+/// <item>compaction's snapshot write (<c>ReplaceEventOperation</c>) left the calling tenant's whole
+/// aggregate state sitting in the other tenant's stream.</item>
+/// </list>
+///
+/// Nothing threw in any of the three: all are <c>NoDataReturnedCall</c>.
+/// </summary>
+public class Bug_5234_cross_tenant_event_rewrites: PartitionedStoreContext
+{
+    protected override string SchemaPrefix => "tp_5234";
+
+    protected override void ConfigureStore(StoreOptions opts)
+    {
+        opts.Events.AddEventType<MaskProbeEvent>();
+        opts.Events.AddEventType<CompactProbeEvent>();
+
+        opts.Events.AddMaskingRuleForProtectedInformation<MaskProbeEvent>(x => x.Secret = "***");
+
+        opts.Projections.Snapshot<CompactProbeAggregate>(SnapshotLifecycle.Inline);
+    }
+
+    [Fact]
+    public async Task masking_one_tenant_must_not_rewrite_another_tenants_events()
+    {
+        await Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "alpha", "beta");
+
+        var alphaStream = Guid.NewGuid();
+        var betaStream = Guid.NewGuid();
+
+        await using (var session = Store.LightweightSession("alpha"))
+        {
+            session.Events.StartStream(alphaStream, new MaskProbeEvent { Secret = "alpha-secret" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = Store.LightweightSession("beta"))
+        {
+            session.Events.StartStream(betaStream, new MaskProbeEvent { Secret = "beta-secret" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // The collision this bug depends on: each tenant has its own sequence, so both events are
+        // seq_id 1. If this ever stops being true the test below stops proving anything.
+        (await sequenceOf(alphaStream, "alpha")).ShouldBe(await sequenceOf(betaStream, "beta"));
+
+        await Store.Advanced.ApplyEventDataMasking(x =>
+        {
+            x.ForTenant("alpha");
+            x.IncludeStream(alphaStream);
+        }, CancellationToken.None);
+
+        await using var query = Store.QuerySession("beta");
+        var betaEvent = (await query.Events.FetchStreamAsync(betaStream, token: TestContext.Current.CancellationToken)).Single();
+
+        betaEvent.Data.ShouldBeOfType<MaskProbeEvent>().Secret.ShouldBe("beta-secret",
+            "masking tenant alpha must not touch tenant beta's same-numbered event");
+    }
+
+    [Fact]
+    public async Task masking_still_masks_the_tenant_it_was_asked_to()
+    {
+        // The guard must not be so tight that the feature stops working.
+        await Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "alpha", "beta");
+
+        var alphaStream = Guid.NewGuid();
+
+        await using (var session = Store.LightweightSession("alpha"))
+        {
+            session.Events.StartStream(alphaStream, new MaskProbeEvent { Secret = "alpha-secret" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await Store.Advanced.ApplyEventDataMasking(x =>
+        {
+            x.ForTenant("alpha");
+            x.IncludeStream(alphaStream);
+        }, CancellationToken.None);
+
+        await using var query = Store.QuerySession("alpha");
+        var alphaEvent = (await query.Events.FetchStreamAsync(alphaStream, token: TestContext.Current.CancellationToken)).Single();
+
+        alphaEvent.Data.ShouldBeOfType<MaskProbeEvent>().Secret.ShouldBe("***");
+    }
+
+    [Fact]
+    public async Task compacting_one_tenants_stream_must_not_delete_another_tenants_events()
+    {
+        await Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "alpha", "beta");
+
+        var alphaStream = Guid.NewGuid();
+        var betaStream = Guid.NewGuid();
+
+        await using (var session = Store.LightweightSession("alpha"))
+        {
+            session.Events.StartStream<CompactProbeAggregate>(alphaStream,
+                new CompactProbeEvent(), new CompactProbeEvent(), new CompactProbeEvent());
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = Store.LightweightSession("beta"))
+        {
+            session.Events.StartStream<CompactProbeAggregate>(betaStream,
+                new CompactProbeEvent(), new CompactProbeEvent(), new CompactProbeEvent());
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = Store.LightweightSession("alpha"))
+        {
+            await session.Events.CompactStreamAsync<CompactProbeAggregate>(alphaStream);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = Store.QuerySession("beta");
+        var betaEvents = await query.Events.FetchStreamAsync(betaStream, token: TestContext.Current.CancellationToken);
+
+        // Pre-fix this was 1 -- beta's three events deleted, and the survivor was alpha's
+        // Compacted<CompactProbeAggregate> snapshot sitting in beta's stream.
+        betaEvents.Count.ShouldBe(3, "compacting alpha's stream must leave beta's events alone");
+        betaEvents.ShouldAllBe(x => x.Data is CompactProbeEvent);
+    }
+
+    [Fact]
+    public async Task compaction_still_compacts_the_stream_it_was_asked_to()
+    {
+        await Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "alpha", "beta");
+
+        var alphaStream = Guid.NewGuid();
+
+        await using (var session = Store.LightweightSession("alpha"))
+        {
+            session.Events.StartStream<CompactProbeAggregate>(alphaStream,
+                new CompactProbeEvent(), new CompactProbeEvent(), new CompactProbeEvent());
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = Store.LightweightSession("alpha"))
+        {
+            await session.Events.CompactStreamAsync<CompactProbeAggregate>(alphaStream);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = Store.QuerySession("alpha");
+        var alphaEvents = await query.Events.FetchStreamAsync(alphaStream, token: TestContext.Current.CancellationToken);
+
+        alphaEvents.Single().Data.ShouldBeOfType<Compacted<CompactProbeAggregate>>();
+    }
+
+    private async Task<long> sequenceOf(Guid streamId, string tenantId)
+    {
+        await using var query = Store.QuerySession(tenantId);
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+        return events[0].Sequence;
+    }
+}
+
+public class MaskProbeEvent
+{
+    public string Secret { get; set; } = string.Empty;
+}
+
+public class CompactProbeEvent
+{
+}
+
+public class CompactProbeAggregate
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+
+    public void Apply(CompactProbeEvent _) => Count++;
+}


### PR DESCRIPTION
Closes #5234. Thanks to @arnelirobles for a report that came with executed failing tests and the exact mechanism — this was diagnosed, not discovered.

## The defect

Under `Events.UseTenantPartitionedEvents` each tenant draws from its own `mt_events_sequence_{suffix}`, so **`seq_id` is not unique across tenants** — `seq_id = 1` exists in every tenant's partition. Three operations that rewrite `mt_events` keyed their `WHERE` on `seq_id` alone, so the write escaped the tenant the read had correctly scoped to.

| Operation | Effect on an uninvolved tenant |
|---|---|
| `OverwriteEventOperation` (masking) | Payload destroyed, replaced with the calling tenant's masked JSON |
| `DeleteEventsOperation` (compaction) | Events permanently deleted |
| `ReplaceEventOperation` (compaction) | Left holding the calling tenant's whole aggregate state as `Compacted<T>` |

None of the three raised an error — all are `NoDataReturnedCall`. Masking is the right-to-erasure path, so its failure is both a cross-tenant write and a cross-tenant disclosure, in the feature that exists to prevent exactly that.

## The fix

All three append the tenant predicate through a shared `ConjoinedEventFilter` helper.

**Gated on `TenancyStyle.Conjoined`**, matching `SetEventTagsHstoreOperation` — the one operation of this shape that already guarded itself. The reporter explicitly left this call open, offering the narrower `UseTenantPartitionedEvents` alternative. I went with Conjoined because conjoined-without-partitioning keeps a single global sequence, so there the predicate filters nothing and costs nothing, while one shape across every call site is easier to reason about and covers any future mode that makes `seq_id` ambiguous. Say the word if you'd rather have the narrow condition.

The stale comment in `EventsTable.cs` claiming `seq_id` "alone is already store-unique via the sequence" is corrected — it is false in this mode and is the likely reason all three shipped without a predicate.

## Tests

`src/TenantPartitionedEventsTests/Regressions/Bug_5234_cross_tenant_event_rewrites.cs`, 4 tests:

- masking one tenant must not rewrite another's events — **fails on master**
- compacting one tenant's stream must not delete another's events — **fails on master**
- masking still masks the tenant it was asked to — guards against over-tightening
- compaction still compacts the stream it was asked to — same

The first test also asserts that both tenants' events really do land on the same `seq_id`, so if that ever stops being true the test stops silently proving nothing.

Green: **TenantPartitionedEventsTests 242/244** (2 pre-existing skips), **EventSourcingTests 1850/1857** (7 pre-existing skips) — the latter covers the non-partitioned masking and compaction paths, confirming the predicate did not over-tighten them.

## Two things left open, deliberately

**Already-damaged stores.** The reporter asked what happens to stores that have been through this. Nothing in a predicate fix can reverse a masked or deleted event in the wrong tenant's partition. I've added a warning to `docs/events/protection.md` saying so and pointing at backups/archival storage; whether that also warrants a release note is your call.

**`MartenDatabase.MarkEventsAsSkipped`** has the same `where seq_id = ANY(...)` shape and is the fourth site the reporter flagged. I did **not** fix it here: it is public `IMartenDatabase` API taking only `long[] sequences` with no tenant, so scoping it means adding API surface (an overload, or a loud guard that leaves partitioned users unable to skip at all) rather than appending a predicate. That is an API decision rather than a bug fix, so it should be yours. Its only callers in the repo are tests and the `EventSkipping` doc sample — Marten's own daemon does not call it — so nothing internal is exposed to it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)