### PR TITLE
Re-bind compiled query parameters inside Select(), refuse what cannot be

### DIFF
--- a/src/LinqTests/Bugs/Bug_5233_compiled_query_select_clause_parameters.cs
+++ b/src/LinqTests/Bugs/Bug_5233_compiled_query_select_clause_parameters.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Exceptions;
+using Marten.Linq;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+/// <summary>
+/// #5233: compiled-query parameter discovery walks <c>topStatement.AllFilters()</c>, which
+/// enumerates WHERE clauses and never visits the select clause. Any parameter emitted into a
+/// <c>Select()</c> projection is therefore bound once, at plan time, from whichever
+/// <c>ICompiledQuery</c> instance built the plan, and every later execution of the cached plan
+/// silently reuses that first value.
+///
+/// <para>
+/// Three emitters can put a query member's value into a projection, and they do NOT all fail the
+/// same way — which is the point of covering all three here rather than asserting the mechanism
+/// once:
+/// </para>
+///
+/// <list type="number">
+/// <item><c>ConstantParameterSql</c> — a captured constant projected into
+/// <c>jsonb_build_object(...)</c> (9.18, #5011).</item>
+/// <item><c>ChildCollectionJsonPathCount</c> — <c>Count(predicate)</c> inside a projection
+/// (#5223), whose values ride inside a jsonb <c>vars</c> payload and so need a *filter* to be
+/// re-bound, not just a value match.</item>
+/// <item>The client-side <c>LambdaSelectClause</c> fallback, whose compiled delegate closes over
+/// the plan-time instance.</item>
+/// </list>
+/// </summary>
+public class Bug_5233_compiled_query_select_clause_parameters: BugIntegrationContext
+{
+    private async Task seedAsync()
+    {
+        theSession.Store(new Shop5233
+        {
+            Id = Guid.NewGuid(),
+            Name = "north",
+            Lines =
+            [
+                new ShopLine5233 { Product = "foo" },
+                new ShopLine5233 { Product = "foo" },
+                new ShopLine5233 { Product = "bar" }
+            ]
+        });
+
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task a_constant_projected_into_the_select_list_rebinds()
+    {
+        await seedAsync();
+
+        var first = await theSession.QueryAsync(new ShopWithLabel { Label = 111 });
+        var second = await theSession.QueryAsync(new ShopWithLabel { Label = 222 });
+
+        first.Single().Label.ShouldBe(111);
+        second.Single().Label.ShouldBe(222,
+            "the second execution of the cached plan must use its own Label, not the plan-time one");
+    }
+
+    [Fact]
+    public async Task a_count_predicate_inside_the_select_list_rebinds()
+    {
+        await seedAsync();
+
+        var foo = await theSession.QueryAsync(new ShopWithProductCount { Product = "foo" });
+        var bar = await theSession.QueryAsync(new ShopWithProductCount { Product = "bar" });
+
+        foo.Single().Count.ShouldBe(2);
+        bar.Single().Count.ShouldBe(1,
+            "the second execution of the cached plan must count its own Product, not the plan-time one");
+    }
+
+    [Fact]
+    public async Task a_client_side_projection_referencing_a_query_member_is_refused()
+    {
+        await seedAsync();
+
+        // Nothing can re-bind a delegate that was compiled once with the plan-time instance baked
+        // into it, so this is refused rather than silently answering with the first value forever.
+        var ex = await Should.ThrowAsync<InvalidCompiledQueryException>(async () =>
+            await theSession.QueryAsync(new ShopWithComputedLabel { Suffix = "-one" }));
+
+        ex.Message.ShouldContain("compiled once per plan");
+    }
+
+    [Fact]
+    public async Task a_client_side_projection_that_captures_nothing_still_works()
+    {
+        await seedAsync();
+
+        // The refusal above must be narrow. This projection also falls back to the client -- string
+        // concatenation is not translatable -- but it reads only the source document, so the
+        // compiled delegate is stable across invocations and the plan is perfectly cacheable.
+        var first = await theSession.QueryAsync(new ShopWithStaticLabel());
+        var second = await theSession.QueryAsync(new ShopWithStaticLabel());
+
+        first.Single().Label.ShouldBe("north!");
+        second.Single().Label.ShouldBe("north!");
+    }
+}
+
+public class Shop5233
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public List<ShopLine5233> Lines { get; set; } = new();
+}
+
+public class ShopLine5233
+{
+    public string Product { get; set; }
+}
+
+public class Shop5233Dto
+{
+    public string Name { get; set; }
+    public int Label { get; set; }
+    public int Count { get; set; }
+}
+
+public class Shop5233LabelDto
+{
+    public string Label { get; set; }
+}
+
+/// <summary>ConstantParameterSql: a captured int projected straight into jsonb_build_object.</summary>
+public class ShopWithLabel: ICompiledListQuery<Shop5233, Shop5233Dto>
+{
+    public int Label { get; set; }
+
+    public Expression<Func<IMartenQueryable<Shop5233>, IEnumerable<Shop5233Dto>>> QueryIs()
+    {
+        return q => q.Select(x => new Shop5233Dto { Name = x.Name, Label = Label });
+    }
+}
+
+/// <summary>ChildCollectionJsonPathCount: the predicate's value rides in a jsonb vars payload.</summary>
+public class ShopWithProductCount: ICompiledListQuery<Shop5233, Shop5233Dto>
+{
+    public string Product { get; set; }
+
+    public Expression<Func<IMartenQueryable<Shop5233>, IEnumerable<Shop5233Dto>>> QueryIs()
+    {
+        return q => q.Select(x => new Shop5233Dto
+        {
+            Name = x.Name, Count = x.Lines.Count(line => line.Product == Product)
+        });
+    }
+}
+
+/// <summary>LambdaSelectClause: string concatenation forces the client-side fallback.</summary>
+public class ShopWithComputedLabel: ICompiledListQuery<Shop5233, Shop5233LabelDto>
+{
+    public string Suffix { get; set; }
+
+    public Expression<Func<IMartenQueryable<Shop5233>, IEnumerable<Shop5233LabelDto>>> QueryIs()
+    {
+        return q => q.Select(x => new Shop5233LabelDto { Label = x.Name + Suffix });
+    }
+}
+
+/// <summary>Falls back to the client, but captures nothing — must stay allowed.</summary>
+public class ShopWithStaticLabel: ICompiledListQuery<Shop5233, Shop5233LabelDto>
+{
+    public Expression<Func<IMartenQueryable<Shop5233>, IEnumerable<Shop5233LabelDto>>> QueryIs()
+    {
+        return q => q.Select(x => new Shop5233LabelDto { Label = x.Name + "!" });
+    }
+}

--- a/src/Marten/Internal/CompiledQueries/QueryCompiler.cs
+++ b/src/Marten/Internal/CompiledQueries/QueryCompiler.cs
@@ -9,6 +9,7 @@ using Marten.Internal.Sessions;
 using Marten.Linq;
 using Marten.Linq.Includes;
 using Marten.Linq.Parsing;
+using Marten.Linq.SqlGeneration;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CompiledQueries;
@@ -219,9 +220,31 @@ internal class QueryCompiler
 
         var statements = parser.BuildStatements();
         var topStatement = statements.Top;
+        var selectClause = statements.MainSelector.SelectClause;
         topStatement.Apply(queryPlan);
 
-        var filters = topStatement.AllFilters().OfType<ICompiledQueryAwareFilter>().ToArray();
+        // #5233: a compiled query whose projection is applied on the client caches ONE compiled
+        // delegate, closing over the ICompiledQuery instance that built the plan. If that lambda
+        // reads anything off the instance, every later execution silently returns the plan-time
+        // value. Nothing can re-bind a baked-in closure, so refuse the plan instead.
+        if (selectClause is IClientSideProjectionSelectClause { ClosesOverCapturedState: true })
+        {
+            throw new InvalidCompiledQueryException(
+                $"Invalid compiled query type `{typeof(TDoc).FullNameInCode()}`. Its Select() projection cannot be translated to SQL, so Marten applies it on the client through a delegate that is compiled once per plan -- and it reads a value off the compiled query instance, which that delegate would freeze at plan time. Either simplify the projection so Marten can translate it (direct member access, and Count() over a child collection, both translate), or move the captured value into the Where() clause, or run this as a normal LINQ query instead of a compiled one.");
+        }
+
+        // #5233: the select clause can render parameters of its own, and AllFilters() only walks
+        // WHERE clauses. Most select-list parameters re-bind anyway through QueryMember's direct
+        // value match, but one whose value is buried in a composite parameter (a jsonpath vars
+        // payload) has no scalar to match and needs its own filter to reach MatchParameters.
+        var selectFragments = selectClause is IParameterBearingSelectClause parameterBearing
+            ? parameterBearing.SelectFragments()
+            : [];
+
+        var filters = topStatement.AllFilters()
+            .Concat(selectFragments)
+            .OfType<ICompiledQueryAwareFilter>()
+            .ToArray();
 
         queryPlan.MatchParameters(((IMartenSession)session).Options, filters);
 

--- a/src/Marten/Linq/Parsing/SelectParser.cs
+++ b/src/Marten/Linq/Parsing/SelectParser.cs
@@ -431,6 +431,30 @@ internal class NewObject : ISqlFragment
 
     public Dictionary<string, ISqlFragment> Members { get; } = new();
 
+    /// <summary>
+    /// #5233: every fragment in this projection, nested objects included. Compiled-query parameter
+    /// discovery needs to see these, because a fragment that carries a query member's value inside
+    /// a composite parameter (a jsonpath vars payload) can only be re-bound through its own
+    /// ICompiledQueryAwareFilter -- a plain value match against the parameter cannot find it.
+    /// </summary>
+    public IEnumerable<ISqlFragment> AllFragments()
+    {
+        foreach (var member in Members.Values)
+        {
+            if (member is NewObject nested)
+            {
+                foreach (var inner in nested.AllFragments())
+                {
+                    yield return inner;
+                }
+            }
+            else
+            {
+                yield return member;
+            }
+        }
+    }
+
     public void Apply(ICommandBuilder builder)
     {
         builder.Append(" jsonb_build_object(");

--- a/src/Marten/Linq/Parsing/SelectorVisitor.cs
+++ b/src/Marten/Linq/Parsing/SelectorVisitor.cs
@@ -151,9 +151,16 @@ public class SelectorVisitor: ExpressionVisitor
             var lambda = Expression.Lambda(selectExpression, parameter);
             var compiled = lambda.Compile();
 
+            // #5233: `compiled` closes over whatever ConstantExpressions the projection reads from.
+            // Harmless for an ordinary query -- the expression tree is rebuilt per call -- but a
+            // compiled query caches this delegate, so a captured value would be frozen at plan time.
+            // Record it here; QueryCompiler is the only caller that cares.
+            var closesOverCapturedState = CapturedStateDetector.Detect(selectExpression);
+
             _statement.SelectClause =
                 typeof(LambdaSelectClause<,>).CloseAndBuildAs<ISelectClause>(_statement.SelectClause.FromObject,
                     compiled,
+                    closesOverCapturedState,
                     _collection.ElementType,
                     selectExpression.Type);
         }
@@ -182,5 +189,40 @@ internal sealed class ParameterFinder: ExpressionVisitor
     {
         _found ??= node;
         return base.VisitParameter(node);
+    }
+}
+
+
+/// <summary>
+/// #5233: does this projection read a value off a captured object? A member access whose root is a
+/// <see cref="ConstantExpression" /> is a closure field or, inside <c>ICompiledQuery.QueryIs()</c>,
+/// a property of the compiled query instance. A static member (null root) and a plain literal are
+/// both fine -- neither varies between invocations.
+/// </summary>
+internal sealed class CapturedStateDetector: ExpressionVisitor
+{
+    private bool _found;
+
+    public static bool Detect(Expression expression)
+    {
+        var detector = new CapturedStateDetector();
+        detector.Visit(expression);
+        return detector._found;
+    }
+
+    protected override Expression VisitMember(MemberExpression node)
+    {
+        var root = node.Expression;
+        while (root is MemberExpression inner)
+        {
+            root = inner.Expression;
+        }
+
+        if (root is ConstantExpression)
+        {
+            _found = true;
+        }
+
+        return base.VisitMember(node);
     }
 }

--- a/src/Marten/Linq/SqlGeneration/IParameterBearingSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/IParameterBearingSelectClause.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System.Collections.Generic;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.SqlGeneration;
+
+/// <summary>
+/// #5233: implemented by a select clause that can render command parameters of its own.
+///
+/// <para>
+/// Compiled-query parameter discovery used to walk <c>Statement.AllFilters()</c> only, which
+/// enumerates WHERE clauses and never visits the select clause. Most select-list parameters
+/// survived that anyway, because <c>QueryMember.tryToFind</c> falls back to matching a query
+/// member's value directly against the parameter's value. What did NOT survive is a fragment whose
+/// value is buried inside a COMPOSITE parameter — a jsonpath <c>vars</c> payload, say — because
+/// there is no scalar to compare and re-binding has to go through the fragment's own
+/// <see cref="Marten.Internal.CompiledQueries.ICompiledQueryAwareFilter" />. Exposing the
+/// fragments here lets those reach <c>MatchParameters</c>.
+/// </para>
+/// </summary>
+internal interface IParameterBearingSelectClause
+{
+    IEnumerable<ISqlFragment> SelectFragments();
+}

--- a/src/Marten/Linq/SqlGeneration/LambdaSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/LambdaSelectClause.cs
@@ -20,6 +20,14 @@ namespace Marten.Linq.SqlGeneration;
 /// </summary>
 internal interface IClientSideProjectionSelectClause
 {
+    /// <summary>
+    /// #5233: true when the projection lambda reads a value off a captured object (in a compiled
+    /// query, that is the ICompiledQuery instance itself). The lambda is compiled ONCE, closing
+    /// over the instance that happened to build the plan, so a cached compiled-query plan would
+    /// keep returning the first invocation's values forever. QueryCompiler refuses to build a plan
+    /// in that case rather than silently serving wrong data.
+    /// </summary>
+    bool ClosesOverCapturedState { get; }
 }
 
 /// <summary>
@@ -38,11 +46,15 @@ internal class LambdaSelectClause<TSource, TResult>: ISelectClause, IScalarSelec
 {
     private readonly Func<TSource, TResult> _transform;
 
-    public LambdaSelectClause(string from, Func<TSource, TResult> transform)
+    public LambdaSelectClause(string from, Func<TSource, TResult> transform,
+        bool closesOverCapturedState = false)
     {
         FromObject = from;
         _transform = transform;
+        ClosesOverCapturedState = closesOverCapturedState;
     }
+
+    public bool ClosesOverCapturedState { get; }
 
     public string? DistinctOn { get; set; }
 

--- a/src/Marten/Linq/SqlGeneration/SelectDataSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/SelectDataSelectClause.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using JasperFx.Core;
 using Marten.Internal;
 using Marten.Linq.Parsing;
@@ -10,8 +11,16 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.SqlGeneration;
 
-internal class SelectDataSelectClause<T>: ISelectClause, IScalarSelectClause, IModifyableFromObject, IDistinctOnSelectClause where T : notnull
+internal class SelectDataSelectClause<T>: ISelectClause, IScalarSelectClause, IModifyableFromObject,
+    IDistinctOnSelectClause, IParameterBearingSelectClause where T : notnull
 {
+    /// <summary>
+    /// #5233: the fragments this projection renders into the SELECT list, so compiled-query
+    /// parameter discovery can include them alongside the WHERE-clause filters.
+    /// </summary>
+    public IEnumerable<ISqlFragment> SelectFragments()
+        => Selector is NewObject newObject ? newObject.AllFragments() : [Selector];
+
     public string? DistinctOn { get; set; }
 
     public SelectDataSelectClause(string from, ISqlFragment selector)


### PR DESCRIPTION
Closes #5233.

## One correction to the issue first

The issue lists three emitters as affected. I wrote a test for each **before** fixing anything, and they do not fail the same way — **one of them was never broken**:

| Emitter | Actual behavior on `master` |
|---|---|
| `ConstantParameterSql` (9.18, #5011) | ✅ **already re-binds correctly** |
| `ChildCollectionJsonPathCount` (#5223) | ❌ frozen at plan time |
| `LambdaSelectClause` client-side fallback | ❌ frozen at plan time |

`QueryMember.tryToFind` has a first branch that matches a query member's value **directly** against a parameter's value, and it does not care which clause produced the parameter. A plain scalar projected into `jsonb_build_object(...)` is found by that path. So the issue's claim that this has been silently wrong since 9.18 is not correct — good news, and worth knowing before anyone goes looking for damage in the field. The test stays as cover.

## What actually needed fixing

**`ChildCollectionJsonPathCount` — fixed properly.** Its values ride inside a composite jsonb `vars` payload, so there is no scalar for the direct match to compare, and re-binding has to go through the fragment's own `ICompiledQueryAwareFilter`. That filter was unreachable because `AllFilters()` only walks WHERE clauses. `SelectDataSelectClause` now exposes its fragments through a new internal `IParameterBearingSelectClause` seam and `QueryCompiler` concatenates them into the filter set before `MatchParameters`. `Count(predicate)` in a projection now works in a compiled query.

**`LambdaSelectClause` — refused, not fixed.** The delegate is compiled once with the plan-time instance closed over; nothing can re-bind that. `QueryCompiler` now throws `InvalidCompiledQueryException` at plan time, naming the three workarounds (simplify the projection so it translates, move the value into `Where()`, or use a normal LINQ query). Silent wrong data becomes an immediate error.

This is the stopgap half of the issue's two suggestions rather than making `LambdaSelectClause` rebindable. Reworking the client-side fallback to be per-invocation is a real change to the compiled-query core, and this release is already staged — happy to do it as a follow-up if you'd rather have the full fix.

## The refusal is deliberately narrow

`CapturedStateDetector` flags only a member access whose **root is a `ConstantExpression`** — a closure field, or a property of the `ICompiledQuery` instance. A static member has a null root and is not flagged; a plain literal is not a member access at all. So a client-side projection that reads only the source document keeps working in a compiled query, which matters because that describes every non-translatable projection people have in compiled queries today. There's an explicit test for it.

## Tests

`src/LinqTests/Bugs/Bug_5233_compiled_query_select_clause_parameters.cs`, 4 tests — one per emitter, plus the over-throw guard. Each compiled query is executed **twice with different values**, which is the only way this class of bug shows itself.

Green: **LinqTests 1434/1434**, **DocumentDbTests 1091/1092** (1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)