### PR TITLE
Release EF Core placeholder connections however the save ends

### DIFF
--- a/src/Marten.EntityFrameworkCore.Tests/Bug_5228_inline_projection_connection_leak.cs
+++ b/src/Marten.EntityFrameworkCore.Tests/Bug_5228_inline_projection_connection_leak.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten.Exceptions;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace Marten.EntityFrameworkCore.Tests;
+
+public record LeakProbePlaced(Guid OrderId, string CustomerName, decimal Amount);
+
+/// <summary>An event no projection here is interested in.</summary>
+public record UnrelatedThing(string What);
+
+public class LeakProbeProjection
+    : EfCoreMultiStreamProjection<CustomerOrderHistory, string, TestDbContext>
+{
+    public LeakProbeProjection()
+    {
+        Identity<LeakProbePlaced>(e => e.CustomerName);
+    }
+
+    public override CustomerOrderHistory? ApplyEvent(CustomerOrderHistory? snapshot,
+        string identity, IEvent @event, TestDbContext dbContext)
+    {
+        if (@event.Data is LeakProbePlaced placed && placed.CustomerName == "explode")
+        {
+            throw new InvalidOperationException("boom from inside the projection");
+        }
+
+        snapshot ??= new CustomerOrderHistory { Id = identity };
+        snapshot.TotalOrders++;
+        return snapshot;
+    }
+}
+
+/// <summary>
+/// #5228: the EF Core integration's placeholder NpgsqlConnection was released only at the end of
+/// <c>DbContextTransactionParticipant.BeforeCommitAsync</c>, i.e. only on the success path. Any
+/// route that never reached that line stranded a pooled connection:
+///
+/// <list type="bullet">
+/// <item>a projection that throws while applying;</item>
+/// <item>an optimistic concurrency failure on <c>SaveChangesAsync</c> — and note that an inline
+/// multi-stream projection has its storage built for events it will not even process, because
+/// the grouper's empty result is only known after the connection is already open;</item>
+/// <item>a throw from inside <c>BeforeCommitAsync</c> itself.</item>
+/// </list>
+///
+/// Each test drives one failing save many times and asserts the pool did not grow. Counting
+/// connections rather than inspecting internals is the point: the leak was only ever observable
+/// as pool exhaustion in production.
+/// </summary>
+public class Bug_5228_inline_projection_connection_leak: IAsyncLifetime
+{
+    private const string SchemaName = "efcore_leak_5228";
+
+    // Deliberately NOT small enough to exhaust. An earlier version of this test used a tiny pool
+    // and asserted that a connection could still be acquired -- which does reproduce the bug, but
+    // the unfixed failure mode is a multi-minute block on the pool rather than an assertion, and a
+    // hang is a miserable CI failure. Counting backend connections instead fails fast with a
+    // number that says what went wrong.
+    // Bounded well under the server's max_connections (100 by default) because this class runs in
+    // parallel with the rest of the suite. Steady state with the fix is 2; without it the loops
+    // below would otherwise happily eat every backend the server has and take unrelated tests
+    // down with them.
+    private const int MaxPoolSize = 30;
+    private const int Iterations = 20;
+
+    private DocumentStore theStore = null!;
+    private string theConnectionString = null!;
+    private string theObserverConnectionString = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theConnectionString = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            MaxPoolSize = MaxPoolSize,
+            ApplicationName = SchemaName,
+            Timeout = 5
+        }.ConnectionString;
+
+        // A separate identity so the observer below never counts itself.
+        theObserverConnectionString = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            ApplicationName = SchemaName + "_observer"
+        }.ConnectionString;
+
+        theStore = DocumentStore.For(opts =>
+        {
+            opts.Connection(theConnectionString);
+            opts.DatabaseSchemaName = SchemaName;
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Add(new LeakProbeProjection(), ProjectionLifecycle.Inline);
+        });
+
+        await theStore.Advanced.Clean.CompletelyRemoveAllAsync();
+
+        // Force the schema into existence once so the loops below only exercise the save path.
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(Guid.NewGuid().ToString(), new LeakProbePlaced(Guid.NewGuid(), "warmup", 1m));
+        await session.SaveChangesAsync();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        theStore?.Dispose();
+        return default;
+    }
+
+    [Fact]
+    public async Task a_throwing_projection_does_not_strand_the_placeholder_connection()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            await using var session = theStore.LightweightSession();
+            session.Events.StartStream(Guid.NewGuid().ToString(),
+                new LeakProbePlaced(Guid.NewGuid(), "explode", 1m));
+
+            await Should.ThrowAsync<Exception>(async () =>
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken));
+        }
+
+        await assertNoConnectionsWereStrandedAsync();
+    }
+
+    [Fact]
+    public async Task an_optimistic_concurrency_failure_does_not_strand_the_placeholder_connection()
+    {
+        // The reporter's second case, and the nastier one: these events are not the projection's
+        // at all. The grouper returns nothing so the projector never runs -- but the placeholder
+        // connection was already opened when the projection's storage was built.
+        for (var i = 0; i < Iterations; i++)
+        {
+            var streamKey = Guid.NewGuid().ToString();
+
+            await using (var seed = theStore.LightweightSession())
+            {
+                seed.Events.StartStream(streamKey, new UnrelatedThing("first"));
+                await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
+            }
+
+            await using var session = theStore.LightweightSession();
+
+            // Append at a version that is already taken -> optimistic concurrency failure on save
+            session.Events.Append(streamKey, 1, new UnrelatedThing("collides"));
+
+            await Should.ThrowAsync<Exception>(async () =>
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken));
+        }
+
+        await assertNoConnectionsWereStrandedAsync();
+    }
+
+    [Fact]
+    public async Task the_success_path_still_releases_exactly_once()
+    {
+        // Guard against the fix double-disposing, and against it releasing so late that a
+        // long-lived workload accumulates connections it has finished with.
+        for (var i = 0; i < Iterations; i++)
+        {
+            await using var session = theStore.LightweightSession();
+            session.Events.StartStream(Guid.NewGuid().ToString(),
+                new LeakProbePlaced(Guid.NewGuid(), $"customer-{i}", 1m));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await assertNoConnectionsWereStrandedAsync();
+    }
+
+    /// <summary>
+    /// A leaked placeholder is checked out of the pool forever and stays open on the server, so it
+    /// shows up in pg_stat_activity and never leaves. One leak per iteration means the backend
+    /// count tracks Iterations; the fix keeps it at the handful the pool actually reuses.
+    /// </summary>
+    private async Task assertNoConnectionsWereStrandedAsync()
+    {
+        await using var observer = new NpgsqlConnection(theObserverConnectionString);
+        await observer.OpenAsync(TestContext.Current.CancellationToken);
+
+        await using var cmd = observer.CreateCommand();
+        cmd.CommandText = "select count(*) from pg_stat_activity where application_name = @name";
+        cmd.Parameters.AddWithValue("name", SchemaName);
+
+        var open = (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+
+        // Measured: 2 with the fix, against 21 / 22 / 41 for the three cases without it. The bound
+        // is deliberately loose -- the property under test is that the count does not scale with
+        // the number of saves, not that it hits an exact number.
+        open.ShouldBeLessThan(Iterations,
+            $"{open} backend connections are still open after {Iterations} saves -- the EF Core placeholder connection is being stranded");
+    }
+}

--- a/src/Marten.EntityFrameworkCore/DbContextTransactionParticipant.cs
+++ b/src/Marten.EntityFrameworkCore/DbContextTransactionParticipant.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -11,13 +12,31 @@ namespace Marten.EntityFrameworkCore;
 /// the provided connection and transaction, then its tracked changes are flushed.
 /// The initial placeholder connection (used only for provider registration) is
 /// disposed after being swapped out.
+///
+/// <para>
+/// #5228: the placeholder connection used to be released ONLY on the success path, at the end of
+/// <see cref="BeforeCommitAsync"/>. Every route that never reached that line leaked it — a
+/// projection that threw while applying, an optimistic concurrency failure on
+/// <c>SaveChangesAsync</c>, or a throw from inside <c>BeforeCommitAsync</c> itself. Worse, the
+/// participant is created when the projection's storage is built, which for an inline
+/// multi-stream projection happens for EVERY <c>SaveChangesAsync</c> whose events reach the
+/// projection at all — including the very common case where the grouper returns nothing and the
+/// projector never runs. So a workload that merely has an EF Core inline projection registered
+/// leaked a pooled connection per failed save.
+/// </para>
+///
+/// <para>
+/// Release is now owned by disposal rather than by the commit path, so it happens exactly once
+/// however the save ends. <see cref="BeforeCommitAsync"/> still releases eagerly on success so a
+/// long-lived session does not hold connections it has finished with.
+/// </para>
 /// </summary>
-internal class DbContextTransactionParticipant<TDbContext>: ITransactionParticipant
+internal class DbContextTransactionParticipant<TDbContext>: ITransactionParticipant, IAsyncDisposable, IDisposable
     where TDbContext : DbContext
 {
-    public TDbContext DbContext { get; }
     private readonly NpgsqlConnection _initialConnection;
     private readonly string? _schemaName;
+    private bool _released;
 
     public DbContextTransactionParticipant(TDbContext dbContext, NpgsqlConnection initialConnection,
         string? schemaName = null)
@@ -26,6 +45,8 @@ internal class DbContextTransactionParticipant<TDbContext>: ITransactionParticip
         _initialConnection = initialConnection;
         _schemaName = schemaName;
     }
+
+    public TDbContext DbContext { get; }
 
     public async Task BeforeCommitAsync(NpgsqlConnection connection,
         NpgsqlTransaction transaction, CancellationToken token)
@@ -46,7 +67,33 @@ internal class DbContextTransactionParticipant<TDbContext>: ITransactionParticip
         // Flush all tracked changes into the same transaction
         await DbContext.SaveChangesAsync(token).ConfigureAwait(false);
 
-        // Dispose the initial placeholder connection
+        // The placeholder has been swapped out and is no longer referenced by the DbContext, so
+        // release it now rather than waiting for the session to be disposed. Disposal is
+        // idempotent, so the session's own teardown pass is a no-op after this.
+        await ReleaseAsync().ConfigureAwait(false);
+    }
+
+    public ValueTask DisposeAsync() => ReleaseAsync();
+
+    public void Dispose()
+    {
+        if (_released)
+        {
+            return;
+        }
+
+        _released = true;
+        _initialConnection.Dispose();
+    }
+
+    private async ValueTask ReleaseAsync()
+    {
+        if (_released)
+        {
+            return;
+        }
+
+        _released = true;
         await _initialConnection.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/Marten/Events/Daemon/Internals/ProjectionUpdateBatch.cs
+++ b/src/Marten/Events/Daemon/Internals/ProjectionUpdateBatch.cs
@@ -99,6 +99,26 @@ public class ProjectionUpdateBatch: IUpdateBatch, IAsyncDisposable, IDisposable,
 
         foreach (var page in _pages) page.ReleaseSession();
 
+        // #5228: the daemon's own path to the same leak. A participant registered by an EF Core
+        // projection holds an open placeholder connection that it only releases inside
+        // BeforeCommitAsync; a batch that fails before or during the flush must not strand it.
+        // Participant disposal is idempotent, so a clean commit makes this a no-op.
+        foreach (var participant in _transactionParticipants)
+        {
+            switch (participant)
+            {
+                case IAsyncDisposable asyncDisposable:
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                    break;
+
+                case IDisposable disposable:
+                    disposable.Dispose();
+                    break;
+            }
+        }
+
+        _transactionParticipants.Clear();
+
         if (_session != null)
         {
             await _session.DisposeAsync().ConfigureAwait(true);

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading.Tasks;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Events;
@@ -59,6 +60,38 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
     }
 
     internal IReadOnlyList<ITransactionParticipant> TransactionParticipants => _transactionParticipants;
+
+    // #5228: release anything a participant is holding open, however the save ended. Disposal on
+    // the participant side is idempotent, so a participant that already released itself on the
+    // success path of BeforeCommitAsync is a no-op here.
+    private protected override async ValueTask releaseTransactionParticipantsAsync()
+    {
+        foreach (var participant in _transactionParticipants)
+        {
+            switch (participant)
+            {
+                case IAsyncDisposable asyncDisposable:
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                    break;
+
+                case IDisposable disposable:
+                    disposable.Dispose();
+                    break;
+            }
+        }
+
+        _transactionParticipants.Clear();
+    }
+
+    private protected override void releaseTransactionParticipants()
+    {
+        foreach (var participant in _transactionParticipants.OfType<IDisposable>())
+        {
+            participant.Dispose();
+        }
+
+        _transactionParticipants.Clear();
+    }
 
     public void EjectAllPendingChanges()
     {

--- a/src/Marten/Internal/Sessions/QuerySession.Disposal.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Disposal.cs
@@ -16,6 +16,7 @@ public partial class QuerySession
         }
 
         _disposed = true;
+        releaseTransactionParticipants();
         _connection?.Dispose();
         GC.SuppressFinalize(this);
     }
@@ -28,12 +29,27 @@ public partial class QuerySession
         }
 
         _disposed = true;
+        await releaseTransactionParticipantsAsync().ConfigureAwait(false);
         if (_connection != null)
         {
             await _connection.DisposeAsync().ConfigureAwait(false);
         }
 
         GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// #5228: a transaction participant can hold unmanaged resources -- the EF Core integration
+    /// holds an open placeholder NpgsqlConnection -- that it only releases when its
+    /// BeforeCommitAsync runs. Every path where SaveChangesAsync throws before, or during, that
+    /// call would otherwise leak them. ITransactionParticipant deliberately does not require
+    /// IAsyncDisposable (it is public API and most participants hold nothing), so this is a
+    /// best-effort pass over the ones that opted in.
+    /// </summary>
+    private protected virtual ValueTask releaseTransactionParticipantsAsync() => default;
+
+    private protected virtual void releaseTransactionParticipants()
+    {
     }
 
     protected void assertNotDisposed()


### PR DESCRIPTION
Closes #5228. Credit to @markotny for the diagnosis and the repro — the mechanism described in the issue is exactly right.

## The defect

`DbContextTransactionParticipant` disposed its placeholder `NpgsqlConnection` on the **last line of `BeforeCommitAsync`** — the success path only. Every route that never reached that line stranded a pooled connection:

- a projection that throws while applying
- an optimistic concurrency failure on `SaveChangesAsync`
- a throw from inside `BeforeCommitAsync` itself

The reporter's second case is the one that makes this bite in ordinary use. An inline multi-stream projection has its storage built for events it will not process, because **the grouper's empty result is only known after the placeholder connection is already open**. So a workload that merely has an EF Core inline projection registered leaked a connection on every failed save, whether or not the projection had anything to do with it.

## The fix

Release is owned by **disposal** instead of by the commit path, so it happens exactly once however the save ends:

- `DbContextTransactionParticipant` implements `IAsyncDisposable`/`IDisposable` with an idempotent release. `BeforeCommitAsync` still releases eagerly on success, so a long-lived session doesn't hold connections it has finished with.
- `QuerySession` disposal runs a release pass over the session's transaction participants, overridden in `DocumentSessionBase` where the list actually lives.
- `ProjectionUpdateBatch.DisposeAsync` does the same for the async daemon, which reaches the identical participant by its own route.

`ITransactionParticipant` is **not** widened to require `IAsyncDisposable`. It is public API and most participants hold nothing, so the pass is best-effort over the ones that opt in — no breaking change for anyone implementing it.

This is a superset of the reporter's suggested "defer opening the placeholder until the grouper returns". Deferring narrows the window; it doesn't close it for a projection that genuinely runs and then fails. Deferring is still worth doing as an efficiency change — it would avoid opening a connection at all in the very common empty-grouper case — but that's a separate optimization, not the leak fix.

## Measured

20 saves per case, counting backends in `pg_stat_activity`:

| Case | Without fix | With fix |
|---|---|---|
| Throwing projection | 41 | 2 |
| Optimistic concurrency failure | 21 | 2 |
| Success path | 22 | 2 |

The success-path number moving was unexpected and worth flagging: it's the early-return branch in `SaveChanges`, where a session that has participants but no Marten changes never ran `BeforeCommitAsync` at all. So the success path leaked too, just less obviously.

## A note on the test

My first version proved the leak by exhausting a tiny pool and asserting a connection could still be acquired. That does reproduce it — but the unfixed failure mode is a **multi-minute block** on the pool rather than an assertion, and a hang is a miserable way for CI to tell you something broke. It counts backends instead and fails in about a second with the actual number in the message. Its pool is capped at 30 so the loops cannot starve a 100-connection server for tests running in parallel.

## Verification

`Marten.EntityFrameworkCore.Tests` **42/42**, `DocumentDbTests` **1091/1092** (1 pre-existing skip), `DaemonTests` **304/304**. `CoreTests` shows 531 passes and the same 4 known environmental failures (`Bug_4185`, `Bug_4187`, `rolling_range_partitioning` host startup, assembly-reuse warning) as a clean `master` worktree measured in the same environment.

One thing I'd rather report than bury: on the very first run of the EF Core suite after a fresh build I saw a single failure in `EfCoreMultiStreamProjectionAsyncTests.multi_stream_projection_creates_separate_aggregates_per_identity`, a test this change does not touch. It did not reproduce in five subsequent full runs, including after capping the pool. I believe it was my new class competing for connections before the cap, but I could not reproduce it to prove that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)