### PR TITLE
Fix store level CompactStreamAsync throwing NullReferenceException

### DIFF
--- a/src/EventSourcingTests/Aggregation/stream_compacting.cs
+++ b/src/EventSourcingTests/Aggregation/stream_compacting.cs
@@ -312,6 +312,54 @@ public class stream_compacting : OneOffConfigurationsContext
     }
 
     [Fact]
+    public async Task store_level_compaction_by_guid_identity()
+    {
+        StoreOptions(opts => opts.Projections.Snapshot<Letters>(SnapshotLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<Letters>(streamId, A(), B(), A(), C(), C(), D(), D(), A(), A());
+        await theSession.SaveChangesAsync();
+
+        // The store level overload resolves the aggregate type off the stream state
+        // and owns its own session, so it has to commit for itself
+        await ((IEventStore)theStore).CompactStreamAsync(streamId, CancellationToken.None);
+
+        await using var session = theStore.LightweightSession();
+        var events = await session.Events.FetchStreamAsync(streamId);
+        var compacted = events.Single().ShouldBeOfType<Event<Compacted<Letters>>>();
+        compacted.Version.ShouldBe(9);
+        compacted.Data.Snapshot.ACount.ShouldBe(4);
+        compacted.Data.Snapshot.BCount.ShouldBe(1);
+        compacted.Data.Snapshot.CCount.ShouldBe(2);
+        compacted.Data.Snapshot.DCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task store_level_compaction_by_string_identity()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Add<LetterCountsByStringProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamKey = Guid.NewGuid().ToString();
+        theSession.Events.StartStream<LetterCountsByString>(streamKey, A(), B(), A(), C(), C(), D(), D(), A(), A());
+        await theSession.SaveChangesAsync();
+
+        await ((IEventStore)theStore).CompactStreamAsync(streamKey, CancellationToken.None);
+
+        await using var session = theStore.LightweightSession();
+        var events = await session.Events.FetchStreamAsync(streamKey);
+        var compacted = events.Single().ShouldBeOfType<Event<Compacted<LetterCountsByString>>>();
+        compacted.Version.ShouldBe(9);
+        compacted.Data.Snapshot.ACount.ShouldBe(4);
+        compacted.Data.Snapshot.BCount.ShouldBe(1);
+        compacted.Data.Snapshot.CCount.ShouldBe(2);
+        compacted.Data.Snapshot.DCount.ShouldBe(2);
+    }
+
+    [Fact]
     public async Task end_to_end_string_identification_at_specified_version()
     {
         StoreOptions(opts =>

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx;
@@ -14,7 +15,6 @@ using JasperFx.Events.Aggregation;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Descriptors;
 using JasperFx.Events.Projections;
-using JasperFx.Events.Protected;
 using Marten.Events;
 using Marten.Events.Archiving;
 using Marten.Events.Daemon;
@@ -698,6 +698,33 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
         return (IReadOnlyEventStore)session.Events;
     }
 
+    // #5153 lifted both CompactStreamAsync<T> overloads off Marten.Events.IEventStoreOperations and
+    // onto JasperFx.Events.IEventStoreOperations, which left the reflective lookup here resolving to
+    // null on every call. Type.GetMethod does not walk an interface's base interfaces, and its
+    // closed-parameter-signature overload cannot match an open generic method definition either, so
+    // aiming at the moved interface would still have returned null. Reflecting at a private generic
+    // helper instead keeps the resolved signature one Marten owns, and leaves the SaveChangesAsync
+    // and the token that the session level overload expects from its caller in compiled code.
+    private static readonly MethodInfo _compactByStreamId =
+        typeof(DocumentStore).GetMethod(nameof(compactStreamAsync), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static readonly MethodInfo _compactByStreamKey =
+        typeof(DocumentStore).GetMethod(nameof(compactStreamByKeyAsync), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static async Task compactStreamAsync<T>(IDocumentSession session, Guid streamId, CancellationToken token)
+        where T : class
+    {
+        await session.Events.CompactStreamAsync<T>(streamId, x => x.CancellationToken = token).ConfigureAwait(false);
+        await session.SaveChangesAsync(token).ConfigureAwait(false);
+    }
+
+    private static async Task compactStreamByKeyAsync<T>(IDocumentSession session, string streamKey,
+        CancellationToken token) where T : class
+    {
+        await session.Events.CompactStreamAsync<T>(streamKey, x => x.CancellationToken = token).ConfigureAwait(false);
+        await session.SaveChangesAsync(token).ConfigureAwait(false);
+    }
+
     async Task IEventStore.CompactStreamAsync(Guid streamId, CancellationToken token)
     {
         await using var session = LightweightSession();
@@ -708,10 +735,8 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
                 $"Cannot compact stream {streamId}: stream not found or no aggregate type associated.");
         }
 
-        var method = typeof(Marten.Events.IEventStoreOperations).GetMethod(nameof(Marten.Events.IEventStoreOperations.CompactStreamAsync),
-            [typeof(Guid), typeof(Action<>).MakeGenericType(typeof(StreamCompactingRequest<>).MakeGenericType(state.AggregateType))]);
-        var genericMethod = method!.MakeGenericMethod(state.AggregateType);
-        await ((Task)genericMethod.Invoke(session.Events, [streamId, null])!).ConfigureAwait(false);
+        var genericMethod = _compactByStreamId.MakeGenericMethod(state.AggregateType);
+        await ((Task)genericMethod.Invoke(null, [session, streamId, token])!).ConfigureAwait(false);
     }
 
     async Task IEventStore.CompactStreamAsync(string streamKey, CancellationToken token)
@@ -724,9 +749,7 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
                 $"Cannot compact stream '{streamKey}': stream not found or no aggregate type associated.");
         }
 
-        var method = typeof(Marten.Events.IEventStoreOperations).GetMethod(nameof(Marten.Events.IEventStoreOperations.CompactStreamAsync),
-            [typeof(string), typeof(Action<>).MakeGenericType(typeof(StreamCompactingRequest<>).MakeGenericType(state.AggregateType))]);
-        var genericMethod = method!.MakeGenericMethod(state.AggregateType);
-        await ((Task)genericMethod.Invoke(session.Events, [streamKey, null])!).ConfigureAwait(false);
+        var genericMethod = _compactByStreamKey.MakeGenericMethod(state.AggregateType);
+        await ((Task)genericMethod.Invoke(null, [session, streamKey, token])!).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
# Fix store level `CompactStreamAsync` throwing `NullReferenceException`

## What breaks

`IEventStore.CompactStreamAsync` on `IDocumentStore` throws `NullReferenceException` on every call,
both the `Guid streamId` and the `string streamKey` overload. There is no partial success and no
diagnostic: the caller gets a bare NRE pointing into `DocumentStore.EventStore.cs`.

Against `main` at f686ad7 (9.24.0), on JasperFx.Events 2.48.0:

```
System.NullReferenceException : Object reference not set to an instance of an object.
   at Marten.DocumentStore.JasperFx.Events.IEventStore.CompactStreamAsync(Guid streamId, CancellationToken token)
      in src/Marten/DocumentStore.EventStore.cs:line 713
```

and the same at line 729 for the string overload.

This is the self-contained maintenance entry point: no session in the signature, a
`CancellationToken`, documented in JasperFx.Events as *"Compact a stream by aggregating events into
a snapshot. Resolves aggregate type from stream state."* It is the overload an operator or a
background job reaches for, and it cannot work at all. Every existing compaction test goes through
the session level `IEventStoreOperations.CompactStreamAsync<T>` overload and calls
`SaveChangesAsync` itself (`src/EventSourcingTests/Aggregation/stream_compacting.cs:214`), which is
why nothing covered this.

## The two causes

`src/Marten/DocumentStore.EventStore.cs:711` and `:727`, identical in both overloads:

```csharp
var method = typeof(Marten.Events.IEventStoreOperations).GetMethod(nameof(Marten.Events.IEventStoreOperations.CompactStreamAsync),
    [typeof(Guid), typeof(Action<>).MakeGenericType(typeof(StreamCompactingRequest<>).MakeGenericType(state.AggregateType))]);
var genericMethod = method!.MakeGenericMethod(state.AggregateType);
```

`method` is always null, and the null-forgiving operator dereferences it. Two independent reasons,
both measured against 2.48.0:

**1. The declaration moved.** #5153 lifted both `CompactStreamAsync<T>` overloads off
`Marten.Events.IEventStoreOperations` and onto `JasperFx.Events.IEventStoreOperations`. The comment
left behind at `src/Marten/Events/IEventOperations.cs:21-25` records the move. `Type.GetMethod` and
`GetMethods` on an *interface* do not walk base interfaces, so the derived interface finds nothing:

```
typeof(Marten.Events.IEventStoreOperations).GetMethods().Count(m => m.Name == "CompactStreamAsync")   => 0
typeof(JasperFx.Events.IEventStoreOperations).GetMethods().Count(m => m.Name == "CompactStreamAsync") => 2
```

**2. The overload used cannot match.** The lookup builds a *closed*
`Action<StreamCompactingRequest<TAggregate>>` and matches it against the *open generic definition*
`CompactStreamAsync<T>(Guid, Action<StreamCompactingRequest<T>>)`. The closed-parameter-signature
overload of `GetMethod` cannot match an open generic method definition. Measured: the same
`GetMethod` call against `JasperFx.Events.IEventStoreOperations` also returns null.

So a fix that corrects only the declaring type still returns null and still throws. Both have to go.

**3. A third defect sits behind the null**, and only surfaces once the lookup works. The session
level `CompactStreamAsync<T>` only *queues* a `ReplaceEventOperation<T>` and a
`DeleteEventsOperation` (`src/Marten/Events/EventStore.StreamCompacting.cs:28-32` and `:130-132`);
it does not commit. This method disposes its own `LightweightSession` and never calls
`SaveChangesAsync`, so a lookup-only fix compacts nothing, silently. The `token` was also dropped
after `FetchStreamStateAsync`, so the fetch, the aggregation and the archiver callback inside
`StreamCompactingExecution.ExecuteAsync` all ran uncancellable.

## The fix

Both overloads dispatch through a private generic helper on `DocumentStore` instead of reflecting
into the interface:

```csharp
private static readonly MethodInfo _compactByStreamId =
    typeof(DocumentStore).GetMethod(nameof(compactStreamAsync), BindingFlags.NonPublic | BindingFlags.Static)!;

private static async Task compactStreamAsync<T>(IDocumentSession session, Guid streamId, CancellationToken token)
    where T : class
{
    await session.Events.CompactStreamAsync<T>(streamId, x => x.CancellationToken = token).ConfigureAwait(false);
    await session.SaveChangesAsync(token).ConfigureAwait(false);
}
```

Both causes are gone because the reflected signature is one Marten owns rather than an interface in
a dependency, so the next declaration move cannot break this call site silently the way #5153 did.
It also puts the `SaveChangesAsync` and the `CancellationToken` back in ordinary compiled code
instead of trying to build an `Action<StreamCompactingRequest<T>>` reflectively for an aggregate
type only known at runtime. The `MethodInfo` lookups are resolved once into static readonly fields.

Nothing else changed. `using JasperFx.Events.Protected;` came out of
`DocumentStore.EventStore.cs` because `StreamCompactingRequest<>` was its only reference.

## What the tests prove

Two end to end tests in `src/EventSourcingTests/Aggregation/stream_compacting.cs`, beside the
existing session level ones:

- `store_level_compaction_by_guid_identity`
- `store_level_compaction_by_string_identity`

Each starts a nine event stream, calls `((IEventStore)theStore).CompactStreamAsync(...)`, then
re-reads the stream **through a fresh session**. That last part is deliberate: it fails on the
missing `SaveChangesAsync` as well as on the lookup, so cause 3 cannot regress back in unnoticed.
Both fail on `main` with the `NullReferenceException` quoted above.

## Verification

`src/EventSourcingTests` on net10.0 against Postgres 17: **1852 passed, 7 skipped, 0 failed**,
including the two new tests. Postgres came from the repo's own `docker-compose.yml`.

## One open question

I kept reflection here because the aggregate type is only known from stream state at runtime, and
narrowed it to a signature Marten controls. If you would rather remove the reflection entirely, say
by caching a `Func<IDocumentSession, Guid, CancellationToken, Task>` per aggregate type off the
projection registry, I am happy to switch it in this PR.
