### PR TITLE
#5239: the window-step loader must not claim a ceiling it never scanned

### DIFF
--- a/src/DaemonTests/Internals/Bug_5239_window_step_reports_unscanned_ceiling.cs
+++ b/src/DaemonTests/Internals/Bug_5239_window_step_reports_unscanned_ceiling.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.MultiTenancy;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten.Events.Daemon.Internals;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql.SqlGeneration;
+using Xunit;
+
+namespace DaemonTests.Internals;
+
+public class Bug_5239_window_step_reports_unscanned_ceiling: OneOffConfigurationsContext
+{
+    private const long WindowSize = 10_000;
+
+    /// <summary>
+    /// #5239: the window-step walk scans one 10,000-wide window at a time, but computed the page
+    /// ceiling against the full high-water mark instead of the window it actually scanned. The
+    /// consumer writes that ceiling as durable projection progress (EventRange(floor, page.Ceiling)
+    /// -> last_seq_id), so everything between the window ceiling and the high-water mark was skipped
+    /// permanently — no exception, no dead letter, and a shard reporting itself as caught up.
+    ///
+    /// The trigger is the ordinary case rather than an edge case: the window is 10,000 sequence
+    /// numbers wide, the batch size is 500, and this strategy exists precisely because matching
+    /// events are sparse, so "returned fewer than BatchSize events" — the branch that took
+    /// highWaterMark — is the expected outcome.
+    /// </summary>
+    [Fact]
+    public async Task window_step_ceiling_never_exceeds_the_window_it_scanned()
+    {
+        var (highWater, loader) = await arrangeSparseEventsAcrossTwoWindowsAsync();
+
+        var request = requestFrom(0, highWater);
+
+        var page = await loader.LoadWithWindowStepAsync(request, CancellationToken.None);
+
+        // Only the first window was scanned, so only the five events inside it can be reported...
+        page.Count.ShouldBe(5);
+
+        // ...and the ceiling must say so. Pre-fix this was highWater (11005), which handed the
+        // daemon progress over 6,000 sequence numbers of events it had never looked at.
+        page.Ceiling.ShouldBe(WindowSize);
+    }
+
+    /// <summary>
+    /// The other half of the contract: capping the ceiling is only correct if the walk actually
+    /// comes back for the rest. Feeding the reported ceiling back as the next floor — which is what
+    /// the daemon does — must surface the events above the first window.
+    /// </summary>
+    [Fact]
+    public async Task the_next_pass_picks_up_the_events_above_the_first_window()
+    {
+        var (highWater, loader) = await arrangeSparseEventsAcrossTwoWindowsAsync();
+
+        var first = await loader.LoadWithWindowStepAsync(requestFrom(0, highWater), CancellationToken.None);
+        var second = await loader.LoadWithWindowStepAsync(requestFrom(first.Ceiling, highWater), CancellationToken.None);
+
+        second.Count.ShouldBe(5);
+        second.Ceiling.ShouldBe(highWater);
+
+        // Between the two passes every matching event is accounted for, which is the property
+        // #5239 broke: pre-fix the first page claimed highWater and these five were never loaded.
+        (first.Count + second.Count).ShouldBe(10);
+    }
+
+    /// <summary>
+    /// A walk that genuinely scans every window up to the high-water mark and finds nothing may
+    /// still report highWater — that branch was correct and must stay that way, or the shard stalls
+    /// re-reading empty windows forever.
+    /// </summary>
+    [Fact]
+    public async Task exhausting_the_whole_range_still_reports_the_high_water_mark()
+    {
+        await resetEventsAsync();
+
+        // Events exist, but none of the type this loader filters on, so every window comes back empty.
+        theSession.Events.StartStream<Letters>(Guid.NewGuid(), new MTBEvent(), new MTBEvent());
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await setSequenceAsync(11_000);
+
+        var loader = loaderForMTAEvents();
+        var page = await loader.LoadWithWindowStepAsync(requestFrom(0, 11_005), CancellationToken.None);
+
+        page.Count.ShouldBe(0);
+        page.Ceiling.ShouldBe(11_005);
+    }
+
+    /// <summary>
+    /// Five matching events low in the sequence, then a jump past the first 10,000-wide window and
+    /// five more above it. Returns the high-water mark and a loader filtered to the matching type.
+    /// </summary>
+    private async Task<(long HighWater, EventLoader Loader)> arrangeSparseEventsAcrossTwoWindowsAsync()
+    {
+        await resetEventsAsync();
+
+        theSession.Events.StartStream<Letters>(Guid.NewGuid(), new MTAEvent(), new MTAEvent(), new MTAEvent(),
+            new MTAEvent(), new MTAEvent());
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Jump the sequence clear of the first window so the next append lands above it.
+        await setSequenceAsync(11_000);
+
+        theSession.Events.StartStream<Letters>(Guid.NewGuid(), new MTAEvent(), new MTAEvent(), new MTAEvent(),
+            new MTAEvent(), new MTAEvent());
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return (11_005, loaderForMTAEvents());
+    }
+
+    private EventLoader loaderForMTAEvents()
+    {
+        var filters = new ISqlFragment[] { new EventTypeFilter(theStore.Events, new[] { typeof(MTAEvent) }) };
+
+        // BatchSize well above the five events each window holds, so the page never fills the batch
+        // — the partial-page branch is exactly the one #5239 got wrong.
+        return new EventLoader(theStore, (MartenDatabase)theStore.Tenancy.Default.Database,
+            new AsyncOptions { BatchSize = 500 }, filters);
+    }
+
+    private static EventRequest requestFrom(long floor, long highWater) =>
+        new()
+        {
+            Floor = floor,
+            HighWater = highWater,
+            BatchSize = 500,
+            ErrorOptions = new ErrorHandlingOptions(),
+            Runtime = new NulloDaemonRuntime(),
+            Name = new ShardName("Letters", "All", 1)
+        };
+
+    private async Task resetEventsAsync()
+    {
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
+
+        // DeleteAllEventDataAsync is not required to rewind the sequence, and the assertions here
+        // are stated in absolute sequence numbers, so pin it rather than inherit whatever ran before.
+        await setSequenceAsync(1, isCalled: false);
+    }
+
+    private async Task setSequenceAsync(long value, bool isCalled = true)
+    {
+        var schema = theStore.Options.Events.DatabaseSchemaName;
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"select setval('{schema}.mt_events_sequence', {value}, {isCalled.ToString().ToLowerInvariant()});";
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        await conn.CloseAsync();
+    }
+}

--- a/src/Marten/Events/Daemon/Internals/EventLoader.cs
+++ b/src/Marten/Events/Daemon/Internals/EventLoader.cs
@@ -307,6 +307,12 @@ internal sealed class EventLoader: IEventLoader
     internal Task<EventPage> LoadWithSkipAheadAsync(EventRequest request, CancellationToken token)
         => loadWithSkipAheadAsync(request, token);
 
+    // #5239 test seam, same rationale as #4744's above: drive the window-step walk directly so a
+    // regression test can assert the ceiling it reports against the window it actually scanned,
+    // without having to provoke two real statement timeouts to escalate into it. Not used at runtime.
+    internal Task<EventPage> LoadWithWindowStepAsync(EventRequest request, CancellationToken token)
+        => loadWithWindowStepAsync(request, token);
+
     /// <summary>
     /// Skip-ahead strategy: find the MIN(seq_id) matching the type filter after the floor,
     /// then run the normal query starting from there. Avoids scanning non-matching events.
@@ -405,11 +411,20 @@ internal sealed class EventLoader: IEventLoader
             await using var session = (QuerySession)_store.QuerySession(SessionOptions.ForDatabase(Database));
             var page = new EventPage(request.Floor); // Use original floor for page tracking
 
+            // #5239: both counters exist to keep the page's ceiling honest about what this window
+            // actually scanned. skippedEvents mirrors loadNormalAsync so a window that filled the
+            // batch partly with skips is still recognized as full; rowsRead is what decides whether
+            // it is safe to advance past windowCeiling at all (see below).
+            var skippedEvents = 0;
+            var rowsRead = 0;
+
             await using var reader = await session.ExecuteReaderAsync(_command, token).ConfigureAwait(false);
             try
             {
                 while (await reader.ReadAsync(token).ConfigureAwait(false))
                 {
+                    rowsRead++;
+
                     try
                     {
                         var @event = await ((ISelector<IEvent>)_storage).ResolveAsync(reader, token).ConfigureAwait(false);
@@ -427,6 +442,7 @@ internal sealed class EventLoader: IEventLoader
                         if (request.ErrorOptions.SkipUnknownEvents)
                         {
                             request.Runtime.Logger.EventUnknown(e.EventTypeName);
+                            skippedEvents++;
                         }
                         else { throw; }
                     }
@@ -436,6 +452,7 @@ internal sealed class EventLoader: IEventLoader
                         {
                             request.Runtime.Logger.EventDeserializationException(e.InnerException!.GetType().Name!, e.Sequence);
                             await request.Runtime.RecordDeadLetterEventAsync(e.ToDeadLetterEvent(request.Name)).ConfigureAwait(false);
+                            skippedEvents++;
                         }
                         else { throw; }
                     }
@@ -446,19 +463,40 @@ internal sealed class EventLoader: IEventLoader
                 await reader.CloseAsync().ConfigureAwait(false);
             }
 
-            if (page.Count > 0)
+            // #5239: return on any row read, not just on a row that made it into the page. A window
+            // whose rows were all skipped (unknown type / deserialization failure) may have had the
+            // LIMIT truncate matching events further up the same window, so advancing past
+            // windowCeiling here would drop them exactly as the ceiling bug below did.
+            if (rowsRead > 0)
             {
-                page.CalculateCeiling(_batchSize, highWater, 0);
+                // #5239: windowCeiling, NOT highWater. The SELECT above is bounded by
+                // (currentFloor, windowCeiling], so that — not the full high-water mark — is the
+                // most this page can claim to have scanned. CalculateCeiling's contract is "if the
+                // page did not fill the batch, the query exhausted everything up to this bound";
+                // passing highWater asserted an exhaustion that never happened, and since the
+                // consumer writes Ceiling as durable projection progress, every matching event
+                // between windowCeiling and highWater was skipped permanently. A window returning
+                // fewer than _batchSize events is the ordinary case here — the window is 10,000
+                // sequence numbers wide and this strategy exists because matching events are
+                // sparse — so that was the common path, not an edge case.
+                //
+                // The full-batch branch stays correct either way, since Last().Sequence is always
+                // <= windowCeiling. Leaving (windowCeiling, highWater] for the next pass is the
+                // intended behaviour of a stepping strategy.
+                page.CalculateCeiling(_batchSize, windowCeiling, skippedEvents);
+
                 // Found events — reset strategy for next batch
                 _currentStrategy = LoadStrategy.Normal;
                 return page;
             }
 
-            // No events in this window — advance
+            // The window returned no rows at all, so nothing in it was elided by the LIMIT and it
+            // is safe to step over.
             currentFloor = windowCeiling;
         }
 
-        // Exhausted the entire range with no matching events
+        // Exhausted the entire range with no matching events. highWater is correct here, unlike in
+        // the loop above: the walk really did scan every window between request.Floor and it.
         var emptyPage = new EventPage(request.Floor);
         emptyPage.CalculateCeiling(_batchSize, highWater, 0);
         return emptyPage;


### PR DESCRIPTION
Fixes #5239.

`loadWithWindowStepAsync` scans one 10,000-wide window at a time — the `SELECT` is bounded by `(currentFloor, windowCeiling]` ([EventLoader.cs:403](https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Daemon/Internals/EventLoader.cs#L403)) — but computed the page ceiling against the **full** high-water mark ([line 451](https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Daemon/Internals/EventLoader.cs#L451)). `CalculateCeiling`'s contract is *"if the page did not fill the batch, the query exhausted everything up to this bound"*, so passing `highWater` asserted an exhaustion that never happened.

The consumer treats that ceiling as durable progress — `SubscriptionAgent` sets `LastEnqueued = page.Ceiling`, `EnqueueAsync` builds `EventRange(floor, page.Ceiling)`, and `UpdateProjectionProgress` writes it as `last_seq_id`. Every matching event between the window ceiling and the high-water mark was therefore **skipped permanently**: no exception, no dead-letter row, and a shard reporting itself as caught up while its read model is missing most of its data.

The trigger is the ordinary case rather than an edge case. The window is 10,000 sequence numbers wide, the batch size is 500, and this strategy exists *because* matching events are sparse — so "returned fewer than `BatchSize` events", the branch that took `highWaterMark`, is the expected outcome. It is only reached after two consecutive statement timeouts, i.e. on exactly the large, busy stores the strategy was added for.

By contrast `loadNormalAsync` is genuinely bounded by `request.HighWater` ([line 237](https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Daemon/Internals/EventLoader.cs#L237)), so its identical call at line 292 is correct. Only the window-step copy broke the contract.

## Changes

**1. Pass `windowCeiling` rather than `highWater`** — the reporter's suggested fix. Correct in both branches, since a full batch yields `Last().Sequence <= windowCeiling`. Leaving `(windowCeiling, highWater]` to the next pass is what a stepping strategy is supposed to do.

**2. Accumulate `skippedEvents`.** `loadNormalAsync` counts skipped unknown/undeserializable events and feeds them to `CalculateCeiling` so a batch filled partly by skips is still recognized as full. The window-step copy never had the counter at all and passed a literal `0`, so it misclassified those windows too.

**3. Advance on rows read, not on `page.Count`.** A window whose rows were *all* skipped leaves `Count` at 0. Stepping past `windowCeiling` there drops any matching events the `LIMIT` truncated further up the same window — the same silent skip in a narrower dress.

## What deliberately did *not* change

The exhaustion path at the end of the method keeps `highWater`, and that is correct: the walk really did scan every window between `request.Floor` and the high-water mark, and capping it would stall the shard re-reading empty windows forever. A mechanical replacement of `highWater` throughout this method would be a regression, so `exhausting_the_whole_range_still_reports_the_high_water_mark` pins the branch.

One residual is left alone on purpose: if an entire `_batchSize` of *consecutive* rows is skipped, `CalculateCeiling`'s `Count > 0` guard still falls back to the bound it was handed. That lives in `JasperFx.Events` and affects `loadNormalAsync` identically; forcing progress is a deliberate trade there, since the alternative is a shard that re-reads the same undeserializable rows forever. Worth a JasperFx issue rather than a local divergence.

## Tests

`src/DaemonTests/Internals/Bug_5239_window_step_reports_unscanned_ceiling.cs`, driven through a new `LoadWithWindowStepAsync` internal seam following the #4744 precedent — no need to provoke two real statement timeouts to escalate into the strategy.

Verified by reverting the two behavioral lines and re-running:

| Test | On master | With fix |
|---|---|---|
| `window_step_ceiling_never_exceeds_the_window_it_scanned` | ❌ `page.Ceiling` was `11005`, expected `10000` | ✅ |
| `the_next_pass_picks_up_the_events_above_the_first_window` | ❌ `second.Count` was `0`, expected `5` | ✅ |
| `exhausting_the_whole_range_still_reports_the_high_water_mark` | ✅ (guard — must pass both ways) | ✅ |

The second one is the data loss made concrete: feeding the reported ceiling back as the next floor recovers **none** of the five events above the first window on master.

Full `DaemonTests.Internals` namespace green on net9.0 (68/68), including the neighbouring `Bug_4720` and `Bug_4744` EventLoader regressions.

Reported by @arnelirobles from [barakoCMS](https://github.com/BaryoDev/barakoCMS), with the mechanism traced and a failing test already in hand — the diagnosis in the issue was correct as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)