### PR TITLE
#5241: adopt JasperFx 2.49.0 and replay ValueTypes in the document compliance fixture

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -252,16 +252,26 @@
          virtuals is told apart from a `new` hiding member, the evolver is handed the registered
          projection instead of a shadow instance, `partial` is only required where the dispatcher
          actually lives, and unregistered published types are reported rather than skipped in
-         silence. The dead opt-out for the removed lambda registration APIs is gone. -->
-    <PackageVersion Include="JasperFx" Version="2.48.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.48.0" />
+         silence. The dead opt-out for the removed lambda registration APIs is gone.
+         JasperFx 2.49.0: jasperfx#665/#666 (marten#5241) — IDocumentReadOperations gains
+         LoadAsync<T>(object id), so store-agnostic code can load a document keyed by a strong-typed
+         identifier. Marten needs NO product change for it: IQuerySession already declares the
+         overload (IQuerySession.cs) and QuerySession implements it publicly, dispatching on
+         id.GetType() — Marten is in fact the store the member was modeled on. It ships with a
+         default implementation (unbox a Guid or string and forward, else NotSupportedException) so
+         Polecat and Fisher can take the bump before adopting it, which means the enforcement lives
+         in DocumentLoadAndStoreCompliance rather than the compiler. What Marten does owe is the
+         fixture line below: DocumentComplianceConfig gained ValueTypes/RegisterValueType<T>() and a
+         fixture that does not replay it fails the two strong-typed facts at runtime. -->
+    <PackageVersion Include="JasperFx" Version="2.49.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.49.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.48.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.49.0" />
     <!--
       Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
       the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
@@ -279,11 +289,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.48.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.49.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.48.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.49.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/Marten.Testing/Harness/MartenDocumentComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenDocumentComplianceFixture.cs
@@ -49,6 +49,23 @@ public class MartenDocumentComplianceFixture: DocumentStorageComplianceFixture
             options.Storage.MappingFor(documentType);
         }
 
+        // jasperfx#665/#666 (#5241). ValueTypes carries the strong-typed identifier wrappers the
+        // suite's documents are keyed by, which LoadAsync<T>(object) needs resolved — the one member
+        // of the document contract whose behavior depends on store configuration the contract itself
+        // does not carry.
+        //
+        // Replayed for the same reason as DocumentTypes above, and with the same status: not
+        // strictly required. Marten's identity convention already discovers a strong-typed id from
+        // the document's Id property, which is how every value type these suites currently declare
+        // reaches the store — the four suites pass with this loop deleted, so do not read it as
+        // load-bearing. It is here because the fixture's job is to replay the config it was handed
+        // rather than to rely on a convention reaching the same answer, and a value type that is
+        // NOT a document's Id (a query parameter, a nested identity) would not be discovered.
+        foreach (var valueType in config.ValueTypes)
+        {
+            options.RegisterValueType(valueType);
+        }
+
         _store = new DocumentStore(options);
 
         await _store.Storage.ApplyAllConfiguredChangesToDatabaseAsync().ConfigureAwait(false);


### PR DESCRIPTION
Closes #5241.

[jasperfx#665](https://github.com/JasperFx/jasperfx/issues/665) / [jasperfx#666](https://github.com/JasperFx/jasperfx/pull/666) add `IDocumentReadOperations.LoadAsync<T>(object id)`, so store-agnostic code can load a document keyed by a strong-typed identifier. Previously only the `Guid` and `string` overloads existed, and passing the wrapped primitive compiled and then threw the store's id-type mismatch at runtime.

All five JasperFx pins move `2.48.0` → `2.49.0` together. `2.49.0` contains exactly one change (jasperfx `fb418f9..80c44f5` is #666 plus the version commit), so the blast radius is that member and the compliance suites around it.

## Marten needs no product change

`IQuerySession` already declares the overload and `QuerySession` implements it publicly, dispatching on `id.GetType()` into `StorageFor<T, TId>()`. Marten is in fact the store the member was modeled on, so it satisfies the new contract member implicitly — the same way the `Guid` and `string` overloads already do.

Worth noting #666 shipped the member with a **default implementation** (unbox a `Guid` or `string` and forward, else `NotSupportedException`) rather than an abstract one, so Polecat and Fisher can take the bump before adopting it. That moves enforcement from the compiler to `DocumentLoadAndStoreCompliance` — but it changes nothing for Marten, which overrides it either way.

## The fixture loop — and a correction to the issue

The fixture replays `config.ValueTypes` alongside the existing `DocumentTypes` loop. The issue predicted this would be load-bearing:

> the fixture builds fine without it and then fails `store_and_load_by_strong_typed_identity` and `load_returns_null_for_a_missing_strong_typed_identity` at runtime, which reads like a Marten bug rather than a missing fixture line.

**That does not hold for Marten.** I checked by deleting the loop and re-running rather than taking it on faith: all four suites still pass, 45/45. The suites key their strong-typed document off a `public CouponCode Id { get; set; }` property, and Marten's identity convention discovers a strong-typed id from the `Id` property without being told — which is exactly the "stores that discover value types automatically can ignore it" case the upstream doc comment allows for.

The loop is kept anyway, and the comment in the fixture says plainly that it is not load-bearing, so nobody later reads it as a guard it isn't. It earns its place for two narrower reasons: replaying the config the fixture was handed is more honest than relying on a convention to arrive at the same answer, and a value type that is *not* a document's `Id` (a query parameter, a nested identity) would not be discovered by that convention.

## The predicted CS0108 does appear

`IQuerySession.LoadAsync<T>(object, CancellationToken)` now hides the inherited member ([IQuerySession.cs:152](https://github.com/JasperFx/marten/blob/master/src/Marten/IQuerySession.cs#L152)), joining the `Guid` and `string` overloads that already did at lines 143 and 179.

Left un-`new`'d. The issue called this a tidiness call between "all three or none" — but the family is larger than three: `IDocumentOperations` (5 sites), `IDocumentSession` and `IDocumentStore` all hide inherited members the same way, none of them `new`'d. Adding the keyword to only the `LoadAsync` overloads would be the inconsistent choice. Nothing in `Directory.Build.props` treats warnings as errors.

## Verification

- Four document compliance suites: **45/45 green**
- Full `EventSourcingTests`: **1860 total, 0 failed**, 7 skipped (net9.0)
- Whole solution builds clean on net9.0 and net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)