### PR TITLE
Assert stream identity on the CompactStreamAsync overloads

### DIFF
--- a/src/EventSourcingTests/Aggregation/stream_compacting_identity_mismatch.cs
+++ b/src/EventSourcingTests/Aggregation/stream_compacting_identity_mismatch.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Aggregation;
+
+/// <summary>
+/// Follow-up to #5240. Compacting is identity-sensitive — <c>StreamCompactingRequest</c> carries one
+/// of StreamId/StreamKey and <c>ExecuteAsync</c> branches on the store's configured
+/// <see cref="StreamIdentity" /> rather than on which overload was called — but unlike every other
+/// identity-sensitive entry point (appends, FetchForWriting) it never asserted the two agreed.
+/// </summary>
+/// <remarks>
+/// The two failure modes were not symmetric, which is why both directions are pinned here rather
+/// than just the one that throws:
+/// <list type="bullet">
+/// <item>string overload on a Guid store: <c>InvalidOperationException("Nullable object must have a
+/// value")</c> out of <c>request.StreamId!.Value</c> — an error naming nothing actionable.</item>
+/// <item>Guid overload on a string store: the AsString branch read a null StreamKey, matched no
+/// stream, and returned at <c>if (!events.Any()) return;</c> — compaction <em>silently did
+/// nothing</em>, which is the worse of the two.</item>
+/// </list>
+/// </remarks>
+public class stream_compacting_identity_mismatch: OneOffConfigurationsContext
+{
+    public AEvent A() => new();
+    public BEvent B() => new();
+    public CEvent C() => new();
+
+    [Fact]
+    public async Task session_level_string_overload_against_guid_store_is_rejected()
+    {
+        StoreOptions(opts => opts.Projections.Snapshot<Letters>(SnapshotLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<Letters>(streamId, A(), B(), C());
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var session = theStore.LightweightSession();
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => session.Events.CompactStreamAsync<Letters>(streamId.ToString()));
+
+        ex.Message.ShouldBe("This Marten event store is configured to identify streams with Guids");
+    }
+
+    [Fact]
+    public async Task session_level_guid_overload_against_string_store_is_rejected()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Add<LetterCountsByStringProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamKey = Guid.NewGuid().ToString();
+        theSession.Events.StartStream<LetterCountsByString>(streamKey, A(), B(), C());
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var session = theStore.LightweightSession();
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => session.Events.CompactStreamAsync<LetterCountsByString>(Guid.NewGuid()));
+
+        ex.Message.ShouldBe("This Marten event store is configured to identify streams with strings");
+    }
+
+    /// <summary>
+    /// The silent branch, pinned explicitly: the stream must still hold all three of its original
+    /// events. Pre-fix this call returned successfully having compacted nothing, so a caller had no
+    /// way to tell a no-op from a completed compaction.
+    /// </summary>
+    [Fact]
+    public async Task the_silently_ignored_mirror_case_leaves_the_stream_untouched_and_now_throws()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Add<LetterCountsByStringProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamKey = Guid.NewGuid().ToString();
+        theSession.Events.StartStream<LetterCountsByString>(streamKey, A(), B(), C());
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var session = theStore.LightweightSession();
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => session.Events.CompactStreamAsync<LetterCountsByString>(Guid.NewGuid()));
+
+        var events = await session.Events.FetchStreamAsync(streamKey, token: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(3);
+        events.Any(x => x.Data is Compacted<LetterCountsByString>).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task store_level_string_overload_against_guid_store_names_the_real_mistake()
+    {
+        StoreOptions(opts => opts.Projections.Snapshot<Letters>(SnapshotLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<Letters>(streamId, A(), B(), C());
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Pre-fix this reported "stream not found or no aggregate type associated", which is a
+        // misdiagnosis — the stream is right there, just identified the other way.
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => ((IEventStore)theStore).CompactStreamAsync(streamId.ToString(), CancellationToken.None));
+
+        ex.Message.ShouldBe("This Marten event store is configured to identify streams with Guids");
+    }
+
+    [Fact]
+    public async Task store_level_guid_overload_against_string_store_names_the_real_mistake()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Add<LetterCountsByStringProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamKey = Guid.NewGuid().ToString();
+        theSession.Events.StartStream<LetterCountsByString>(streamKey, A(), B(), C());
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => ((IEventStore)theStore).CompactStreamAsync(Guid.NewGuid(), CancellationToken.None));
+
+        ex.Message.ShouldBe("This Marten event store is configured to identify streams with strings");
+    }
+
+    /// <summary>
+    /// The coverage gap called out while reviewing #5240: that PR started propagating the caller's
+    /// CancellationToken into the request (the old code passed a literal null for `configure`, so the
+    /// token was accepted and discarded), but nothing asserted the request actually honors it. Driven
+    /// at the session level because that is where the token is settable, and it is the same
+    /// StreamCompactingRequest.CancellationToken the store-level overload now sets.
+    /// </summary>
+    [Fact]
+    public async Task the_requests_cancellation_token_is_honored()
+    {
+        StoreOptions(opts => opts.Projections.Snapshot<Letters>(SnapshotLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<Letters>(streamId, A(), B(), C());
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        using var cancelled = new CancellationTokenSource();
+        await cancelled.CancelAsync();
+
+        await using var session = theStore.LightweightSession();
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => session.Events.CompactStreamAsync<Letters>(streamId, x => x.CancellationToken = cancelled.Token));
+    }
+}

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -22,6 +22,7 @@ using Marten.Events.Daemon.Internals;
 using Marten.Events.Daemon.Progress;
 using Marten.Events.Projections;
 using Marten.Exceptions;
+using Marten.Internal;
 using Marten.Internal.OpenTelemetry;
 using Marten.Internal.Sessions;
 using Marten.Schema;
@@ -728,6 +729,15 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
     async Task IEventStore.CompactStreamAsync(Guid streamId, CancellationToken token)
     {
         await using var session = LightweightSession();
+
+        // Assert the identity BEFORE looking the stream up, because FetchStreamStateAsync does not
+        // guard on StreamIdentity itself and neither pre-existing outcome named the actual mistake:
+        // the string overload on a Guid store matched nothing and fell into the "stream not found"
+        // guard below (a misdiagnosis — the stream is there, just identified the other way), while
+        // this Guid overload on a string store reached Npgsql with a null parameter and surfaced
+        // "Parameter '' cannot be null, DBNull.Value should be used instead."
+        Options.EventGraph.EnsureAsGuidStorage((IMartenSession)session);
+
         var state = await session.Events.FetchStreamStateAsync(streamId, token).ConfigureAwait(false);
         if (state?.AggregateType == null)
         {
@@ -742,6 +752,10 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
     async Task IEventStore.CompactStreamAsync(string streamKey, CancellationToken token)
     {
         await using var session = LightweightSession();
+
+        // See the Guid overload above.
+        Options.EventGraph.EnsureAsStringStorage((IMartenSession)session);
+
         var state = await session.Events.FetchStreamStateAsync(streamKey, token).ConfigureAwait(false);
         if (state?.AggregateType == null)
         {

--- a/src/Marten/Events/EventStore.StreamCompacting.cs
+++ b/src/Marten/Events/EventStore.StreamCompacting.cs
@@ -36,6 +36,14 @@ internal partial class EventStore
     public async Task CompactStreamAsync<T>(string streamKey, Action<StreamCompactingRequest<T>>? configure = null)
         where T : class
     {
+        // Reject the wrong overload the same way every other identity-sensitive entry point does
+        // (see EventStore.ConcurrentAppends and EventStore.FetchForWriting). Without this the
+        // request carries a null StreamId into ExecuteAsync, which branches on the store's
+        // configured StreamIdentity rather than on which overload was called, and the caller got
+        // "Nullable object must have a value" from request.StreamId!.Value -- an error that names
+        // nothing the caller can act on.
+        _store.Events.EnsureAsStringStorage(_session);
+
         var request = new StreamCompactingRequest<T>(streamKey);
         configure?.Invoke(request);
 
@@ -45,6 +53,11 @@ internal partial class EventStore
     public async Task CompactStreamAsync<T>(Guid streamId, Action<StreamCompactingRequest<T>>? configure = null)
         where T : class
     {
+        // The mirror case is worse than a bad message: on a string-identified store ExecuteAsync
+        // takes the AsString branch, reads a null StreamKey, matches no stream and returns at the
+        // `if (!events.Any()) return;` guard -- so compaction silently did nothing at all.
+        _store.Events.EnsureAsGuidStorage(_session);
+
         var request = new StreamCompactingRequest<T>(streamId);
         configure?.Invoke(request);
 


### PR DESCRIPTION
Closes #5244. Follow-up to #5240.

Compacting is identity-sensitive — `StreamCompactingRequest<T>` carries one of `StreamId`/`StreamKey`, and `StreamCompactingExecution.ExecuteAsync` branches on the store's configured `StreamIdentity` rather than on which overload the caller used. Unlike every other identity-sensitive entry point (`EventStore.ConcurrentAppends`, `EventStore.FetchForWriting`, which both call `EnsureAsGuidStorage`/`EnsureAsStringStorage`), the compaction entry points never asserted the two agreed.

## The case that motivates the fix is silent

`CompactStreamAsync<T>(Guid)` against a **string-identified** store took the `AsString` branch, read a null `StreamKey`, matched no stream, and returned at `if (!events.Any()) return;`.

**No exception. Compaction did nothing, and the caller had no way to tell a no-op from a completed compaction.** `the_silently_ignored_mirror_case_leaves_the_stream_untouched_and_now_throws` pins both halves — that it now throws, and that the stream still holds all three original events with no `Compacted<T>`.

## All four paths, verified by running

| Path | Before | After |
|---|---|---|
| session, `string` on Guid store | `InvalidOperationException: Nullable object must have a value` | names the mismatch |
| session, `Guid` on string store | **silent no-op** | names the mismatch |
| store, `string` on Guid store | `Cannot compact stream 'X': stream not found…` (misdiagnosis — the stream exists) | names the mismatch |
| store, `Guid` on string store | `Parameter '' cannot be null, DBNull.Value should be used instead.` (Npgsql) | names the mismatch |

"Names the mismatch" is the message Marten already uses for this class of mistake — `This Marten event store is configured to identify streams with Guids`/`…with strings` — reached through the existing `EventGraph.EnsureAsGuidStorage`/`EnsureAsStringStorage` helpers rather than a new bespoke check. The store-level overloads assert *before* the stream lookup, since `FetchStreamStateAsync` does not guard on `StreamIdentity` itself.

## Also closes a coverage gap from the #5240 review

#5240 began propagating the caller's `CancellationToken` into the request (the old code passed a literal `null` for `configure`, so the token was accepted and discarded), but nothing asserted the request honors it. `the_requests_cancellation_token_is_honored` pins it.

Being explicit: **that test passes on master too.** It documents working behaviour rather than fixing a bug, and is included because the propagation was previously untested, not because it is broken. Five of the six new tests fail on master; this is the sixth.

## Verification

- 6 new tests green; **5 of 6 fail on master** (the sixth is the token test above)
- Full `EventSourcingTests`: **1868 total, 0 failed**, 7 skipped (net9.0) — including the two store-level compaction tests that landed with #5240

🤖 Generated with [Claude Code](https://claude.com/claude-code)