### PR TITLE
jasperfx#669: consume the JasperFx 2.50.0 session Events accessor + promoted binary serializer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.25.0</Version>
+        <Version>9.26.0</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -262,16 +262,28 @@
          Polecat and Fisher can take the bump before adopting it, which means the enforcement lives
          in DocumentLoadAndStoreCompliance rather than the compiler. What Marten does owe is the
          fixture line below: DocumentComplianceConfig gained ValueTypes/RegisterValueType<T>() and a
-         fixture that does not replay it fails the two strong-typed facts at runtime. -->
-    <PackageVersion Include="JasperFx" Version="2.49.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.49.0" />
+         fixture that does not replay it fails the two strong-typed facts at runtime.
+         JasperFx 2.50.0: jasperfx#669/#671 — two additive changes. (1) The document session
+         contracts gain an Events accessor: IDocumentReadOperations.Events (IQueryEventStore) and
+         IDocumentSessionOperations.Events (IEventStoreOperations), both with throwing defaults.
+         ⚠️ Marten did NOT satisfy either implicitly, on BOTH tiers: its sessions declare Events as
+         Marten.Events.IQueryEventStore / Marten.Events.IEventStoreOperations — Marten's own
+         subtypes — and C# interface implementation is not return-type covariant, so both members
+         bound to the throwing defaults with no compile error anywhere. QuerySession and
+         DocumentSessionBase now carry one explicit interface implementation each, pinned by
+         DocumentSessionEventsCompliance. (2) IEventBinarySerializer and BinaryEventAttribute are
+         promoted out of Marten.Events into JasperFx.Events; Marten's interface now derives from the
+         core one, its attribute is checked alongside the core one (which is sealed, so no
+         inheritance), and the registration surface is widened to the core interface. -->
+    <PackageVersion Include="JasperFx" Version="2.50.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.50.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.49.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.50.0" />
     <!--
       Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
       the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
@@ -289,11 +301,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.49.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.50.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.49.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.50.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/docs/documents/sessions.md
+++ b/docs/documents/sessions.md
@@ -51,6 +51,30 @@ The recommended session type for read/write operations is `LightweightSession`, 
 For read-only access, use `QuerySession`.
 :::
 
+## Reaching the event store from a store-agnostic session <Badge type="tip" text="9.26" />
+
+Marten's sessions implement the shared Critter Stack session contracts in `JasperFx.Events.Documents`,
+which is what lets one body of code be compiled against Marten, Polecat or Fisher. As of 9.26 those
+contracts carry an `Events` accessor, so a consumer holding a session as the shared contract can
+reach the event store without naming a Marten type:
+
+```csharp
+// The session was opened through the shared IDocumentSessionFactory, so nothing here
+// knows it is talking to Marten.
+IDocumentSessionOperations session = factory.LightweightSession();
+
+session.Events.StartStream<Order>(streamKey, new OrderPlaced(/* ... */));
+await session.SaveChangesAsync(token);
+```
+
+The split mirrors Marten's own: `IDocumentReadOperations.Events` is read-only
+(`IQueryEventStore`), and `IDocumentSessionOperations.Events` adds appending
+(`IEventStoreOperations`) — so a query session cannot append. Appends made through the accessor ride
+the session's unit of work exactly as `Store()` does; nothing is written until `SaveChangesAsync`.
+
+Nothing changes for code that holds a Marten session as `IQuerySession` / `IDocumentSession` — that
+is the same `Events` property it always was.
+
 ## Read Only QuerySession
 
 For strictly read-only querying, the `QuerySession` is a lightweight session that is optimized

--- a/docs/events/binary-serialization.md
+++ b/docs/events/binary-serialization.md
@@ -8,6 +8,13 @@ ergonomic wins for a meaningful throughput and storage-size improvement on
 hot streams. See [#4515](https://github.com/JasperFx/marten/issues/4515) for
 the design discussion.
 
+::: tip New in 9.26
+Both `IEventBinarySerializer` and `[BinaryEvent]` now live in **`JasperFx.Events`**, shared by every
+Critter Stack store, so one serializer implementation and one attribute serve Marten, Polecat and
+Fisher alike. The Marten-namespaced spellings still work exactly as before — see
+[Store-agnostic serializers and events](#store-agnostic-serializers-and-events) below.
+:::
+
 The opt-in is **per event type** — binary-serialized and JSON-serialized events
 coexist in the same `mt_events` table, so the feature can be rolled out on an
 existing store with **no migration of existing data**.
@@ -87,15 +94,79 @@ public partial record TripEnded(Guid TripId, DateTimeOffset EndedAt);
 opts.Events.UseBinarySerializer<TripEnded>(new MemoryPackEventSerializer());
 ```
 
-Resolution order on `EventMapping` construction:
+Resolution order:
 
 1. Explicit `opts.Events.UseBinarySerializer<TEvent>(...)` for that type.
 2. `[BinaryEvent]` attribute + `opts.Events.DefaultBinarySerializer`.
 3. Otherwise, plain JSON (existing path).
 
 If a type carries `[BinaryEvent]` but no per-type serializer was wired AND
-`DefaultBinarySerializer` is `null`, Marten throws at the first append with a
+`DefaultBinarySerializer` is `null`, Marten throws at the first use with a
 remediation message naming both registration entry points.
+
+**Registration order does not matter.** Resolution happens on first use, not when the event type is
+registered, so these two are equivalent:
+
+```csharp
+// Either order works.
+opts.Events.AddEventType(typeof(TripEnded));
+opts.Events.DefaultBinarySerializer = new MemoryPackEventSerializer();
+
+opts.Events.DefaultBinarySerializer = new MemoryPackEventSerializer();
+opts.Events.AddEventType(typeof(TripEnded));
+```
+
+::: warning Fixed in 9.26
+Before 9.26 the serializer was resolved when the `EventMapping` was built, which made the first
+ordering above throw `"no IEventBinarySerializer was registered"` out of what looks like a plain
+type registration.
+:::
+
+## Store-agnostic serializers and events
+
+As of 9.26 the two public building blocks of this feature are shared across the Critter Stack rather
+than owned by Marten:
+
+| Type | Home |
+| --- | --- |
+| `IEventBinarySerializer` | `JasperFx.Events` |
+| `BinaryEventAttribute` (`[BinaryEvent]`) | `JasperFx.Events` |
+
+That matters if you compile one body of event definitions against more than one store — the shape
+the store-agnostic document/session contracts already exist for. Write the serializer once against
+the JasperFx interface and register it with Marten directly:
+
+```csharp
+using JasperFx.Events;
+
+public sealed class MessagePackEventSerializer : IEventBinarySerializer  // JasperFx.Events
+{
+    public byte[] Serialize(Type type, object data) => /* ... */;
+    public object Deserialize(Type type, byte[] data) => /* ... */;
+}
+
+// Marten's registration surface takes the JasperFx interface, so nothing Marten-specific
+// is needed to wire it up.
+opts.Events.DefaultBinarySerializer = new MessagePackEventSerializer();
+opts.Events.UseBinarySerializer<TripStarted>(new MessagePackEventSerializer());
+```
+
+Likewise, mark shared event types with `JasperFx.Events.BinaryEventAttribute` so the same declaration
+is honored by every store.
+
+### Nothing existing breaks
+
+- `Marten.Events.IEventBinarySerializer` still exists and now simply **derives** from the JasperFx
+  interface while declaring nothing of its own. An existing serializer class compiles untouched and
+  is accepted everywhere the JasperFx interface is.
+- `Marten.Events.BinaryEventAttribute` still exists and is still honored. Marten checks for **both**
+  attributes, so a type marked with either is picked up. (Two checks rather than one against a
+  common base because the JasperFx attribute is `sealed`.)
+- `opts.Events.DefaultBinarySerializer` and `opts.Events.UseBinarySerializer<TEvent>(...)` were
+  *widened* to accept the JasperFx interface. Every existing call site still compiles, because the
+  Marten interface derives from it.
+
+Prefer the JasperFx spellings in new code.
 
 ## Bring your own serializer
 
@@ -103,6 +174,8 @@ remediation message naming both registration entry points.
 binary format — MessagePack, protobuf, etc.:
 
 ```csharp
+// JasperFx.Events (9.26+); Marten.Events.IEventBinarySerializer derives from it
+// and is still accepted everywhere.
 public interface IEventBinarySerializer
 {
     byte[] Serialize(Type type, object data);

--- a/src/EventSourcingTests/Compliance/marten_document_storage_compliance.cs
+++ b/src/EventSourcingTests/Compliance/marten_document_storage_compliance.cs
@@ -39,6 +39,20 @@ public class document_delete_compliance
 public class document_session_compliance
     : DocumentSessionCompliance<MartenDocumentComplianceFixture>;
 
+/*
+ * jasperfx#669. The fifth suite, and the only opt-in one of the five -- it requires the store to be
+ * an event store as well as a document store. It exists to catch a silent failure: C# interface
+ * implementation is not return-type covariant, so Marten's sessions, which already declared an
+ * `Events` property of Marten's OWN IQueryEventStore / IEventStoreOperations, did not implement
+ * IDocumentReadOperations.Events or IDocumentSessionOperations.Events at all -- both bound to the
+ * interfaces' throwing default implementations with no compile error anywhere. Both tiers now carry
+ * an explicit interface implementation (QuerySession / DocumentSessionBase) and this is what pins
+ * them.
+ */
+[Collection(DocumentComplianceCollection.Name)]
+public class document_session_events_compliance
+    : DocumentSessionEventsCompliance<MartenDocumentComplianceFixture>;
+
 public static class DocumentComplianceCollection
 {
     public const string Name = "document storage compliance";

--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave9.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave9.cs
@@ -1,0 +1,33 @@
+using JasperFx.Events.ComplianceTests;
+using Marten;
+using Marten.Testing.Harness;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * Wave 9 -- binary event serialization compliance, shipped in JasperFx 2.50.0 alongside the
+ * promotion of IEventBinarySerializer and BinaryEventAttribute out of Marten.Events and into
+ * JasperFx.Events (jasperfx#669).
+ *
+ * Marten is the reference implementation here rather than a late adopter: the feature originated as
+ * marten#4515 and the suite was written against it, so Polecat (polecat#475) and Fisher (fisher#93)
+ * are being ported to match this behavior. That makes a red fact in this suite genuinely
+ * interesting -- it is either a real Marten gap or the shared suite encoding something Marten never
+ * promised.
+ *
+ * It is an opt-in suite: a store that has not implemented binary event storage simply does not
+ * enroll, and IComplianceStoreRegistrar.UseBinarySerializer / SetDefaultBinarySerializer keep their
+ * throwing defaults. Marten implements both on MartenComplianceRegistrar, which is only possible
+ * because EventGraph.UseBinarySerializer / DefaultBinarySerializer were widened in 9.26 to accept
+ * the promoted JasperFx.Events.IEventBinarySerializer.
+ *
+ * One real defect fell out of enrolling it, and it was never suite-specific. The suite's config
+ * registers its event types before it sets the store-wide default serializer, and EventMapping used
+ * to resolve its binary serializer in its constructor -- so AddEventType<T>() on a [BinaryEvent]
+ * type threw "no IEventBinarySerializer was registered" purely because of the order two lines were
+ * written in. Resolution is lazy now (EventMapping.BinarySerializer), which is what the
+ * documentation always described.
+ */
+
+public class binary_event_serialization_compliance
+    : BinaryEventSerializationCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;

--- a/src/EventSourcingTests/binary_event_serializer_promotion.cs
+++ b/src/EventSourcingTests/binary_event_serializer_promotion.cs
@@ -1,0 +1,157 @@
+using System;
+using Marten;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+#region promotion test events
+
+/// <summary>
+/// Marked with Marten's own attribute — the spelling every existing user wrote.
+/// </summary>
+[Marten.Events.BinaryEvent]
+public record PromotionMartenMarked(string Name);
+
+/// <summary>
+/// Marked with the promoted JasperFx attribute — the spelling an event type shared by source
+/// compiled against Marten, Polecat and Fisher can use.
+/// </summary>
+[JasperFx.Events.BinaryEvent]
+public record PromotionCoreMarked(string Name);
+
+public record PromotionUnmarked(string Name);
+
+/// <summary>
+/// Implements ONLY <see cref="JasperFx.Events.IEventBinarySerializer" /> — nothing Marten-namespaced.
+/// Registering this at all is the whole point of the widening.
+/// </summary>
+public class CoreOnlyBinarySerializer: JasperFx.Events.IEventBinarySerializer
+{
+    public byte[] Serialize(Type type, object data) => throw new NotSupportedException("Not exercised here");
+
+    public object Deserialize(Type type, byte[] data) => throw new NotSupportedException("Not exercised here");
+}
+
+/// <summary>
+/// Implements the Marten-namespaced interface exactly as a pre-9.26 user would have. It must keep
+/// compiling and must still be accepted by the widened registration surface.
+/// </summary>
+public class LegacyMartenBinarySerializer: Marten.Events.IEventBinarySerializer
+{
+    public byte[] Serialize(Type type, object data) => throw new NotSupportedException("Not exercised here");
+
+    public object Deserialize(Type type, byte[] data) => throw new NotSupportedException("Not exercised here");
+}
+
+#endregion
+
+/// <summary>
+/// jasperfx#669: IEventBinarySerializer and BinaryEventAttribute were promoted out of
+/// Marten.Events into JasperFx.Events. These pin the compatibility claims that promotion rests on.
+/// No database — every assertion is about registration and resolution.
+/// </summary>
+public class binary_event_serializer_promotion
+{
+    [Fact]
+    public void martens_own_binary_event_attribute_is_still_honored()
+    {
+        var options = new StoreOptions();
+        options.Events.DefaultBinarySerializer = new CoreOnlyBinarySerializer();
+        options.Events.AddEventType(typeof(PromotionMartenMarked));
+
+        options.EventGraph.EventMappingFor(typeof(PromotionMartenMarked))
+            .IsBinary.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void the_promoted_jasperfx_binary_event_attribute_is_honored()
+    {
+        var options = new StoreOptions();
+        options.Events.DefaultBinarySerializer = new CoreOnlyBinarySerializer();
+        options.Events.AddEventType(typeof(PromotionCoreMarked));
+
+        options.EventGraph.EventMappingFor(typeof(PromotionCoreMarked))
+            .IsBinary.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void an_unmarked_event_type_stays_on_the_json_path()
+    {
+        var options = new StoreOptions();
+        options.Events.DefaultBinarySerializer = new CoreOnlyBinarySerializer();
+        options.Events.AddEventType(typeof(PromotionUnmarked));
+
+        options.EventGraph.EventMappingFor(typeof(PromotionUnmarked))
+            .IsBinary.ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// The registration surface takes the core interface now, so a serializer that knows nothing
+    /// about Marten can be registered. This would not have compiled before 9.26.
+    /// </summary>
+    [Fact]
+    public void a_serializer_implementing_only_the_core_contract_can_be_registered()
+    {
+        var serializer = new CoreOnlyBinarySerializer();
+
+        var options = new StoreOptions();
+        options.Events.UseBinarySerializer<PromotionUnmarked>(serializer);
+
+        options.EventGraph.EventMappingFor(typeof(PromotionUnmarked))
+            .BinarySerializer.ShouldBeSameAs(serializer);
+    }
+
+    /// <summary>
+    /// The other half of "non-breaking": a serializer written against the Marten-namespaced
+    /// interface still satisfies the widened parameter, because that interface now derives from the
+    /// core one and declares nothing itself.
+    /// </summary>
+    [Fact]
+    public void a_serializer_implementing_the_marten_contract_still_registers()
+    {
+        var serializer = new LegacyMartenBinarySerializer();
+
+        var options = new StoreOptions();
+        options.Events.DefaultBinarySerializer = serializer;
+        options.Events.UseBinarySerializer<PromotionUnmarked>(serializer);
+
+        options.EventGraph.EventMappingFor(typeof(PromotionUnmarked))
+            .BinarySerializer.ShouldBeSameAs(serializer);
+    }
+
+    /// <summary>
+    /// Registration order must not matter. EventMapping used to resolve its binary serializer in
+    /// its constructor, so AddEventType on a [BinaryEvent] type threw out of what looks like a
+    /// plain type registration whenever DefaultBinarySerializer had not been assigned yet — while
+    /// the two lines in the other order worked fine. Resolution is lazy now.
+    /// </summary>
+    [Fact]
+    public void the_default_serializer_may_be_registered_after_the_event_type()
+    {
+        var options = new StoreOptions();
+
+        Should.NotThrow(() => options.Events.AddEventType(typeof(PromotionCoreMarked)));
+
+        options.Events.DefaultBinarySerializer = new CoreOnlyBinarySerializer();
+
+        options.EventGraph.EventMappingFor(typeof(PromotionCoreMarked))
+            .IsBinary.ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Deferring the resolution must not lose the diagnostic — it moves to first use, which is
+    /// where the documentation always said it was.
+    /// </summary>
+    [Fact]
+    public void a_marked_event_type_with_no_serializer_anywhere_still_throws_on_use()
+    {
+        var options = new StoreOptions();
+        options.Events.AddEventType(typeof(PromotionCoreMarked));
+
+        var mapping = options.EventGraph.EventMappingFor(typeof(PromotionCoreMarked));
+
+        Should.Throw<InvalidOperationException>(() => _ = mapping.BinarySerializer)
+            .Message.ShouldContain("no IEventBinarySerializer was registered");
+    }
+}

--- a/src/Marten.Testing/Harness/MartenComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenComplianceFixture.cs
@@ -212,6 +212,21 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
 
         public void AddEventType(Type eventType) => _options.Events.AddEventType(eventType);
 
+        /// <summary>
+        ///     jasperfx#669: both binary-serialization members take the promoted
+        ///     <see cref="JasperFx.Events.IEventBinarySerializer" />, which Marten's registration surface was
+        ///     widened to accept in 9.26. Before that widening these could only have been implemented by
+        ///     wrapping the compliance suite's serializer in a Marten-namespaced adapter — the exact
+        ///     per-store duplication the promotion exists to delete.
+        /// </summary>
+        public void UseBinarySerializer<TEvent>(JasperFx.Events.IEventBinarySerializer serializer)
+            where TEvent : notnull
+            => _options.Events.UseBinarySerializer<TEvent>(serializer);
+
+        /// <inheritdoc cref="UseBinarySerializer{TEvent}" />
+        public void SetDefaultBinarySerializer(JasperFx.Events.IEventBinarySerializer serializer)
+            => _options.Events.DefaultBinarySerializer = serializer;
+
         public ITagTypeRegistration RegisterTagType<TTag>(string tableSuffix) where TTag : notnull
             => _options.Events.RegisterTagType<TTag>(tableSuffix);
 

--- a/src/Marten.Testing/Harness/MartenDocumentComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenDocumentComplianceFixture.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using JasperFx;
+using JasperFx.Events;
 using JasperFx.Events.ComplianceTests;
 using JasperFx.Events.Documents;
 
@@ -64,6 +65,22 @@ public class MartenDocumentComplianceFixture: DocumentStorageComplianceFixture
         foreach (var valueType in config.ValueTypes)
         {
             options.RegisterValueType(valueType);
+        }
+
+        // jasperfx#669. Only DocumentSessionEventsCompliance populates this, and unlike the two
+        // loops above it IS load-bearing: that suite appends through a session's Events accessor
+        // with a *string* stream key, and Marten's default StreamIdentity is Guid — so without the
+        // switch below every fact in it fails on the append rather than on the accessor it is
+        // there to hold to a definition. Conditional on the list being non-empty so the four
+        // document-only suites, which share this schema, never provoke event storage at all.
+        if (config.EventTypes.Count != 0)
+        {
+            options.Events.StreamIdentity = StreamIdentity.AsString;
+
+            foreach (var eventType in config.EventTypes)
+            {
+                options.Events.AddEventType(eventType);
+            }
         }
 
         _store = new DocumentStore(options);

--- a/src/Marten/Events/BinaryEventAttribute.cs
+++ b/src/Marten/Events/BinaryEventAttribute.cs
@@ -26,6 +26,23 @@ namespace Marten.Events;
 ///         continue to read through the JSON path.
 ///     </para>
 /// </remarks>
+/// <remarks>
+///     <para>
+///         jasperfx#669 / JasperFx 2.50.0: the attribute was promoted into
+///         <see cref="JasperFx.Events.BinaryEventAttribute"/> so an event type shared by source
+///         compiled against several Critter Stack stores can declare its intent once. Marten
+///         honors <strong>both</strong> spellings — <see cref="EventGraph.ResolveBinarySerializerFor"/>
+///         tests for either attribute — so this one keeps working untouched and no existing user
+///         has anything to change. Prefer the JasperFx attribute in new code, and use it in any
+///         event type shared across stores.
+///     </para>
+///     <para>
+///         The two are checked separately rather than this one deriving from the core attribute
+///         (which would have let a single <c>IsDefined</c> against the base cover both): the
+///         promoted <c>JasperFx.Events.BinaryEventAttribute</c> is <c>sealed</c>, so there is no
+///         inheritance to lean on.
+///     </para>
+/// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
 public sealed class BinaryEventAttribute: Attribute
 {

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -406,13 +406,13 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     // constructor calls ResolveBinarySerializerFor when the mapping is built
     // (lazily on first use); UseBinarySerializer<T> populates this dictionary
     // ahead of time so the resolution lands on the registered instance.
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<Type, IEventBinarySerializer> _binarySerializerByType = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<Type, JasperFx.Events.IEventBinarySerializer> _binarySerializerByType = new();
 
     /// <inheritdoc />
-    public IEventBinarySerializer? DefaultBinarySerializer { get; set; }
+    public JasperFx.Events.IEventBinarySerializer? DefaultBinarySerializer { get; set; }
 
     /// <inheritdoc />
-    public IEventStoreOptions UseBinarySerializer<TEvent>(IEventBinarySerializer serializer)
+    public IEventStoreOptions UseBinarySerializer<TEvent>(JasperFx.Events.IEventBinarySerializer serializer)
     {
         if (serializer == null) throw new ArgumentNullException(nameof(serializer));
 
@@ -441,14 +441,20 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     ///     beats <see cref="BinaryEventAttribute"/> + <see cref="DefaultBinarySerializer"/>.
     ///     Returns <c>null</c> for plain JSON events.
     /// </summary>
-    internal IEventBinarySerializer? ResolveBinarySerializerFor(Type eventType)
+    internal JasperFx.Events.IEventBinarySerializer? ResolveBinarySerializerFor(Type eventType)
     {
         if (_binarySerializerByType.TryGetValue(eventType, out var explicitSerializer))
         {
             return explicitSerializer;
         }
 
-        if (eventType.IsDefined(typeof(BinaryEventAttribute), inherit: false))
+        // jasperfx#669: BOTH attributes are honored. Marten.Events.BinaryEventAttribute is what
+        // every existing user wrote; JasperFx.Events.BinaryEventAttribute is the promoted one an
+        // event type shared across Marten / Polecat / Fisher can declare. Two checks rather than
+        // one against a common base because the promoted attribute is sealed, so Marten's cannot
+        // derive from it.
+        if (eventType.IsDefined(typeof(BinaryEventAttribute), inherit: false)
+            || eventType.IsDefined(typeof(JasperFx.Events.BinaryEventAttribute), inherit: false))
         {
             if (DefaultBinarySerializer is null)
             {

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -50,12 +50,6 @@ public abstract class EventMapping: EventTypeData, IDocumentMapping, IEventType
         _parent = parent;
         DocumentType = eventType;
 
-        // #4515: pick up binary-serializer wiring at construction. Either an
-        // explicit per-type registration via UseBinarySerializer<T>(...) or
-        // the BinaryEventAttribute + store-wide DefaultBinarySerializer.
-        // Null = plain JSON-serialized event (the existing path).
-        BinarySerializer = parent.ResolveBinarySerializerFor(eventType);
-
         IdMember = DocumentType.GetProperty(nameof(IEvent.Id))!;
 
         _inner = new DocumentMapping(eventType, parent.Options);
@@ -79,8 +73,43 @@ public abstract class EventMapping: EventTypeData, IDocumentMapping, IEventType
     ///     row's <c>bdata IS NULL</c> state so JSON-serialized rows for the same
     ///     event type still read correctly.
     /// </summary>
+    /// <remarks>
+    ///     Resolved <strong>lazily</strong>, and that is load-bearing rather than an optimization.
+    ///     It used to be resolved in this constructor, which made the store options
+    ///     order-dependent in a way nothing announced: <c>opts.Events.AddEventType&lt;T&gt;()</c>
+    ///     builds the mapping eagerly, so registering a <c>[BinaryEvent]</c> type <em>before</em>
+    ///     assigning <c>opts.Events.DefaultBinarySerializer</c> threw
+    ///     "no IEventBinarySerializer was registered" out of what looks like a plain type
+    ///     registration — while the reverse order worked. Resolving on first read defers the
+    ///     failure to first use, which is what the documentation always claimed and what makes the
+    ///     fluent options builder order-insensitive. Caught by
+    ///     <c>BinaryEventSerializationCompliance</c>, whose config registers event types first.
+    /// </remarks>
     [IgnoreDescription]
-    public IEventBinarySerializer? BinarySerializer { get; internal set; }
+    public JasperFx.Events.IEventBinarySerializer? BinarySerializer
+    {
+        get
+        {
+            if (!_binarySerializerResolved)
+            {
+                // Deliberately NOT latched before the call: ResolveBinarySerializerFor throws for
+                // an attribute-marked type with no serializer registered yet, and a later
+                // DefaultBinarySerializer assignment has to still be able to satisfy it.
+                _binarySerializer = _parent.ResolveBinarySerializerFor(DocumentType);
+                _binarySerializerResolved = true;
+            }
+
+            return _binarySerializer;
+        }
+        internal set
+        {
+            _binarySerializer = value;
+            _binarySerializerResolved = true;
+        }
+    }
+
+    private JasperFx.Events.IEventBinarySerializer? _binarySerializer;
+    private bool _binarySerializerResolved;
 
     /// <summary>
     /// #4680: true when this <see cref="EventMapping"/> was created by

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -109,7 +109,13 @@ public abstract class EventMapping: EventTypeData, IDocumentMapping, IEventType
     }
 
     private JasperFx.Events.IEventBinarySerializer? _binarySerializer;
-    private bool _binarySerializerResolved;
+
+    // volatile, and it matters now that resolution is lazy: the flag's release/acquire semantics are
+    // what stop a racing reader from seeing "resolved" before the serializer reference it guards is
+    // visible. Reading null there would silently route a binary event down the JSON path -- a data
+    // corruption rather than an exception. Resolution itself is idempotent, so a duplicated race is
+    // harmless.
+    private volatile bool _binarySerializerResolved;
 
     /// <summary>
     /// #4680: true when this <see cref="EventMapping"/> was created by

--- a/src/Marten/Events/IEventBinarySerializer.cs
+++ b/src/Marten/Events/IEventBinarySerializer.cs
@@ -26,19 +26,17 @@ namespace Marten.Events;
 ///         store-wide <c>opts.Events.DefaultBinarySerializer</c> if one is set.
 ///     </para>
 /// </remarks>
-public interface IEventBinarySerializer
+public interface IEventBinarySerializer: JasperFx.Events.IEventBinarySerializer
 {
-    /// <summary>
-    ///     Serialize an event data instance to bytes.
-    /// </summary>
-    /// <param name="type">The runtime CLR type of the event data.</param>
-    /// <param name="data">The event data to serialize.</param>
-    byte[] Serialize(Type type, object data);
-
-    /// <summary>
-    ///     Deserialize bytes back into an event data instance.
-    /// </summary>
-    /// <param name="type">The target CLR type to deserialize into.</param>
-    /// <param name="data">The bytes previously produced by <see cref="Serialize"/>.</param>
-    object Deserialize(Type type, byte[] data);
+    // jasperfx#669 / JasperFx 2.50.0: the contract was promoted verbatim into JasperFx.Events so
+    // one serializer implementation can serve every Critter Stack store. Both members
+    // (byte[] Serialize(Type, object) and object Deserialize(Type, byte[])) now come from the core
+    // interface -- this one deliberately declares NOTHING of its own.
+    //
+    // Keeping the Marten-namespaced name as a derived interface is what makes the move
+    // non-breaking in both directions: an existing `class MySerializer : Marten.Events.IEventBinarySerializer`
+    // keeps compiling untouched AND now satisfies the core type, while Marten's registration
+    // surface (EventGraph.UseBinarySerializer / DefaultBinarySerializer) has been widened to accept
+    // the core type so a store-agnostic serializer can be registered without implementing anything
+    // Marten-specific.
 }

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -250,8 +250,14 @@ namespace Marten.Events
         ///     serializer was wired via <see cref="UseBinarySerializer{TEvent}"/>. Default
         ///     is <c>null</c>; setting this is what makes attribute-only opt-in work for
         ///     the common case of one binary serializer per store. See #4515.
+        ///     <para>
+        ///         Typed as the promoted <see cref="JasperFx.Events.IEventBinarySerializer"/> since
+        ///         9.26 (jasperfx#669) so a store-agnostic serializer can be registered. Marten's
+        ///         own <see cref="IEventBinarySerializer"/> derives from it, so existing
+        ///         implementations still assign here unchanged.
+        ///     </para>
         /// </summary>
-        public IEventBinarySerializer? DefaultBinarySerializer { get; set; }
+        public JasperFx.Events.IEventBinarySerializer? DefaultBinarySerializer { get; set; }
 
         /// <summary>
         ///     Opt a single event type into binary serialization (#4515). The event's
@@ -261,9 +267,14 @@ namespace Marten.Events
         ///     the registry (no separate <see cref="AddEventType{TEvent}"/> call needed).
         /// </summary>
         /// <typeparam name="TEvent">CLR event type to opt in.</typeparam>
-        /// <param name="serializer">Per-type serializer to use for this event.</param>
+        /// <param name="serializer">
+        ///     Per-type serializer to use for this event. Widened to the promoted
+        ///     <see cref="JasperFx.Events.IEventBinarySerializer"/> in 9.26 (jasperfx#669); Marten's
+        ///     own <see cref="IEventBinarySerializer"/> derives from it, so existing call sites are
+        ///     unaffected.
+        /// </param>
         /// <returns>Event store options, to allow fluent definition.</returns>
-        IEventStoreOptions UseBinarySerializer<TEvent>(IEventBinarySerializer serializer);
+        IEventStoreOptions UseBinarySerializer<TEvent>(JasperFx.Events.IEventBinarySerializer serializer);
 
         /// <summary>
         ///     Maps CLR event type as particular event type name. This is useful for event type migration.

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -320,6 +320,14 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
 
     public new Marten.Events.IEventStoreOperations Events => (Marten.Events.IEventStoreOperations)base.Events;
 
+    // jasperfx#669: the write tier of the store-agnostic Events accessor. C# interface
+    // implementation is NOT return-type covariant, so the public property above -- typed as
+    // Marten.Events.IEventStoreOperations, which *derives* from the JasperFx one -- does not
+    // satisfy IDocumentSessionOperations.Events. Without this line the member silently binds to
+    // the interface's throwing default implementation, with no compile error anywhere; only a test
+    // calling through a contract-typed session notices. Pinned by DocumentSessionEventsCompliance.
+    JasperFx.Events.IEventStoreOperations JasperFx.Events.Documents.IDocumentSessionOperations.Events => Events;
+
 
     public void QueueOperation(Weasel.Storage.IStorageOperation storageOperation)
     {

--- a/src/Marten/Internal/Sessions/QuerySession.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.cs
@@ -44,6 +44,14 @@ public partial class QuerySession: IMartenSession, IQuerySession, ITenantedQuery
     public StoreOptions Options { get; }
     public IQueryEventStore Events { get; }
 
+    // jasperfx#669: the read tier of the store-agnostic Events accessor. The public property above
+    // is Marten.Events.IQueryEventStore -- Marten's OWN subtype of JasperFx.Events.IQueryEventStore,
+    // which the `using Marten.Events;` at the top of this file is what makes the unqualified name
+    // resolve to. Interface implementation is not return-type covariant, so it does NOT satisfy
+    // IDocumentReadOperations.Events; absent this line the member binds to the throwing default with
+    // no compile error. Pinned by DocumentSessionEventsCompliance.
+    JasperFx.Events.IQueryEventStore JasperFx.Events.Documents.IDocumentReadOperations.Events => Events;
+
     protected virtual IQueryEventStore CreateEventStore(DocumentStore store, Tenant tenant)
     {
         return new QueryEventStore(this, store, tenant);


### PR DESCRIPTION
Bumps the JasperFx line to **2.50.0** and adopts both additive changes it carries (jasperfx#671). `JasperFx.RuntimeCompiler` is on a separate 5.x line and is untouched.

Version 9.25.0 → 9.26.0.

## 1. The session `Events` accessor (jasperfx#669)

`JasperFx.Events.Documents.IDocumentReadOperations` gains `IQueryEventStore Events`, and `IDocumentSessionOperations` gains `IEventStoreOperations Events` — both with throwing default implementations.

**Marten satisfied neither implicitly, on BOTH tiers.** The going-in assumption was that the read tier was already fine because `Marten.IQuerySession` declares `IQueryEventStore Events { get; }`. It does — but `src/Marten/Events/IQueryEventStore.cs` exists, and the `using Marten.Events;` at the top of that file is what the unqualified name binds to. So the property is **`Marten.Events.IQueryEventStore`**, Marten's own subtype of the JasperFx interface, not the JasperFx interface. Same story on the write tier with `Marten.Events.IEventStoreOperations`. C# interface implementation is not return-type covariant, so both members bound to the throwing defaults.

Fix is one explicit interface implementation per session type:

- `QuerySession` — `JasperFx.Events.IQueryEventStore JasperFx.Events.Documents.IDocumentReadOperations.Events => Events;`
- `DocumentSessionBase` — `JasperFx.Events.IEventStoreOperations JasperFx.Events.Documents.IDocumentSessionOperations.Events => Events;`

Those two cover every concrete session Marten hands out, including `NestedTenantSession` / `NestedTenantQuerySession`, which derive from them.

### Verifying the non-covariance trap

Not taken on trust. Both lines were commented out and the tree rebuilt:

- `dotnet build src/EventSourcingTests` → **`Build succeeded.`, 0 errors.** The trap really is invisible to the compiler.
- The same build then failed **5 of 5** facts in `DocumentSessionEventsCompliance` at runtime:

  > `System.NotSupportedException : Marten.Internal.Sessions.QuerySession does not implement IDocumentReadOperations.Events, so the event store cannot be reached from a session this store opened.`

  > `System.NotSupportedException : Marten.Internal.Sessions.LightweightSession does not implement IDocumentSessionOperations.Events, so events cannot be appended through a session this store opened.`

Both lines restored, both suites green.

## 2. `IEventBinarySerializer` + `BinaryEventAttribute` promoted

Both types moved into `JasperFx.Events` so one serializer implementation and one attribute serve Marten, Polecat and Fisher. Everything below is non-breaking.

| | Approach |
| --- | --- |
| `Marten.Events.IEventBinarySerializer` | now **derives** from `JasperFx.Events.IEventBinarySerializer` and declares nothing itself. Existing implementations compile untouched and now satisfy the core type. |
| `Marten.Events.BinaryEventAttribute` | unchanged and still honored. `EventGraph.ResolveBinarySerializerFor` checks for it **and** the core attribute. |
| `EventGraph.UseBinarySerializer<TEvent>` / `DefaultBinarySerializer` / `IEventStoreOptions` | **widened** to accept the core interface, so a store-agnostic serializer registers with no Marten-specific adapter. Existing call sites unaffected, since the Marten interface derives from the core one. |

⚠️ **`JasperFx.Events.BinaryEventAttribute` is `sealed`**, so the tidier "Marten's attribute derives from the core one and a single `IsDefined` against the base covers both" is not available (`CS0509`). Two explicit checks instead. Worth knowing if the sealing is ever reconsidered upstream — it would collapse to one line here.

## 3. A real Marten defect the compliance suite caught

`EventMapping` resolved its binary serializer **in its constructor**, and `opts.Events.AddEventType<T>()` builds the mapping eagerly. So registering a `[BinaryEvent]` type *before* assigning `DefaultBinarySerializer` threw `"no IEventBinarySerializer was registered"` out of what looks like a plain type registration — while the same two lines in the other order worked. A fluent options builder that is order-sensitive with no announcement.

`EventMapping.BinarySerializer` resolves **lazily** now, deferring the failure to first use — which is exactly what `docs/events/binary-serialization.md` always claimed ("throws at the first append"). The suite surfaced it because `BinaryEventSerializationCompliance`'s config registers event types before it sets the store-wide default; the bug was never suite-specific.

This is the only behavior change to existing functionality in the PR, and it strictly turns a throw into a non-throw.

## 4. Compliance enrollment

- **`DocumentSessionEventsCompliance<MartenDocumentComplianceFixture>`** → `marten_document_storage_compliance.cs`, joining the existing `DocumentComplianceCollection` (all five suites pin `SchemaName = "compliance_documents"`, so serializing them is load-bearing). **5 passed.**
- **`BinaryEventSerializationCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>`** → new `marten_event_store_compliance_wave9.cs`. **6 passed.**

Two fixture changes were required:

- `MartenComplianceRegistrar` implements the two members that previously had throwing defaults, `UseBinarySerializer<TEvent>` and `SetDefaultBinarySerializer`. Both take the **core** interface — which is only implementable at all because of the widening in §2; before it, they would have needed a Marten-namespaced adapter wrapping the suite's serializer, i.e. exactly the per-store duplication the promotion exists to delete.
- `MartenDocumentComplianceFixture.BuildStoreAsync` honors `config.EventTypes`, **and sets `StreamIdentity.AsString` when it is non-empty**. That second half is load-bearing and worth flagging for the Polecat/Fisher ports: `DocumentSessionEventsCompliance` appends with a *string* stream key while Marten's default identity is `Guid`, and `DocumentComplianceConfig` carries no `StreamIdentity` knob — so a fixture that only replays `EventTypes` fails every fact on the append rather than on the accessor under test. It is conditional on the list being non-empty so the four document-only suites never provoke event storage in the shared schema.

**No compliance suite was modified or weakened.** Nothing in the shared suites needed a change to pass against Marten.

## 5. Tests

New `src/EventSourcingTests/binary_event_serializer_promotion.cs` (7 facts, no database) pins the compatibility claims directly: Marten's attribute still honored, the core attribute honored, unmarked types stay JSON, a serializer implementing only the core contract registers, a legacy Marten-contract serializer still registers, order-independence, and that the diagnostic survives the move to lazy resolution.

### Run locally (PostgreSQL 17 on :5442, net9.0)

| | |
| --- | --- |
| `EventSourcingTests.Compliance.*` (all enrollments) | **286 passed, 0 failed** |
| `binary_event_serializer_promotion` | **7 passed** |
| `Marten.MemoryPack.Tests` (the existing binary-event coverage) | **14 passed** |
| `dotnet build src/Marten.slnx` | **Build succeeded** |

Not run locally: the rest of `EventSourcingTests`, `DocumentDbTests`, `LinqTests`, `CoreTests`, `DaemonTests`, `MultiTenancyTests`, `ValueTypeTests`, `PatchingTests` — left to CI.

## 6. Docs

- `docs/events/binary-serialization.md` — the promotion, the widened registration surface, a "nothing existing breaks" table, and the now-explicit order-independence.
- `docs/documents/sessions.md` — a short section on reaching the event store from a store-agnostic session, including the read/write split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ri7jHRKhaFNBesQM1B5i1k