### PR TITLE
Derive Marten's BinaryEventAttribute from JasperFx's (#5248)

### DIFF
--- a/docs/events/binary-serialization.md
+++ b/docs/events/binary-serialization.md
@@ -159,9 +159,9 @@ is honored by every store.
 - `Marten.Events.IEventBinarySerializer` still exists and now simply **derives** from the JasperFx
   interface while declaring nothing of its own. An existing serializer class compiles untouched and
   is accepted everywhere the JasperFx interface is.
-- `Marten.Events.BinaryEventAttribute` still exists and is still honored. Marten checks for **both**
-  attributes, so a type marked with either is picked up. (Two checks rather than one against a
-  common base because the JasperFx attribute is `sealed`.)
+- `Marten.Events.BinaryEventAttribute` still exists and is still honored. It now **derives** from
+  `JasperFx.Events.BinaryEventAttribute` and declares nothing of its own, so a type marked with
+  either spelling is picked up by one attribute lookup — attribute lookup matches by assignability.
 - `opts.Events.DefaultBinarySerializer` and `opts.Events.UseBinarySerializer<TEvent>(...)` were
   *widened* to accept the JasperFx interface. Every existing call site still compiles, because the
   Marten interface derives from it.

--- a/src/EventSourcingTests/binary_event_serializer_promotion.cs
+++ b/src/EventSourcingTests/binary_event_serializer_promotion.cs
@@ -75,6 +75,25 @@ public class binary_event_serializer_promotion
             .IsBinary.ShouldBeTrue();
     }
 
+    /// <summary>
+    /// jasperfx#672: the promoted attribute was unsealed so Marten's own could derive from it, which
+    /// is what lets ResolveBinarySerializerFor do ONE lookup instead of two. If someone ever unpicks
+    /// the derivation, martens_own_binary_event_attribute_is_still_honored above starts failing —
+    /// this says why, so the fix is to restore the base type rather than to re-add the second check.
+    /// </summary>
+    [Fact]
+    public void martens_attribute_derives_from_the_promoted_one()
+    {
+        typeof(Marten.Events.BinaryEventAttribute)
+            .IsAssignableTo(typeof(JasperFx.Events.BinaryEventAttribute))
+            .ShouldBeTrue();
+
+        // ...which is the whole mechanism: a lookup for the base finds the subclass.
+        typeof(PromotionMartenMarked)
+            .IsDefined(typeof(JasperFx.Events.BinaryEventAttribute), inherit: false)
+            .ShouldBeTrue();
+    }
+
     [Fact]
     public void an_unmarked_event_type_stays_on_the_json_path()
     {

--- a/src/Marten/Events/BinaryEventAttribute.cs
+++ b/src/Marten/Events/BinaryEventAttribute.cs
@@ -30,20 +30,26 @@ namespace Marten.Events;
 ///     <para>
 ///         jasperfx#669 / JasperFx 2.50.0: the attribute was promoted into
 ///         <see cref="JasperFx.Events.BinaryEventAttribute"/> so an event type shared by source
-///         compiled against several Critter Stack stores can declare its intent once. Marten
-///         honors <strong>both</strong> spellings — <see cref="EventGraph.ResolveBinarySerializerFor"/>
-///         tests for either attribute — so this one keeps working untouched and no existing user
-///         has anything to change. Prefer the JasperFx attribute in new code, and use it in any
-///         event type shared across stores.
+///         compiled against several Critter Stack stores can declare its intent once. This one
+///         keeps working untouched and no existing user has anything to change. Prefer the JasperFx
+///         attribute in new code, and use it in any event type shared across stores.
 ///     </para>
 ///     <para>
-///         The two are checked separately rather than this one deriving from the core attribute
-///         (which would have let a single <c>IsDefined</c> against the base cover both): the
-///         promoted <c>JasperFx.Events.BinaryEventAttribute</c> is <c>sealed</c>, so there is no
-///         inheritance to lean on.
+///         jasperfx#672 / JasperFx 2.51.0 unsealed the promoted attribute specifically so this one
+///         could <strong>derive</strong> from it. <see cref="EventGraph.ResolveBinarySerializerFor"/>
+///         used to test for both attribute types separately, because a sealed base left no
+///         inheritance to lean on (CS0509); now a single lookup for
+///         <see cref="JasperFx.Events.BinaryEventAttribute"/> finds this one too, since attribute
+///         lookup matches by assignability.
+///     </para>
+///     <para>
+///         Marten is the only store that subclasses the promoted attribute, and only because of the
+///         back-compat obligation to the users who already applied this one. A store without a
+///         pre-existing attribute should use the JasperFx one directly — a store-namespaced
+///         subclass reintroduces exactly what promoting the attribute removed.
 ///     </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
-public sealed class BinaryEventAttribute: Attribute
+public sealed class BinaryEventAttribute: JasperFx.Events.BinaryEventAttribute
 {
 }

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -448,13 +448,14 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
             return explicitSerializer;
         }
 
-        // jasperfx#669: BOTH attributes are honored. Marten.Events.BinaryEventAttribute is what
-        // every existing user wrote; JasperFx.Events.BinaryEventAttribute is the promoted one an
-        // event type shared across Marten / Polecat / Fisher can declare. Two checks rather than
-        // one against a common base because the promoted attribute is sealed, so Marten's cannot
-        // derive from it.
-        if (eventType.IsDefined(typeof(BinaryEventAttribute), inherit: false)
-            || eventType.IsDefined(typeof(JasperFx.Events.BinaryEventAttribute), inherit: false))
+        // jasperfx#669/#672: BOTH spellings are honored, in ONE lookup. Marten.Events
+        // .BinaryEventAttribute is what every existing user wrote; JasperFx.Events
+        // .BinaryEventAttribute is the promoted one an event type shared across Marten / Polecat /
+        // Fisher can declare. Marten's now derives from the promoted one (2.51.0 unsealed it for
+        // exactly this), and IsDefined matches attributes assignable to the requested type, so the
+        // base lookup finds the subclass. `inherit: false` is unrelated and stays as it was — it
+        // governs the EVENT type's hierarchy, not the attribute class's.
+        if (eventType.IsDefined(typeof(JasperFx.Events.BinaryEventAttribute), inherit: false))
         {
             if (DefaultBinarySerializer is null)
             {


### PR DESCRIPTION
Closes #5248.

> **Stacked on #5252** (the JasperFx 2.51.0 bump), because the unsealing this depends on ships there. Base will need retargeting to `master` once that merges; the diff below is only this change.

## The situation

Marten shipped `Marten.Events.BinaryEventAttribute` for #4515 before jasperfx#669 promoted the same attribute into `JasperFx.Events`. Marten can't delete its own — that breaks anyone who applied it — and couldn't derive from the promoted one either, because it was `sealed` (CS0509). So `EventGraph.ResolveBinarySerializerFor` was checking **both** attribute types on every event type, with no path off that.

## The fix

jasperfx#672 / JasperFx/jasperfx#677 unsealed the promoted attribute specifically so Marten could collapse this:

```csharp
public sealed class BinaryEventAttribute: JasperFx.Events.BinaryEventAttribute;
```

and `ResolveBinarySerializerFor` drops back to one lookup for `JasperFx.Events.BinaryEventAttribute` — `IsDefined` matches attributes *assignable* to the requested type, so the base lookup finds Marten's subclass.

`inherit: false` stays exactly as it was. That parameter governs whether the attribute is inherited down the **event type's** hierarchy; it has nothing to do with attribute-class derivation. JasperFx/jasperfx#677 pins that as a property of the shared package (`an_event_marked_with_a_derived_attribute_is_found_by_the_promoted_one`) rather than an assumption Marten is making, and `martens_attribute_derives_from_the_promoted_one` below pins the Marten half.

Marten's attribute keeps its richer XML docs — the `bdata` / `'{}'::jsonb` column story is genuinely Marten-specific. The docs now also say plainly that Marten is the *only* store that should subclass the promoted attribute, and only because of the back-compat obligation.

## Non-breaking

Existing `[BinaryEvent]` usages compile and resolve unchanged; the only observable difference is the number of lookups inside `ResolveBinarySerializerFor`.

## Verification

- `EventSourcingTests.binary_event_serializer_promotion` — 8/8, including the new `martens_attribute_derives_from_the_promoted_one` and the pre-existing `martens_own_binary_event_attribute_is_still_honored`, which is the behavioral guard on the collapse.
- `Marten.MemoryPack.Tests` — 14/14. Its event types are marked with **Marten's** attribute, so this is the real end-to-end path (append → `bdata` → read back) through the derived attribute, not just a reflection assertion.
- `markdownlint` + `cspell` clean on the changed doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)