### PR TITLE
Honor DocumentComplianceConfig.StreamIdentity in the document fixture (#5249)

### DIFF
--- a/src/Marten.Testing/Harness/MartenDocumentComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenDocumentComplianceFixture.cs
@@ -67,20 +67,27 @@ public class MartenDocumentComplianceFixture: DocumentStorageComplianceFixture
             options.RegisterValueType(valueType);
         }
 
-        // jasperfx#669. Only DocumentSessionEventsCompliance populates this, and unlike the two
-        // loops above it IS load-bearing: that suite appends through a session's Events accessor
-        // with a *string* stream key, and Marten's default StreamIdentity is Guid — so without the
-        // switch below every fact in it fails on the append rather than on the accessor it is
-        // there to hold to a definition. Conditional on the list being non-empty so the four
-        // document-only suites, which share this schema, never provoke event storage at all.
-        if (config.EventTypes.Count != 0)
+        // jasperfx#672 (#5249). The suite states the stream identity it needs and the fixture
+        // replays it, rather than the fixture inferring it. This is load-bearing in the same way
+        // ValueTypes above is not: DocumentSessionEventsCompliance and PendingStreamActionsCompliance
+        // both append by string stream *key*, and Marten's default StreamIdentity is Guid — so a
+        // fixture that drops this fails those suites on the append rather than on the thing they are
+        // there to pin.
+        //
+        // It was previously inferred from EventTypes being non-empty, which happened to reach the
+        // same answer only because every suite populating EventTypes wanted AsString. Nullable, so
+        // null still means "leave the store on its own default" and the four document-only suites
+        // sharing this schema are untouched.
+        if (config.StreamIdentity.HasValue)
         {
-            options.Events.StreamIdentity = StreamIdentity.AsString;
+            options.Events.StreamIdentity = config.StreamIdentity.Value;
+        }
 
-            foreach (var eventType in config.EventTypes)
-            {
-                options.Events.AddEventType(eventType);
-            }
+        // Registering event types does not by itself provoke event storage, so unlike the identity
+        // switch above this needs no guard — for the document-only suites the list is empty.
+        foreach (var eventType in config.EventTypes)
+        {
+            options.Events.AddEventType(eventType);
         }
 
         _store = new DocumentStore(options);


### PR DESCRIPTION
Closes #5249.

> **Stacked on #5252** (the JasperFx 2.51.0 bump), because the config member this replays ships there. Base will need retargeting to `master` once that merges; the diff below is only this change.

## Why the knob exists

`DocumentSessionEventsCompliance` appends by stream **key** throughout, but had no way to say so. Three of its five facts failed on any store defaulting to Guid stream identity — which is every current store, Marten included — with an error naming stream identity and nothing about the suite's requirement. A correct store failing an undocumented precondition is a bug in the suite, so jasperfx#672 / JasperFx/jasperfx#677 added `DocumentComplianceConfig.StreamIdentity` as the fix.

## What changed here

`MartenDocumentComplianceFixture.BuildStoreAsync` replays the declared value alongside `DocumentTypes` and `ValueTypes`:

```csharp
if (config.StreamIdentity.HasValue)
{
    options.Events.StreamIdentity = config.StreamIdentity.Value;
}
```

Marten was previously **inferring** it — flipping to `AsString` whenever `config.EventTypes` was non-empty. That reached the right answer, but only because every suite populating `EventTypes` happened to want `AsString`; it was exactly the guess the knob exists to remove.

Two knock-on details:

- The member is nullable and defaults to null, meaning "leave the store on its own default", so this is additive — the four document-only suites sharing this schema are unaffected and no existing behavior changes.
- The `AddEventType` loop no longer needs the `EventTypes.Count != 0` guard. That guard existed to keep the *identity switch* off the document-only suites; registering event types does not by itself provoke event storage, and for those suites the list is empty anyway.

`PendingStreamActionsCompliance` (#5250) appends by string stream key too and declares the same thing, so honoring the config value now covers it as well.

## Verification

- `EventSourcingTests.Compliance.document_*` — 50/50, all five document suites.
- `document_session_events_compliance` specifically — 5/5. This is the real check: the old inference is gone, so if the declared value were being ignored these five would fail on the append.
- Full `EventSourcingTests.Compliance` namespace — 286/286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)