### PR TITLE
Aggregate snapshot cache for FetchForWriting, on the shared contract (#5251)

### DIFF
--- a/docs/events/optimizing.md
+++ b/docs/events/optimizing.md
@@ -152,6 +152,76 @@ so that updates from new events can be directly applied to the in memory documen
 load those documents over and over again from the database as new events trickle in. This is of course much more effective
 when your projection is constantly updating a relatively small number of different aggregates.
 
+## Caching Aggregate Snapshots for FetchForWriting <Badge type="tip" text="9.26" />
+
+The cache above is the *daemon's*. This one is the command side's: an opt-in, node-local cache of aggregate
+snapshots that lets `FetchForWriting` skip loading the stored snapshot and read only the events after it.
+Think of it as an identity map for aggregates with a lifetime longer than a session.
+
+It is off for every aggregate type, and is enabled per type:
+
+```csharp
+opts.Projections.Snapshot<Order>(SnapshotLifecycle.Async);
+
+// Keep up to 1000 recently fetched Order snapshots
+opts.Events.CacheAggregatesForWriting<Order>(sizeLimit: 1000);
+```
+
+Per type rather than store-wide because the win is proportional to how often *one* stream is fetched for
+writing. It is real on a hot aggregate under high message volume, and only overhead on an aggregate
+written once.
+
+### What it does and does not skip
+
+The cached snapshot is only ever a **baseline**. On every call Marten still reads the stream version and
+every event after the cached version from the database, folds those onto the baseline, and leaves the
+optimistic concurrency assertion on append completely untouched. So a stale entry costs a larger delta
+query — never a wrong aggregate, and never a suppressed `EventStreamUnexpectedMaxEventIdException`.
+
+That is what makes a node-local, deliberately incoherent cache the right shape here, and why there is no
+coherence protocol between nodes and no `IDistributedCache` option: a distributed cache would reintroduce
+exactly the round trip this exists to remove.
+
+::: warning
+A "trusted" variant that also skipped the version read was built, measured and **retired**: it was worth
+0.19 ms of a 13.2 ms round, about 1.4%, in exchange for the concurrency guarantee. Do not reintroduce it.
+:::
+
+### The two lifecycles differ
+
+| | Async | Inline |
+| --- | --- | --- |
+| Cached entry is | a baseline; newer events are folded onto it | usable only on an **exact** version match |
+| Written to the cache | as soon as the fetch completes | only **after a successful commit** |
+
+The asymmetry is not an implementation accident. An Inline snapshot is written in the same transaction as
+the events, so it is always exactly at the stream head and there is no delta query to reconcile a stale
+entry with. And under Inline the projection applies the caller's appended events to the very instance
+`FetchForWriting` handed out, during `SaveChangesAsync` — so an entry written at fetch time would describe
+state that is durable only if that commit happens to succeed. Deferring the write to after the commit
+removes the hazard rather than mitigating it: a rolled-back commit simply leaves no entry, and the next
+fetch reloads from the database.
+
+### Supplying your own cache
+
+The default is a bounded, least-recently-used, in-process cache. Substitute any implementation of the
+three-member `JasperFx.Events.Fetching.IAggregateWriteCache`:
+
+```csharp
+opts.Events.AggregateWriteCaching.Cache = new MyAggregateWriteCache();
+opts.Events.CacheAggregatesForWriting<Order>();
+```
+
+One requirement an implementation owes callers, because it is a correctness property rather than a
+performance detail: `TryTake` must **remove** the entry in the same atomic step it hands it out.
+Aggregates are commonly mutable and Marten folds delta events onto the instance it is given, so exactly
+one caller may ever win an entry. Concurrent callers miss and take the normal uncached path, which is
+always correct. Beyond that an implementation may evict whenever it likes — dropping an entry is always
+sound.
+
+`IAggregateWriteCache` and its supporting types live in `JasperFx.Events`, shared across the Critter
+Stack, so one cache implementation serves Marten, Polecat and Fisher alike.
+
 ## Event Type Index for Projection Rebuilds <Badge type="tip" text="8.29" />
 
 If you have projections that filter on a small subset of event types and your event store has

--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave10.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave10.cs
@@ -1,0 +1,36 @@
+using JasperFx.Events.ComplianceTests;
+using Marten;
+using Marten.Testing.Harness;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * Wave 10 -- the second-level FetchForWriting aggregate snapshot cache, shipped in JasperFx 2.51.0
+ * (jasperfx#674). Marten is the reference implementation again: the shape originated here as the
+ * feature/aggregate-cache-fetchforwriting spike and was promoted into JasperFx.Events so Marten,
+ * Polecat and Fisher share one contract rather than each growing its own.
+ *
+ * Opt-in, like wave 9: a store that has not wired IAggregateWriteCache into its fetch plans does not
+ * enroll, and IComplianceStoreRegistrar.CacheAggregatesForWriting keeps its throwing default.
+ *
+ * The subject of the suite is that turning caching ON is unobservable except in latency -- a hit is
+ * indistinguishable from a miss, including when the baseline is stale, ahead of the stream, or
+ * evicted -- plus the OCC fact that a warm cache does not suppress a concurrency failure. Every one
+ * of those is vacuously true of a store that quietly ignored the opt-in, so the suite supplies its
+ * own RecordingAggregateWriteCache and asserts a nonzero hit count, exactly the way the binary
+ * serialization suite gzips to prove its serializer ran.
+ *
+ * It covers both lifecycles with the daemon deliberately never started, so the Async aggregate's
+ * stored snapshot always lags and every fetch has a real delta to fold. It does NOT pin when an
+ * entry is written, because that genuinely differs by lifecycle -- Marten writes the Async entry as
+ * soon as the fetch completes, and defers the Inline one to AfterCommitAsync because the inline
+ * projection mutates the very instance the caller was handed.
+ *
+ * The Marten-specific tests in EventSourcingTests/FetchForWriting/caching_*_aggregates_for_writing
+ * stay: they assert things the shared suite deliberately does not, notably that a hit folds ONLY
+ * the delta (counted in queries rather than watched on a hit counter) and that a failed commit
+ * leaves no entry behind, inspected directly on the cache.
+ */
+
+public class aggregate_write_cache_compliance
+    : AggregateWriteCacheCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;

--- a/src/EventSourcingTests/FetchForWriting/caching_async_aggregates_for_writing.cs
+++ b/src/EventSourcingTests/FetchForWriting/caching_async_aggregates_for_writing.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using JasperFx.Events.Fetching;
+using Marten.Events.Fetching;
+using Marten.Exceptions;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.FetchForWriting;
+
+/// <summary>
+///     Covers the opt in aggregate snapshot cache for FetchForWriting against Async lifecycle projections.
+///     The load bearing claim under test is that the cache is only ever a *baseline*: the stream version and
+///     the events after the cached version are always read from the database, so a stale or even wrong entry
+///     degrades to a bigger delta query rather than a wrong aggregate.
+/// </summary>
+public class caching_async_aggregates_for_writing: OneOffConfigurationsContext
+{
+    private readonly MartenTestAggregateWriteCache theCache = new();
+
+    private void UseCachedAsyncSnapshots()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Async);
+            opts.Events.AggregateWriteCaching.Cache = theCache;
+            opts.Events.CacheAggregatesForWriting<SimpleAggregate>();
+        });
+    }
+
+    [Fact]
+    public async Task cold_fetch_matches_the_uncached_aggregate_and_seeds_the_cache()
+    {
+        UseCachedAsyncSnapshots();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent(), new BEvent(),
+            new BEvent(), new CEvent(), new CEvent());
+        await theSession.SaveChangesAsync();
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        theCache.Hits.ShouldBe(0);
+        theCache.Misses.ShouldBe(1);
+
+        stream.CurrentVersion.ShouldBe(6);
+
+        // Cross check against an independent live replay of the same stream
+        var expected = await session.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+        stream.Aggregate.ACount.ShouldBe(expected.ACount);
+        stream.Aggregate.BCount.ShouldBe(expected.BCount);
+        stream.Aggregate.CCount.ShouldBe(expected.CCount);
+        stream.Aggregate.Id.ShouldBe(streamId);
+
+        // ... and the fetch left a snapshot behind at the stream version
+        var (_, version) = theCache.SingleEntry();
+        version.ShouldBe(6);
+    }
+
+    [Fact]
+    public async Task cache_hit_folds_only_the_delta()
+    {
+        UseCachedAsyncSnapshots();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        // Seed the cache
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        // Deliberately poison the cached baseline. If the next fetch replays the whole stream, ACount comes
+        // back 5; if it folds only events 4 and 5 onto the baseline we handed it, it comes back 102. There
+        // is no other way to land on 102.
+        var key = theCache.SingleKey();
+        theCache.Overwrite(key, new SimpleAggregate { Id = streamId, ACount = 100 }, 3);
+
+        await using (var other = theStore.LightweightSession())
+        {
+            other.Events.Append(streamId, new AEvent(), new AEvent());
+            await other.SaveChangesAsync();
+        }
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        theCache.Hits.ShouldBe(1);
+        stream.CurrentVersion.ShouldBe(5);
+        stream.Aggregate.ACount.ShouldBe(102);
+
+        // and the poisoned-but-now-folded snapshot is written back at the real stream version
+        var (aggregate, version) = theCache.SingleEntry();
+        version.ShouldBe(5);
+        ((SimpleAggregate)aggregate).ACount.ShouldBe(102);
+    }
+
+    [Fact]
+    public async Task stale_cache_entry_still_yields_the_correct_aggregate()
+    {
+        UseCachedAsyncSnapshots();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        // The cache is now three versions behind
+        await using (var other = theStore.LightweightSession())
+        {
+            other.Events.Append(streamId, new BEvent(), new BEvent(), new CEvent());
+            await other.SaveChangesAsync();
+        }
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        theCache.Hits.ShouldBe(1);
+        stream.CurrentVersion.ShouldBe(6);
+
+        var expected = await session.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+        stream.Aggregate.ACount.ShouldBe(expected.ACount);
+        stream.Aggregate.BCount.ShouldBe(expected.BCount);
+        stream.Aggregate.CCount.ShouldBe(expected.CCount);
+    }
+
+    [Fact]
+    public async Task optimistic_concurrency_still_fires_against_a_warm_cache()
+    {
+        UseCachedAsyncSnapshots();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+        theCache.Hits.ShouldBe(1);
+        stream.CurrentVersion.ShouldBe(3);
+        stream.AppendOne(new EEvent());
+
+        // Somebody else gets there first
+        await using (var other = theStore.LightweightSession())
+        {
+            other.Events.Append(streamId, new EEvent());
+            await other.SaveChangesAsync();
+        }
+
+        // The safety net is untouched by the cache
+        await Should.ThrowAsync<EventStreamUnexpectedMaxEventIdException>(async () =>
+        {
+            await session.SaveChangesAsync();
+        });
+    }
+
+    [Fact]
+    public async Task cache_ahead_of_the_database_falls_back_to_the_uncached_path()
+    {
+        UseCachedAsyncSnapshots();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        // Pretend the database was restored out from under a cache that had run ahead
+        var key = theCache.SingleKey();
+        theCache.Overwrite(key, new SimpleAggregate { Id = streamId, ACount = 100 }, 99);
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        stream.CurrentVersion.ShouldBe(3);
+        stream.Aggregate.ACount.ShouldBe(3);
+
+        // and the cache healed itself on the same call rather than staying poisoned
+        var (aggregate, version) = theCache.SingleEntry();
+        version.ShouldBe(3);
+        ((SimpleAggregate)aggregate).ACount.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task cached_aggregates_do_not_leak_across_tenants()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Async).MultiTenanted();
+            opts.Events.AggregateWriteCaching.Cache = theCache;
+            opts.Events.CacheAggregatesForWriting<SimpleAggregate>();
+        });
+
+        // Same stream id, two tenants, deliberately different shapes
+        var streamId = Guid.NewGuid();
+
+        await using (var one = theStore.LightweightSession("one"))
+        {
+            one.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+            await one.SaveChangesAsync();
+        }
+
+        await using (var two = theStore.LightweightSession("two"))
+        {
+            two.Events.StartStream<SimpleAggregate>(streamId, new BEvent(), new BEvent());
+            await two.SaveChangesAsync();
+        }
+
+        // Cold fetches to seed both tenants
+        await using (var one = theStore.LightweightSession("one"))
+        {
+            var stream = await one.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.Aggregate.ACount.ShouldBe(3);
+            stream.Aggregate.BCount.ShouldBe(0);
+        }
+
+        await using (var two = theStore.LightweightSession("two"))
+        {
+            var stream = await two.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.Aggregate.ACount.ShouldBe(0);
+            stream.Aggregate.BCount.ShouldBe(2);
+        }
+
+        theCache.Keys.Count.ShouldBe(2);
+        theCache.Keys.Select(x => x.TenantId).OrderBy(x => x).ShouldBe(new[] { "one", "two" });
+
+        // Warm fetches must stay in their lane
+        await using (var one = theStore.LightweightSession("one"))
+        {
+            var stream = await one.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.Aggregate.ACount.ShouldBe(3);
+            stream.Aggregate.BCount.ShouldBe(0);
+        }
+
+        await using (var two = theStore.LightweightSession("two"))
+        {
+            var stream = await two.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.Aggregate.ACount.ShouldBe(0);
+            stream.Aggregate.BCount.ShouldBe(2);
+        }
+
+        theCache.Hits.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task caching_is_off_unless_the_aggregate_type_opts_in()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Async);
+            opts.Events.AggregateWriteCaching.Cache = theCache;
+            // deliberately NOT calling CacheAggregatesForWriting<SimpleAggregate>()
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using var session = theStore.LightweightSession();
+        await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+        await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        theCache.Hits.ShouldBe(0);
+        theCache.Misses.ShouldBe(0);
+        theCache.Keys.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void take_is_exclusive_so_two_readers_cannot_share_one_mutable_instance()
+    {
+        var cache = new RecentlyUsedAggregateWriteCache(10);
+        var key = new AggregateCacheKey(typeof(SimpleAggregate), "db", "*DEFAULT*", Guid.NewGuid());
+        cache.Store(key, new SimpleAggregate(), 4);
+
+        cache.TryTake(key, out var first, out var firstVersion).ShouldBeTrue();
+        first.ShouldNotBeNull();
+        firstVersion.ShouldBe(4);
+
+        // Take-on-read: the second caller misses and takes the uncached path rather than folding delta
+        // events onto the same instance the first caller is holding.
+        cache.TryTake(key, out _, out _).ShouldBeFalse();
+    }
+}
+
+/// <summary>
+///     Test double with the same take-on-read contract as the real cache, but with the guts exposed so a
+///     test can seed a deliberately stale or wrong entry.
+/// </summary>
+public class MartenTestAggregateWriteCache: IAggregateWriteCache
+{
+    private readonly ConcurrentDictionary<AggregateCacheKey, (object Aggregate, long Version)> _entries = new();
+
+    public long Hits { get; private set; }
+    public long Misses { get; private set; }
+
+    public IReadOnlyList<AggregateCacheKey> Keys => _entries.Keys.ToList();
+
+    public bool TryTake(AggregateCacheKey key, [NotNullWhen(true)] out object? aggregate, out long version)
+    {
+        if (_entries.TryRemove(key, out var entry))
+        {
+            aggregate = entry.Aggregate;
+            version = entry.Version;
+            Hits++;
+            return true;
+        }
+
+        aggregate = default;
+        version = 0;
+        Misses++;
+        return false;
+    }
+
+    public void Store(AggregateCacheKey key, object aggregate, long version)
+    {
+        _entries[key] = (aggregate, version);
+    }
+
+    public void Evict(AggregateCacheKey key)
+    {
+        _entries.TryRemove(key, out _);
+    }
+
+    public AggregateCacheKey SingleKey()
+    {
+        return _entries.Keys.Single();
+    }
+
+    public (object Aggregate, long Version) SingleEntry()
+    {
+        return _entries.Values.Single();
+    }
+
+    public void Overwrite(AggregateCacheKey key, object aggregate, long version)
+    {
+        _entries[key] = (aggregate, version);
+    }
+}

--- a/src/EventSourcingTests/FetchForWriting/caching_inline_aggregates_for_writing.cs
+++ b/src/EventSourcingTests/FetchForWriting/caching_inline_aggregates_for_writing.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
+using JasperFx.Events.Fetching;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.FetchForWriting;
+
+/// <summary>
+///     Covers the opt in aggregate snapshot cache for FetchForWriting against <b>Inline</b> lifecycle
+///     projections, which behave differently from Async in two load bearing ways:
+///     <list type="number">
+///         <item>An Inline snapshot is written in the same transaction as the events, so it is always
+///         exactly at the stream head. There is no delta query to reconcile a stale entry with, so a cached
+///         entry is usable only on an exact version match and anything else falls back to the database.</item>
+///         <item>The inline projection applies the caller's appended events to the very instance
+///         FetchForWriting handed out, during the commit. So the entry may only be written back <i>after</i>
+///         a successful commit -- writing it at fetch time would leave the cache describing state that is
+///         durable only if SaveChangesAsync happens to succeed.</item>
+///     </list>
+/// </summary>
+public class caching_inline_aggregates_for_writing: OneOffConfigurationsContext
+{
+    private readonly MartenTestAggregateWriteCache theCache = new();
+
+    private void UseCachedInlineSnapshots()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline);
+            opts.Events.AggregateWriteCaching.Cache = theCache;
+            opts.Events.CacheAggregatesForWriting<SimpleAggregate>();
+        });
+    }
+
+    [Fact]
+    public async Task cold_fetch_misses_and_seeds_the_cache_only_after_the_commit()
+    {
+        UseCachedInlineSnapshots();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent(), new BEvent());
+        await theSession.SaveChangesAsync();
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        theCache.Hits.ShouldBe(0);
+        theCache.Misses.ShouldBe(1);
+
+        // Nothing cached yet -- the commit has not happened, so nothing is known to be durable
+        theCache.Keys.ShouldBeEmpty();
+
+        stream.AppendOne(new CEvent());
+        await session.SaveChangesAsync();
+
+        // ...and now it is, at the version the commit actually landed on
+        theCache.SingleEntry().Version.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task a_cache_hit_returns_the_same_aggregate_as_the_uncached_path()
+    {
+        UseCachedInlineSnapshots();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent(), new BEvent(),
+            new CEvent());
+        await theSession.SaveChangesAsync();
+
+        // Round one seeds the cache
+        // Note the append: a session that fetches and then commits *nothing* has no commit to hook, so
+        // the write back only happens on rounds that actually change the stream.
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            var warmUpStream = await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+            warmUpStream.AppendOne(new AEvent());
+            await warmUp.SaveChangesAsync();
+        }
+
+        theCache.Keys.Count.ShouldBe(1);
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        theCache.Hits.ShouldBe(1);
+
+        stream.CurrentVersion.ShouldBe(5);
+
+        var expected = await session.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+        stream.Aggregate.ACount.ShouldBe(expected.ACount);
+        stream.Aggregate.BCount.ShouldBe(expected.BCount);
+        stream.Aggregate.CCount.ShouldBe(expected.CCount);
+    }
+
+    [Fact]
+    public async Task a_stale_entry_falls_back_to_the_database_rather_than_returning_it()
+    {
+        UseCachedInlineSnapshots();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent());
+        await theSession.SaveChangesAsync();
+
+        // Seed the cache at version 2
+        // Note the append: a session that fetches and then commits *nothing* has no commit to hook, so
+        // the write back only happens on rounds that actually change the stream.
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            var warmUpStream = await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+            warmUpStream.AppendOne(new AEvent());
+            await warmUp.SaveChangesAsync();
+        }
+
+        // Something else moves the stream past the cached entry. This session does not go through
+        // FetchForWriting, so the cache is left behind at version 2 while the database is at 5.
+        await using (var other = theStore.LightweightSession())
+        {
+            other.Events.Append(streamId, new CEvent(), new CEvent(), new CEvent());
+            await other.SaveChangesAsync();
+        }
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        // The stale entry must not be handed back -- an Inline snapshot has no delta fold to repair it
+        stream.CurrentVersion.ShouldBe(6);
+
+        var expected = await session.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+        stream.Aggregate.ACount.ShouldBe(expected.ACount);
+        stream.Aggregate.BCount.ShouldBe(expected.BCount);
+        stream.Aggregate.CCount.ShouldBe(expected.CCount);
+    }
+
+    [Fact]
+    public async Task a_failed_commit_leaves_no_entry_behind()
+    {
+        UseCachedInlineSnapshots();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent());
+        await theSession.SaveChangesAsync();
+
+        // Seed the cache at version 2
+        // Note the append: a session that fetches and then commits *nothing* has no commit to hook, so
+        // the write back only happens on rounds that actually change the stream.
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            var warmUpStream = await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+            warmUpStream.AppendOne(new AEvent());
+            await warmUp.SaveChangesAsync();
+        }
+
+        theCache.SingleEntry().Version.ShouldBe(3);
+
+        // Fetch (taking the entry out of the cache), mutate through an append, then fail the commit by
+        // racing another writer to the same stream so the OCC assertion trips.
+        await using (var doomed = theStore.LightweightSession())
+        {
+            var stream = await doomed.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.AppendOne(new CEvent());
+
+            await using (var racer = theStore.LightweightSession())
+            {
+                racer.Events.Append(streamId, new CEvent());
+                await racer.SaveChangesAsync();
+            }
+
+            await Should.ThrowAsync<Exception>(async () => await doomed.SaveChangesAsync());
+        }
+
+        // The decisive assertion: take-on-read removed the entry at fetch time and the failed commit never
+        // wrote one back, so the cache is empty rather than holding an aggregate that was mutated past what
+        // the database durably has.
+        theCache.Keys.ShouldBeEmpty();
+
+        // ...and the next fetch is therefore correct
+        await using var session = theStore.LightweightSession();
+        var recovered = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+        var expected = await session.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+
+        recovered.Aggregate.ACount.ShouldBe(expected.ACount);
+        recovered.Aggregate.BCount.ShouldBe(expected.BCount);
+        recovered.Aggregate.CCount.ShouldBe(expected.CCount);
+    }
+
+    [Fact]
+    public async Task repeated_fetch_write_rounds_stay_correct_across_many_hits()
+    {
+        UseCachedInlineSnapshots();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent());
+        await theSession.SaveChangesAsync();
+
+        for (var i = 0; i < 12; i++)
+        {
+            await using var session = theStore.LightweightSession();
+            var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.AppendOne(new BEvent());
+            stream.AppendOne(new CEvent());
+            await session.SaveChangesAsync();
+        }
+
+        await using var verify = theStore.LightweightSession();
+        var actual = await verify.LoadAsync<SimpleAggregate>(streamId);
+        var expected = await verify.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+
+        actual.ACount.ShouldBe(expected.ACount);
+        actual.BCount.ShouldBe(expected.BCount);
+        actual.CCount.ShouldBe(expected.CCount);
+        actual.BCount.ShouldBe(12);
+        actual.CCount.ShouldBe(12);
+
+        // Every round after the first took its snapshot from the cache
+        theCache.Hits.ShouldBe(11);
+    }
+}

--- a/src/Marten.Testing/Harness/MartenComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenComplianceFixture.cs
@@ -233,6 +233,18 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
         public void Snapshot<TDoc>(SnapshotLifecycle lifecycle) where TDoc : notnull
             => _options.Projections.Snapshot<TDoc>(lifecycle);
 
+        /// <summary>
+        ///     jasperfx#674 (#5251). Two lines against the shared <c>EventRegistry</c> surface, which is
+        ///     the point: the enrollment and the cache slot are both inherited, and all the registrar
+        ///     supplies is which options object the store hangs its event registry off.
+        /// </summary>
+        public void CacheAggregatesForWriting<TDoc>(JasperFx.Events.Fetching.IAggregateWriteCache cache)
+            where TDoc : class
+        {
+            _options.Events.AggregateWriteCaching.Cache = cache;
+            _options.Events.CacheAggregatesForWriting<TDoc>();
+        }
+
         public void LiveAggregation<TDoc>() where TDoc : notnull
             => _options.Projections.LiveStreamAggregation<TDoc>();
 

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -15,6 +15,7 @@ using JasperFx.Events.Projections;
 using JasperFx.Events.Subscriptions;
 using JasperFx.Events.Tags;
 using Marten.Events.Aggregation;
+using Marten.Events.Fetching;
 using Marten.Events.Schema;
 using Marten.Exceptions;
 using Marten.Internal;
@@ -921,6 +922,52 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     }
 
     public List<Type> GlobalAggregates { get; } = new();
+
+    /// <summary>
+    ///     Keep recently fetched snapshots of <typeparamref name="T" /> in a node local cache so that a
+    ///     subsequent FetchForWriting can skip loading the stored snapshot and read only the events after
+    ///     it. Effectively an identity map for aggregates with a lifetime longer than a session.
+    ///     <para>
+    ///     The cache is never trusted blindly. The stream version is still read from the database on every
+    ///     call, and the optimistic concurrency assertion on append is untouched, so a stale entry costs an
+    ///     extra query and never yields a wrong aggregate. See
+    ///     <see cref="JasperFx.Events.Fetching.IAggregateWriteCache" /> for the full semantics, which are
+    ///     shared with every other Critter Stack store (jasperfx#674).
+    ///     </para>
+    ///     <para>
+    ///     Supported for both <see cref="ProjectionLifecycle.Async" /> and
+    ///     <see cref="ProjectionLifecycle.Inline" />, but they behave differently:
+    ///     </para>
+    ///     <list type="bullet">
+    ///         <item><b>Async</b> — the cached snapshot is a <i>baseline</i>. Events after the cached
+    ///         version are read and folded onto it, so a stale entry just means a larger delta query. The
+    ///         entry is written as soon as the fetch completes, because the daemon (not the session) applies
+    ///         appended events, so the instance cannot drift ahead of the database.</item>
+    ///         <item><b>Inline</b> — the stored snapshot is written in the same transaction as the events
+    ///         and so is always exactly at the stream head. A cached entry is therefore only usable on an
+    ///         <i>exact</i> version match, and anything else falls back to loading the snapshot. The entry
+    ///         is written back only <i>after a successful commit</i>, because the inline projection applies
+    ///         the caller's events to the fetched instance during that commit.</item>
+    ///     </list>
+    /// </summary>
+    /// <param name="sizeLimit">Maximum number of cached aggregates, when the default cache is built</param>
+    /// <remarks>
+    ///     Overridden rather than merely inherited from <see cref="EventRegistry" /> because the write back
+    ///     for the Inline lifecycle needs a session listener, and where a listener lives is Marten's own
+    ///     business. The enrollment itself — the type set, the size limit, resolving the cache — is the
+    ///     shared registry's.
+    /// </remarks>
+    public override void CacheAggregatesForWriting<T>(int sizeLimit = 1000)
+    {
+        base.CacheAggregatesForWriting<T>(sizeLimit);
+
+        // Inline aggregates are written back to the cache only after a successful commit, which needs a
+        // session listener. Harmless for Async-only usage -- the listener no-ops when nothing was tracked.
+        if (!Options.Listeners.Contains(AggregateWriteCacheListener.Instance))
+        {
+            Options.Listeners.Add(AggregateWriteCacheListener.Instance);
+        }
+    }
 
     internal DocumentProvider<IEvent>? Provider { get; private set; }
 

--- a/src/Marten/Events/Fetching/AggregateWriteCacheWriteBack.cs
+++ b/src/Marten/Events/Fetching/AggregateWriteCacheWriteBack.cs
@@ -1,0 +1,113 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten.Internal;
+using Marten.Services;
+using JasperFx.Events.Fetching;
+
+namespace Marten.Events.Fetching;
+
+/// <summary>
+///     Aggregates fetched through a caching <c>FetchForWriting</c> in one session, waiting to be written
+///     back to the cache once the session commits. Lives in the session's item map, so it is per session
+///     and disappears with it.
+/// </summary>
+/// <remarks>
+///     This is the piece that makes caching safe under the <b>Inline</b> lifecycle. Under Async, the
+///     aggregate handed to the caller cannot drift ahead of the database — the daemon applies appended
+///     events later — so <see cref="FetchAsyncPlan{TDoc,TId}" /> can write to the cache the moment it has
+///     folded the delta. Under Inline that is a silent poisoning: the inline projection applies the
+///     caller's new events to <i>this very instance</i> during commit, so an entry stored at fetch time
+///     would be left describing state that is only durable if the commit succeeds.
+///
+///     Deferring the store to <see cref="IChangeListener.AfterCommitAsync" /> removes the hazard entirely
+///     rather than mitigating it. Combined with take-on-read (<see cref="IAggregateWriteCache.TryTake" />,
+///     which removes the entry as it hands it out) the failure path needs no compensation at all: a
+///     rolled-back commit simply leaves no entry, and the next fetch misses and reloads from the database.
+/// </remarks>
+internal sealed class PendingAggregateCacheWrites
+{
+    private readonly List<Entry> _entries = new();
+
+    public IReadOnlyList<Entry> Entries => _entries;
+
+    public void Track(IAggregateWriteCache cache, AggregateCacheKey key, object aggregate, object streamId,
+        long fetchedVersion)
+    {
+        _entries.Add(new Entry(cache, key, aggregate, streamId, fetchedVersion));
+    }
+
+    internal sealed record Entry(
+        IAggregateWriteCache Cache,
+        AggregateCacheKey Key,
+        object Aggregate,
+        object StreamId,
+        long FetchedVersion);
+}
+
+/// <summary>
+///     Writes aggregates back to the <see cref="IAggregateWriteCache" /> after a successful commit, at the
+///     stream version the commit actually landed on. Registered automatically the first time any aggregate
+///     type opts into caching.
+/// </summary>
+internal sealed class AggregateWriteCacheListener: DocumentSessionListenerBase
+{
+    public static readonly AggregateWriteCacheListener Instance = new();
+
+    public override Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+    {
+        if (session is not IMartenSession martenSession) return Task.CompletedTask;
+
+        if (!martenSession.ItemMap.TryGetValue(typeof(PendingAggregateCacheWrites), out var raw) ||
+            raw is not PendingAggregateCacheWrites pending || pending.Entries.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        // Only remove after a *successful* commit. If SaveChangesAsync threw, this listener never runs, the
+        // pending entries die with the session, and the cache is simply left without an entry -- which is
+        // the correct state, because take-on-read already removed the stale one at fetch time.
+        martenSession.ItemMap.Remove(typeof(PendingAggregateCacheWrites));
+
+        var streams = commit.GetStreams().ToArray();
+
+        foreach (var entry in pending.Entries)
+        {
+            // The committed StreamAction carries the version the stream ended up at. When this session
+            // appended nothing to the stream there is no StreamAction, and the aggregate is still exactly
+            // what was fetched -- so fall back to the fetched version rather than skipping the write back.
+            var version = versionFor(streams, entry.StreamId) ?? entry.FetchedVersion;
+
+            if (version > 0)
+            {
+                entry.Cache.Store(entry.Key, entry.Aggregate, version);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static long? versionFor(StreamAction[] streams, object streamId)
+    {
+        foreach (var stream in streams)
+        {
+            // Marten streams are identified by Guid or by string depending on StreamIdentity, and the
+            // unused slot is left at its default -- so match on whichever one this aggregate was fetched by
+            // rather than assuming an identity style.
+            if (streamId is Guid guid)
+            {
+                if (stream.Id == guid) return stream.Version;
+            }
+            else if (streamId is string key)
+            {
+                if (stream.Key == key) return stream.Version;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.ForUpdate.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.ForUpdate.cs
@@ -14,6 +14,7 @@ using Marten.Linq.QueryHandlers;
 using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
+using JasperFx.Events.Fetching;
 
 namespace Marten.Events.Fetching;
 
@@ -23,6 +24,26 @@ internal partial class FetchAsyncPlan<TDoc, TId>
     [MemberNotNull(nameof(_initialSql))]
     public async Task<IEventStream<TDoc>> FetchForWriting(DocumentSessionBase session, TId id, bool forUpdate, CancellationToken cancellation = default)
     {
+        try
+        {
+            return await fetchForWriting(session, id, forUpdate, true, cancellation).ConfigureAwait(false);
+        }
+        catch (CacheAheadOfDatabaseException)
+        {
+            // The cached snapshot claimed a higher version than the stream actually has, so the delta
+            // query could not possibly reconstitute it. TryTake already removed the entry; redo the fetch
+            // on the normal, always-correct uncached path -- but still write the result back, so the cache
+            // heals in one round instead of two. Rare enough to not be worth optimizing further.
+            return await fetchForWriting(session, id, forUpdate, false, cancellation).ConfigureAwait(false);
+        }
+    }
+
+    [MemberNotNull(nameof(_initialSql))]
+    private async Task<IEventStream<TDoc>> fetchForWriting(DocumentSessionBase session, TId id, bool forUpdate,
+        bool useCachedSnapshot, CancellationToken cancellation)
+    {
+        var cache = _cache;
+
         await _identityStrategy.EnsureEventStorageExists<TDoc>(session, cancellation).ConfigureAwait(false);
         await session.Database.EnsureStorageExistsAsync(typeof(TDoc), cancellation).ConfigureAwait(false);
 
@@ -30,6 +51,12 @@ internal partial class FetchAsyncPlan<TDoc, TId>
             .ConfigureAwait(false);
 
         ensureInitialSql(selector);
+
+        var cacheKey = cache == null ? default : cacheKeyFor(session, id);
+        object? cachedAggregate = null;
+        var cachedVersion = 0L;
+        var cacheHit = cache != null && useCachedSnapshot &&
+                       cache.TryTake(cacheKey, out cachedAggregate, out cachedVersion);
 
         if (forUpdate)
         {
@@ -47,12 +74,20 @@ internal partial class FetchAsyncPlan<TDoc, TId>
 
         builder.StartNewCommand();
 
+        // On a cache hit the snapshot load is exactly the round trip we are here to skip
         var loadHandler = new LoadByIdHandler<TDoc, TId>(_storage, id);
-        loadHandler.ConfigureCommand(builder, session);
+        if (!cacheHit)
+        {
+            loadHandler.ConfigureCommand(builder, session);
 
-        builder.StartNewCommand();
+            builder.StartNewCommand();
 
-        writeEventFetchStatement(id, builder);
+            writeEventFetchStatement(id, builder);
+        }
+        else
+        {
+            writeCachedEventFetchStatement(id, cachedVersion, builder);
+        }
 
         if (!forUpdate)
         {
@@ -66,7 +101,12 @@ internal partial class FetchAsyncPlan<TDoc, TId>
             await using var reader =
                 await session.ExecuteReaderAsync(batch, cancellation).ConfigureAwait(false);
 
-            return await ReadIntoStream(session, id, cancellation, reader, loadHandler, selector).ConfigureAwait(false);
+            return await ReadIntoStream(session, id, cancellation, reader, loadHandler, selector,
+                new CacheAttempt(cache, cacheKey, cacheHit, cachedAggregate, cachedVersion)).ConfigureAwait(false);
+        }
+        catch (CacheAheadOfDatabaseException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -84,6 +124,28 @@ internal partial class FetchAsyncPlan<TDoc, TId>
         }
     }
 
+    /// <summary>
+    ///     Everything the read side needs to know about a cache attempt. Default value == caching off.
+    /// </summary>
+    private readonly record struct CacheAttempt(
+        IAggregateWriteCache? Cache,
+        AggregateCacheKey Key,
+        bool Hit,
+        object? Aggregate,
+        long Version);
+
+    /// <summary>
+    ///     Signals that a cached snapshot was ahead of the database and the fetch must be redone uncached.
+    ///     Never escapes <see cref="FetchForWriting" />.
+    /// </summary>
+    /// <remarks>
+    ///     Derives from <see cref="MartenException" /> even though it is private and never observable,
+    ///     because <c>all_exceptions_should_derive_from_MartenException</c> is a whole-assembly convention
+    ///     rather than a rule about the public surface — and a convention with a nested-private carve-out
+    ///     stops being one.
+    /// </remarks>
+    private sealed class CacheAheadOfDatabaseException: MartenException;
+
     private void ensureInitialSql(IEventStorage selector)
     {
         _initialSql ??=
@@ -91,7 +153,8 @@ internal partial class FetchAsyncPlan<TDoc, TId>
     }
 
     private async Task<IEventStream<TDoc>> ReadIntoStream(DocumentSessionBase session, TId id, CancellationToken cancellation,
-        DbDataReader reader, LoadByIdHandler<TDoc, TId> loadHandler, IEventStorage selector)
+        DbDataReader reader, LoadByIdHandler<TDoc, TId> loadHandler, IEventStorage selector,
+        CacheAttempt cacheAttempt = default)
     {
         long version = 0;
         try
@@ -102,9 +165,29 @@ internal partial class FetchAsyncPlan<TDoc, TId>
                 version = await reader.GetFieldValueAsync<long>(0, cancellation).ConfigureAwait(false);
             }
 
-            // Fetch the existing aggregate -- if any!
-            await reader.NextResultAsync(cancellation).ConfigureAwait(false);
-            var document = await loadHandler.HandleAsync(reader, session, cancellation).ConfigureAwait(false);
+            TDoc? document;
+            if (cacheAttempt.Hit)
+            {
+                if (cacheAttempt.Version > version)
+                {
+                    // The cache is ahead of the database -- a restore, a rollback, or a key collision bug.
+                    // The snapshot was never fetched in this batch so there is nothing to recover from here.
+                    // Drain the batch so the connection is left clean, then let FetchForWriting retry uncached.
+                    while (await reader.NextResultAsync(cancellation).ConfigureAwait(false))
+                    {
+                    }
+
+                    throw new CacheAheadOfDatabaseException();
+                }
+
+                document = (TDoc)cacheAttempt.Aggregate!;
+            }
+            else
+            {
+                // Fetch the existing aggregate -- if any!
+                await reader.NextResultAsync(cancellation).ConfigureAwait(false);
+                document = await loadHandler.HandleAsync(reader, session, cancellation).ConfigureAwait(false);
+            }
 
             // Read in any events from after the current state of the aggregate
             await reader.NextResultAsync(cancellation).ConfigureAwait(false);
@@ -122,6 +205,14 @@ internal partial class FetchAsyncPlan<TDoc, TId>
                 _storage.SetIdentity(document, id);
             }
 
+            // The aggregate is now at the stream version, which is durable truth regardless of what the
+            // caller does with the stream next. Under the Async lifecycle any events the caller appends are
+            // not applied to this instance in session, so it cannot drift ahead of the database.
+            if (cacheAttempt.Cache != null && document != null && version > 0)
+            {
+                cacheAttempt.Cache.Store(cacheAttempt.Key, document, version);
+            }
+
             var stream = version == 0
                 ? _identityStrategy.StartStream(document, session, id, cancellation)
                 : _identityStrategy.AppendToStream(document, session, id, version, cancellation);
@@ -133,6 +224,10 @@ internal partial class FetchAsyncPlan<TDoc, TId>
             }
 
             return stream;
+        }
+        catch (CacheAheadOfDatabaseException)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.cs
@@ -1,10 +1,12 @@
 using JasperFx.Core.Reflection;
 using JasperFx.Events.Aggregation;
 using JasperFx.Events.Projections;
+using Marten.Internal.Sessions;
 using Marten.Internal.Storage;
 using Marten.Storage;
 using Weasel.Postgresql;
 using System.Diagnostics.CodeAnalysis;
+using JasperFx.Events.Fetching;
 
 namespace Marten.Events.Fetching;
 
@@ -20,6 +22,8 @@ internal partial class FetchAsyncPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId>
     private readonly IDocumentStorage<TDoc, TId> _storage;
     private readonly string _versionSelectionSql;
     private readonly string _aggregateTypeName = typeof(TDoc).FullNameInCode();
+    private readonly string _cachedVersionSelectionSql;
+    private readonly IAggregateWriteCache? _cache;
     private string? _initialSql;
 
     public FetchAsyncPlan(EventGraph events, IEventIdentityStrategy<TId> identityStrategy,
@@ -48,6 +52,20 @@ internal partial class FetchAsyncPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId>
             _versionSelectionSql =
                 $" left outer join {storage.TableName.QualifiedName} as a on d.stream_id = a.id and d.tenant_id = a.tenant_id where (a.mt_version is NULL or d.version > a.mt_version) and d.stream_id = ";
         }
+
+        // The cached path knows its baseline version up front, so it needs no join to the aggregate
+        // table at all -- just the events after the snapshot we already hold.
+        _cachedVersionSelectionSql = " where d.stream_id = ";
+
+        // Resolved once per plan, never per fetch. ResolveCache(Type) hands back
+        // NulloAggregateWriteCache for a type nobody enrolled, so a store *may* drop this branch and
+        // let every take miss -- Marten deliberately does not. The cached path builds an
+        // AggregateCacheKey per fetch, which boxes the stream id, and dropping the branch would put
+        // that allocation on every FetchForWriting in every store that never opted in.
+        if (_events.AggregateWriteCaching.IsEnabled(typeof(TDoc)))
+        {
+            _cache = _events.AggregateWriteCaching.ResolveCache(typeof(TDoc));
+        }
     }
 
     public bool IsGlobal { get; }
@@ -68,5 +86,40 @@ internal partial class FetchAsyncPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId>
             builder.Append(" and d.tenant_id = ");
             builder.AppendParameter(builder.TenantId);
         }
+    }
+
+    /// <summary>
+    ///     The delta query for a cache hit: only the events after the version of the snapshot we already
+    ///     hold in memory. Mirrors the tenancy branching of <see cref="writeEventFetchStatement" />.
+    /// </summary>
+    private void writeCachedEventFetchStatement(TId id, long baselineVersion, ICommandBuilder builder)
+    {
+        builder.Append(_initialSql!);
+        builder.Append(_cachedVersionSelectionSql);
+        builder.AppendParameter(id);
+
+        builder.Append(" and d.version > ");
+        builder.AppendParameter(baselineVersion);
+
+        // You must do this for performance even if the stream ids were
+        // magically unique across tenants
+        if (_events.TenancyStyle == TenancyStyle.Conjoined && !_events.GlobalAggregates.Contains(typeof(TDoc)))
+        {
+            builder.Append(" and d.tenant_id = ");
+            builder.AppendParameter(builder.TenantId);
+        }
+    }
+
+    /// <summary>
+    ///     Composes the cache key for a stream. Getting the tenant or database wrong here would be a
+    ///     cross-tenant data leak rather than a performance bug, so both are always part of the key.
+    /// </summary>
+    private AggregateCacheKey cacheKeyFor(DocumentSessionBase session, TId id)
+    {
+        return new AggregateCacheKey(
+            typeof(TDoc),
+            session.Database.Identifier,
+            IsGlobal ? AggregateCacheKey.GlobalTenant : session.TenantId,
+            id);
     }
 }

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.ForUpdate.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.ForUpdate.cs
@@ -12,6 +12,7 @@ using Marten.Linq.QueryHandlers;
 using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
+using JasperFx.Events.Fetching;
 
 namespace Marten.Events.Fetching;
 
@@ -19,6 +20,23 @@ internal partial class FetchInlinedPlan<TDoc, TId>
 {
     public async Task<IEventStream<TDoc>> FetchForWriting(DocumentSessionBase session, TId id, bool forUpdate,
         CancellationToken cancellation = default)
+    {
+        try
+        {
+            return await fetchForWriting(session, id, forUpdate, true, cancellation).ConfigureAwait(false);
+        }
+        catch (CachedSnapshotUnusableException)
+        {
+            // The cached snapshot was not at the stream's current version. Unlike the Async plan there is
+            // no delta query to reconcile with -- an Inline snapshot is always exactly at the stream head,
+            // so anything else means the entry is simply wrong. TryTake has already removed it; redo the
+            // fetch on the always-correct uncached path.
+            return await fetchForWriting(session, id, forUpdate, false, cancellation).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<IEventStream<TDoc>> fetchForWriting(DocumentSessionBase session, TId id, bool forUpdate,
+        bool useCachedSnapshot, CancellationToken cancellation)
     {
         IDocumentStorage<TDoc, TId>? storage = null;
         if (((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
@@ -41,20 +59,38 @@ internal partial class FetchInlinedPlan<TDoc, TId>
             await session.BeginTransactionAsync(cancellation).ConfigureAwait(false);
         }
 
+        var cache = _cache;
+        var cacheKey = cache == null ? default : cacheKeyFor(session, id);
+        object? cachedAggregate = null;
+        var cachedVersion = 0L;
+        var cacheHit = cache != null && useCachedSnapshot &&
+                       cache.TryTake(cacheKey, out cachedAggregate, out cachedVersion);
+
         var builder = new BatchBuilder{TenantId = session.TenantId};
         _identityStrategy.BuildCommandForReadingVersionForStream(IsGlobal, builder, id, forUpdate);
 
-        builder.StartNewCommand();
-
         var handler = new LoadByIdHandler<TDoc, TId>(storage, id);
-        handler.ConfigureCommand(builder, session);
+
+        // Under Inline the stored snapshot is written in the same transaction as the events, so it is
+        // always exactly at the stream head -- there is no delta to fold. That makes the snapshot load the
+        // *whole* cost this cache exists to remove: the doc row, and the JSON deserialize of it.
+        if (!cacheHit)
+        {
+            builder.StartNewCommand();
+            handler.ConfigureCommand(builder, session);
+        }
 
         try
         {
             await using var reader =
                 await session.ExecuteReaderAsync(builder.Compile(), cancellation).ConfigureAwait(false);
 
-            return await ReadIntoStream(session, id, cancellation, reader, handler).ConfigureAwait(false);
+            return await ReadIntoStream(session, id, cancellation, reader, handler,
+                new CacheAttempt(cache, cacheKey, cacheHit, cachedAggregate, cachedVersion)).ConfigureAwait(false);
+        }
+        catch (CachedSnapshotUnusableException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -73,8 +109,29 @@ internal partial class FetchInlinedPlan<TDoc, TId>
     }
 
 
+    /// <summary>
+    ///     Everything the read side needs to know about a cache attempt. Default value == caching off.
+    /// </summary>
+    private readonly record struct CacheAttempt(
+        IAggregateWriteCache? Cache,
+        AggregateCacheKey Key,
+        bool Hit,
+        object? Aggregate,
+        long Version);
+
+    /// <summary>
+    ///     Signals that a cached snapshot did not match the stream's current version and the fetch must be
+    ///     redone uncached. Never escapes <see cref="FetchForWriting" />.
+    /// </summary>
+    /// <remarks>
+    ///     Derives from <see cref="MartenException" /> for the same reason as
+    ///     <c>FetchAsyncPlan.CacheAheadOfDatabaseException</c>: the assembly-wide convention test does not
+    ///     exempt nested private types, and should not.
+    /// </remarks>
+    private sealed class CachedSnapshotUnusableException: MartenException;
+
     private async Task<IEventStream<TDoc>> ReadIntoStream(DocumentSessionBase session, TId id, CancellationToken cancellation,
-        DbDataReader reader, LoadByIdHandler<TDoc, TId> handler)
+        DbDataReader reader, LoadByIdHandler<TDoc, TId> handler, CacheAttempt cacheAttempt = default)
     {
         long version = 0;
         try
@@ -84,23 +141,60 @@ internal partial class FetchInlinedPlan<TDoc, TId>
                 version = await reader.GetFieldValueAsync<long>(0, cancellation).ConfigureAwait(false);
             }
 
-            await reader.NextResultAsync(cancellation).ConfigureAwait(false);
-            var document = await handler.HandleAsync(reader, session, cancellation).ConfigureAwait(false);
+            TDoc? document;
+            if (cacheAttempt.Hit)
+            {
+                if (cacheAttempt.Version != version)
+                {
+                    // An Inline snapshot is durably at the stream head, so a version that is not an exact
+                    // match means the entry is stale or wrong -- and there is no delta query in this plan to
+                    // reconcile it with. The snapshot was never requested in this batch, so drain the reader
+                    // to leave the connection clean and let FetchForWriting retry uncached.
+                    while (await reader.NextResultAsync(cancellation).ConfigureAwait(false))
+                    {
+                    }
 
-            // Always zero -- an Inline snapshot is up to date by construction, so nothing is replayed.
-            // Recorded anyway so the histogram can be compared across lifecycles.
+                    throw new CachedSnapshotUnusableException();
+                }
+
+                document = (TDoc)cacheAttempt.Aggregate!;
+            }
+            else
+            {
+                await reader.NextResultAsync(cancellation).ConfigureAwait(false);
+                document = await handler.HandleAsync(reader, session, cancellation).ConfigureAwait(false);
+            }
+
+            // #5227: always zero -- an Inline snapshot is up to date by construction, so nothing is
+            // replayed on either path. A cache hit does not change that; what it removes is the
+            // snapshot LOAD, which this histogram does not measure. Recorded anyway so the histogram
+            // can be compared across lifecycles.
             _events.Options.OpenTelemetry
                 .RecordEventsReplayed(0, _aggregateTypeName, OpenTelemetryOptions.InlinePlan);
 
-            // As an optimization, put the document in the identity map for later
+            // As an optimization, put the document in the identity map for later. On a cache hit this is
+            // what lets the inline projection reuse the very instance we just handed out when it applies
+            // the caller's events during commit, instead of loading the snapshot a second time.
             if (document != null && ((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
             {
                 session.StoreDocumentInItemMap(id, document);
             }
 
+            // Deliberately NOT stored in the cache here -- see PendingAggregateCacheWrites. Under Inline the
+            // commit mutates this instance, so an entry written now would describe state that is only
+            // durable if SaveChangesAsync succeeds. Queue it for write back after the commit instead.
+            if (cacheAttempt.Cache != null && document != null)
+            {
+                trackForWriteBack(session, cacheAttempt.Cache, cacheAttempt.Key, document, id, version);
+            }
+
             return version == 0
                 ? _identityStrategy.StartStream(document, session, id, cancellation)
                 : _identityStrategy.AppendToStream(document, session, id, version, cancellation);
+        }
+        catch (CachedSnapshotUnusableException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -118,6 +212,20 @@ internal partial class FetchInlinedPlan<TDoc, TId>
         }
     }
 
+
+    private static void trackForWriteBack(DocumentSessionBase session, IAggregateWriteCache cache,
+        AggregateCacheKey key, TDoc document, TId id, long version)
+    {
+        var map = ((IMartenSession)session).ItemMap;
+        if (!map.TryGetValue(typeof(PendingAggregateCacheWrites), out var raw) ||
+            raw is not PendingAggregateCacheWrites pending)
+        {
+            pending = new PendingAggregateCacheWrites();
+            map[typeof(PendingAggregateCacheWrites)] = pending;
+        }
+
+        pending.Track(cache, key, document, id, version);
+    }
 
     public IQueryHandler<IEventStream<TDoc>> BuildQueryHandler(QuerySession session, TId id, bool forUpdate)
     {

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.cs
@@ -15,6 +15,7 @@ using Marten.Internal.Storage;
 using Marten.Linq.QueryHandlers;
 using Npgsql;
 using Weasel.Postgresql;
+using JasperFx.Events.Fetching;
 
 namespace Marten.Events.Fetching;
 
@@ -23,6 +24,7 @@ internal partial class FetchInlinedPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TI
     private readonly EventGraph _events;
     private readonly IEventIdentityStrategy<TId> _identityStrategy;
     private readonly string _aggregateTypeName = typeof(TDoc).FullNameInCode();
+    private readonly IAggregateWriteCache? _cache;
 
     internal FetchInlinedPlan(EventGraph events, IEventIdentityStrategy<TId> identityStrategy)
     {
@@ -30,9 +32,25 @@ internal partial class FetchInlinedPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TI
 
         _events = events;
         _identityStrategy = identityStrategy;
+
+        // See FetchAsyncPlan's constructor for why the enablement branch stays rather than leaning on
+        // ResolveCache(Type) returning the nullo cache.
+        if (events.AggregateWriteCaching.IsEnabled(typeof(TDoc)))
+        {
+            _cache = events.AggregateWriteCaching.ResolveCache(typeof(TDoc));
+        }
     }
 
     public bool IsGlobal { get; }
+
+    private AggregateCacheKey cacheKeyFor(DocumentSessionBase session, TId id)
+    {
+        return new AggregateCacheKey(
+            typeof(TDoc),
+            session.Database.Identifier,
+            IsGlobal ? AggregateCacheKey.GlobalTenant : session.TenantId,
+            id);
+    }
 
     public ProjectionLifecycle Lifecycle => ProjectionLifecycle.Inline;
 

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Events;
+using JasperFx.Events.Fetching;
 using JasperFx.Events.Subscriptions;
 using JasperFx.Events.Tags;
 using Marten.Events;
@@ -42,6 +43,37 @@ namespace Marten.Events
         /// outside of Marten internals
         /// </summary>
         bool UseIdentityMapForAggregates { get; set; }
+
+        /// <summary>
+        ///     Opt in caching of aggregate snapshots between FetchForWriting calls. Disabled for every
+        ///     aggregate type by default; see <see cref="CacheAggregatesForWriting{T}" />.
+        /// </summary>
+        /// <remarks>
+        ///     Both members are declared here as well as inherited by <see cref="EventGraph" /> from
+        ///     JasperFx's <c>EventRegistry</c>, because <c>StoreOptions.Events</c> is typed as this
+        ///     interface rather than as the graph — so without them <c>opts.Events</c> could not reach
+        ///     either one.
+        /// </remarks>
+        AggregateWriteCacheOptions AggregateWriteCaching { get; }
+
+        /// <summary>
+        ///     Keep recently fetched snapshots of <typeparamref name="T" /> in a node local cache so that a
+        ///     subsequent FetchForWriting can skip loading the stored snapshot and read only the events
+        ///     after it. Effectively an identity map for aggregates with a lifetime longer than a session.
+        ///     <para>
+        ///     The cached snapshot is only ever a baseline: the stream version and any newer events are
+        ///     still read from the database on every call, and the optimistic concurrency assertion on
+        ///     append is untouched. A stale entry therefore costs a larger delta query, never a wrong
+        ///     aggregate. See <see cref="JasperFx.Events.Fetching.IAggregateWriteCache" /> for the full
+        ///     semantics, which are shared across the Critter Stack.
+        ///     </para>
+        ///     <para>
+        ///     Supported for both the Async and Inline lifecycles; see
+        ///     <see cref="EventGraph.CacheAggregatesForWriting{T}" /> for how they differ.
+        ///     </para>
+        /// </summary>
+        /// <param name="sizeLimit">Maximum number of cached aggregates, when the default cache is built</param>
+        void CacheAggregatesForWriting<T>(int sizeLimit = 1000) where T : class;
 
         /// <summary>
         ///     Override the database schema name for event related tables. By default this


### PR DESCRIPTION
Closes #5251.

An opt-in, node-local cache of aggregate snapshots that lets `FetchForWriting` skip loading the stored snapshot and read only the events after it — effectively an identity map for aggregates with a lifetime longer than a session. Off for every aggregate type; enabled per type:

```csharp
opts.Events.CacheAggregatesForWriting<Order>(sizeLimit: 1000);
```

This is the parked `feature/aggregate-cache-fetchforwriting` branch (built 2026-07-28, measured 2026-07-30) rebased onto master **and** onto the promoted JasperFx contract.

## What the rebase changed

jasperfx#674 / JasperFx/jasperfx#676 moved the whole contract into `JasperFx.Events.Fetching`, so the Marten-local copies are deleted:

| was, on the branch | now |
|---|---|
| `Marten.Events.Fetching.IAggregateWriteCache` | `JasperFx.Events.Fetching.IAggregateWriteCache` |
| `Marten.Events.Fetching.AggregateCacheKey` | `JasperFx.Events.Fetching.AggregateCacheKey` |
| `MemoryCacheAggregateWriteCache` | `RecentlyUsedAggregateWriteCache` |
| `NulloAggregateWriteCache` | promoted as-is |
| `FetchForWritingCacheOptions` | `AggregateWriteCacheOptions` |
| `EventGraph.AggregateWriteCaching` | deleted — inherited from `EventRegistry` |

**⚠️ No new package on core Marten.** The prototype took `Microsoft.Extensions.Caching.Memory` as a hard dependency and flagged it as a decision to make before graduation. JasperFx/jasperfx#676 decided it: the promoted default is backed by `JasperFx.Core`'s existing `RecentlyUsedCache`, so `Marten.csproj` and `Directory.Packages.props` are reverted here — they do not appear in this diff at all. A deployment that specifically wants entries in a shared `IMemoryCache` writes a small adapter over the three-member interface.

Two places where I did **not** follow the issue's sketch, both deliberate:

- **`EventGraph` overrides `CacheAggregatesForWriting<T>` rather than only inheriting it.** The Inline write-back needs a session listener registered, and where a listener lives is Marten's business; the enrollment itself (type set, size limit, cache resolution) is the shared registry's, so the override calls `base` and then adds the listener.
- **The "is caching enabled for T" branch stays in both fetch plans.** `ResolveCache(Type)` returning `NulloAggregateWriteCache` means a store *may* drop it, but the cached path builds an `AggregateCacheKey` per fetch and that boxes the stream id. Dropping the branch would put that allocation on every `FetchForWriting` in every store that never opted in, to delete one `if`. The plans do use the new `ResolveCache(Type)` overload.

`IEventStoreOptions` keeps both members, because `StoreOptions.Events` is typed as that interface rather than as the graph — without them `opts.Events.CacheAggregatesForWriting<T>()` would not compile.

## Semantics — grade 1 only

The cached snapshot is a **baseline**. The stream version and every event after the cached version are still read on every call, and the OCC assertion on append is untouched, so a stale entry costs a larger delta query — never a wrong aggregate and never a suppressed `EventStreamUnexpectedMaxEventIdException`. ⛔ The retired "trusted" variant that also skipped the version read **stays retired**; it measured 0.19 ms of a 13.2 ms round.

The two lifecycles genuinely differ, and the difference is not an implementation accident:

- **Async** — baseline semantics as above; the entry is written as soon as the fetch completes, because the daemon rather than the session applies appended events, so the instance cannot drift ahead of what is durable.
- **Inline** — the stored snapshot is written in the same transaction as the events, so it is always exactly at the stream head and there is no delta query to reconcile a stale entry with. A hit therefore needs an **exact** version match; anything else drains the reader and retries uncached. The entry is written back only **after a successful commit**, because the inline projection mutates the very instance `FetchForWriting` handed out during that commit. Combined with take-on-read the failure path needs no compensation at all: a rolled-back commit simply leaves no entry. The committed version comes from the `StreamAction`, not off the document, because an aggregate's own `Version` property may mean something else entirely.

## Compliance

Enrolls `AggregateWriteCacheCompliance` as wave 10, via one new registrar member (`CacheAggregatesForWriting<TDoc>(IAggregateWriteCache)`, two lines against the shared `EventRegistry`).

The Marten-local suites stay, pruned only of what is now upstream's: they assert facts the shared suite deliberately does not pin — `cache_hit_folds_only_the_delta` counts *queries* rather than watching a hit counter, and `a_failed_commit_leaves_no_entry_behind` inspects the cache directly. The local recording double is renamed `MartenTestAggregateWriteCache` to avoid colliding with the compliance library's own `RecordingAggregateWriteCache`.

The spike's working note (`AGGREGATE_WRITE_CACHE_SPIKE.md`) is **not** in this PR. It named types that no longer exist and referenced "this session" and commit hashes off a parked branch; its user-facing content is now a section in `docs/events/optimizing.md` instead.

## Follow-ups still open

Carried over from the spike doc §6 and **not** resolved by this PR — flagging rather than silently dropping:

- [ ] Confirm the commit-side load is really skipped under Inline. Assert it by counting queries; do not infer it.
- [ ] Decide `UseIdentityMapForAggregates`. The item-map bridge only fires when it is on, and that is currently silent — either require it for Inline caching or make the store path work without it.
- [ ] A concurrency test for the Inline write-back: two sessions committing the same stream concurrently should leave exactly one entry, at the winning version. The Async side is covered under contention; Inline has no equivalent.
- [x] ~~Decide the `Microsoft.Extensions.Caching.Memory` dependency~~ — decided in JasperFx/jasperfx#676, see above.

## Verification

- `caching_async_aggregates_for_writing`, `caching_inline_aggregates_for_writing` and the new `aggregate_write_cache_compliance` — 27/27 together.
- `markdownlint` + `cspell` clean on the changed doc.
- Full suites run in CI below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)