### PR TITLE
Implement IDocumentSessionOperations.PendingStreams (#5250)

### DIFF
--- a/docs/documents/sessions.md
+++ b/docs/documents/sessions.md
@@ -75,6 +75,32 @@ the session's unit of work exactly as `Store()` does; nothing is written until `
 Nothing changes for code that holds a Marten session as `IQuerySession` / `IDocumentSession` — that
 is the same `Events` property it always was.
 
+### Reading what a session is about to append
+
+`IDocumentSessionOperations.PendingStreams` exposes the `StreamAction`s a session has queued but not
+yet committed — every `StartStream` and `Append` enlisted since the last `SaveChangesAsync`. It is
+there for a listener or a pre-commit hook that needs to decide something from the events the session
+is about to write, again without naming a store:
+
+```csharp
+IDocumentSessionOperations session = factory.LightweightSession();
+
+session.Events.StartStream<Order>(streamKey, new OrderPlaced(/* ... */));
+
+// One StreamAction, carrying the OrderPlaced event, before anything is written.
+foreach (var stream in session.PendingStreams)
+{
+    // stream.ActionType is Start here; it would be Append against an existing stream.
+}
+
+await session.SaveChangesAsync(token);   // PendingStreams is empty again afterwards
+```
+
+Only the streams are exposed, deliberately — pending **document** operations are not part of the shared
+contract. In Marten this is the same collection as `IDocumentSession.PendingChanges.Streams()`, and
+it is a live view of the session rather than a snapshot, so copy it if you need stability across
+further appends.
+
 ## Read Only QuerySession
 
 For strictly read-only querying, the `QuerySession` is a lightweight session that is optimized

--- a/src/EventSourcingTests/Compliance/marten_document_storage_compliance.cs
+++ b/src/EventSourcingTests/Compliance/marten_document_storage_compliance.cs
@@ -53,6 +53,19 @@ public class document_session_compliance
 public class document_session_events_compliance
     : DocumentSessionEventsCompliance<MartenDocumentComplianceFixture>;
 
+/*
+ * jasperfx#673 (#5250). The sixth suite, opt-in for the same reason as the fifth, and reusing its
+ * event types -- so the two are enrolled together. Same trap again, one layer down: Marten's
+ * PendingChanges.Streams() returns IList<StreamAction>, and IList<T> is not assignable to
+ * IReadOnlyList<T>, so it did not satisfy IDocumentSessionOperations.PendingStreams either.
+ * DocumentSessionBase now carries the explicit implementation and this is what pins it. The suite's
+ * first fact -- an empty collection on a session with nothing enlisted -- is precisely the one a
+ * store still on the interface's throwing default cannot pass.
+ */
+[Collection(DocumentComplianceCollection.Name)]
+public class pending_stream_actions_compliance
+    : PendingStreamActionsCompliance<MartenDocumentComplianceFixture>;
+
 public static class DocumentComplianceCollection
 {
     public const string Name = "document storage compliance";

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -328,6 +328,22 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
     // calling through a contract-typed session notices. Pinned by DocumentSessionEventsCompliance.
     JasperFx.Events.IEventStoreOperations JasperFx.Events.Documents.IDocumentSessionOperations.Events => Events;
 
+    // jasperfx#673 (#5250): the StreamActions this session has enlisted but not yet committed, so a
+    // store-agnostic listener or pre-commit hook can read what is about to be written without naming
+    // a store. Same non-covariance trap as the Events accessor above -- PendingChanges.Streams()
+    // returns IList<StreamAction>, and IList<T> is NOT assignable to IReadOnlyList<T>, so the public
+    // surface does not satisfy this member and it would otherwise bind to the interface's throwing
+    // default with no compile error anywhere. Pinned by PendingStreamActionsCompliance.
+    //
+    // Forwards to the work tracker's backing List<StreamAction> rather than PendingChanges.Streams()
+    // .ToArray(): a concrete List<T> DOES implement IReadOnlyList<T>, so this costs no per-call
+    // allocation. That makes it a live view rather than a snapshot, which the contract explicitly
+    // allows -- it says a store may hand back either, and that a caller needing stability across
+    // further appends should copy. The tracker clears this same list on commit rather than replacing
+    // it, so the "committing clears the collection" fact holds through the live view.
+    IReadOnlyList<StreamAction> JasperFx.Events.Documents.IDocumentSessionOperations.PendingStreams
+        => _workTracker.Streams;
+
 
     public void QueueOperation(Weasel.Storage.IStorageOperation storageOperation)
     {


### PR DESCRIPTION
Closes #5250. (Supersedes #5255, which GitHub auto-closed when the branch it was stacked on was deleted on merge. Same commit, rebased onto `master`.)

## What the contract adds

```csharp
IReadOnlyList<StreamAction> IDocumentSessionOperations.PendingStreams { get; }
```

jasperfx#673 / JasperFx/jasperfx#675. It exists so a store-agnostic consumer — a listener, a pre-commit hook deciding something from the events the session is about to write — can read them without naming a store. The payload type was already the shared `JasperFx.Events.StreamAction`; only the accessor's spelling diverged (Marten's `PendingChanges.Streams()`, Polecat's `PendingChanges.Streams`, Fisher's `Events.PendingStreams`).

## The non-covariance trap, again

Marten already had the exact collection one hop away, but the forward is **not** free: `IUnitOfWork.Streams()` returns `IList<StreamAction>`, and `IList<T>` is not assignable to `IReadOnlyList<T>`. So Marten did not satisfy the member — it bound to the interface's **throwing** default with no compile error anywhere, exactly as it did for the `Events` accessor in #5246. `DocumentSessionBase` now carries the explicit implementation.

## Live view rather than a snapshot

The issue's sketch was `PendingChanges.Streams().ToArray()`. This forwards to the work tracker's backing `List<StreamAction>` instead:

```csharp
IReadOnlyList<StreamAction> IDocumentSessionOperations.PendingStreams => _workTracker.Streams;
```

A concrete `List<T>` *does* implement `IReadOnlyList<T>`, so there is no per-call allocation. That makes it a live view, which the contract explicitly permits — it states a store may hand back either, and that a caller needing stability across further appends should copy. Worth checking rather than assuming: `UnitOfWork.Reset()` **clears** that same list on commit rather than replacing it, so the suite's "committing clears the collection" fact holds through the live view.

`IUnitOfWork.Streams()` is untouched — its return type is public API and changing it for this would be a break for no gain.

## Verification

- `pending_stream_actions_compliance` — 9/9. This is the load-bearing check: the suite's first fact is an empty collection on a session with nothing enlisted, which is precisely what a store still on the throwing default cannot pass, so a green run means the explicit implementation is being reached.
- `EventSourcingTests.Compliance.*` — 295/295 (was 286 before the six new tests).
- `CoreTests.Internal.Sessions` — 18/18.
- `markdownlint` + `cspell` clean on the changed doc.

Docs: a short subsection on `docs/documents/sessions.md` under the existing store-agnostic `Events` accessor material, since that is where a reader looking for this will already be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)