### PR TITLE
Implement JasperFx's IDocumentCommitListener (jasperfx#679)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -297,16 +297,36 @@
          the cached snapshot is a baseline, version and delta are always re-read, OCC is untouched.
          The default cache is backed by JasperFx.Core's RecentlyUsedCache, deliberately NOT
          Microsoft.Extensions.Caching.Memory — the prototype's IMemoryCache dependency would have been
-         pushed onto every consumer of JasperFx.Events rather than one store. -->
-    <PackageVersion Include="JasperFx" Version="2.51.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.51.0" />
+         pushed onto every consumer of JasperFx.Events rather than one store.
+         JasperFx 2.52.0: jasperfx#679/#680 (marten#5258) — IDocumentCommitListener, the
+         store-agnostic post-commit SESSION hook, plus IDocumentChangeSet and IDocumentDeletion in
+         JasperFx.Events.Documents, and DocumentComplianceConfig.CommitListeners/AddCommitListener so
+         a compliance suite can register one before the store is built. Purely additive.
+         ⚠️ NOT the same trap as 2.50.0's Events accessor or 2.51.0's PendingStreams, and the
+         difference is worth stating because it changes where the risk lives: no member of this
+         contract has a default implementation, so a near-miss is CS0535 at build time rather than a
+         silent bind to a throwing default. What the compiler still cannot see is the WIRING — a
+         store that declares the interfaces perfectly and never invokes the listener compiles clean
+         and passes every other suite in the library.
+         Marten adopts it as an ADAPTER rather than by widening its own types, and that is forced
+         rather than stylistic. IChangeSet.Inserted/Updated are IEnumerable&lt;object&gt; against the
+         contract's IReadOnlyList&lt;object&gt;; IChangeSet.Deleted is
+         IEnumerable&lt;Weasel.Storage.IDeletion&gt; against IReadOnlyList&lt;IDocumentDeletion&gt;; and
+         DocumentSessionListenerBase.AfterCommitAsync differs from the contract's signature in three
+         of its four positions. Putting IDocumentChangeSet on IChangeSet would therefore be a
+         breaking change to every existing Marten listener, and putting it on ISessionWorkTracker
+         would additionally rope in ProjectionUpdateBatch, whose Inserted/Updated/Deleted all throw
+         NotSupportedException. See DocumentCommitListenerAdapter/MartenDocumentChangeSet and
+         StoreOptions.AddCommitListener, pinned by DocumentCommitListenerCompliance. -->
+    <PackageVersion Include="JasperFx" Version="2.52.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.52.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.51.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.52.0" />
     <!--
       Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
       the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
@@ -324,11 +344,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.51.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.52.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.51.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.52.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -211,6 +211,86 @@ As of Marten 1.4, you can also register `IDocumentSessionListener` objects scope
 
 As of Marten v5, separate listeners will need to be registered for Document Store and Async Daemon. Adding listeners for Async Daemon are covered in the next section.
 
+### Store-agnostic commit listeners <Badge type="tip" text="9.28" />
+
+`IDocumentSessionListener` is a Marten type, so a listener written against it cannot be shared with a codebase that also runs Polecat or Fisher. For the common case of "tell me what a commit wrote, after it committed", implement JasperFx's `IDocumentCommitListener` instead -- it is the same hook expressed in shared types, and the same class works unchanged on all three stores:
+
+<!-- snippet: sample_writing_a_document_commit_listener -->
+<a id='snippet-sample_writing_a_document_commit_listener'></a>
+```cs
+// The store-agnostic post-commit hook. The same class works unchanged against
+// Marten, Polecat and Fisher -- nothing in it names a store.
+public class AuditCommitListener: IDocumentCommitListener
+{
+    private readonly List<string> _audit = new();
+
+    public Task AfterCommitAsync(
+        IDocumentSessionOperations session,
+        IDocumentChangeSet commit,
+        CancellationToken token)
+    {
+        foreach (var document in commit.Inserted) _audit.Add($"Inserted {document.GetType().Name}");
+        foreach (var document in commit.Updated) _audit.Add($"Updated {document.GetType().Name}");
+
+        // Deletions arrive as descriptors rather than as documents, because
+        // Delete<T>(id) and DeleteWhere<T>(...) never loaded one to report
+        foreach (var deletion in commit.Deleted) _audit.Add($"Deleted {deletion.DocumentType.Name} {deletion.Id}");
+
+        return Task.CompletedTask;
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/DocumentCommitListenerSamples.cs#L10-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_writing_a_document_commit_listener' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Register one either directly on `StoreOptions`, or in the container:
+
+<!-- snippet: sample_registering_a_document_commit_listener -->
+<a id='snippet-sample_registering_a_document_commit_listener'></a>
+```cs
+services.AddMarten(opts =>
+{
+    opts.Connection(connectionString);
+
+    // Directly, when you have the instance in hand
+    opts.AddCommitListener(new AuditCommitListener());
+});
+
+// Or register it in the container, and AddMarten() will find it. Note
+// that this only reaches the MAIN store
+services.AddSingleton<IDocumentCommitListener, AuditCommitListener>();
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/DocumentCommitListenerSamples.cs#L42-L56' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_a_document_commit_listener' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: warning The container sweep reaches the main store only
+`AddMarten()` sweeps `IDocumentCommitListener` registrations out of the container, but a bare sweep cannot tell which store a registration was meant for -- so applying it to ancillary stores as well would attach every listener in the application to every `AddMartenStore<T>()`, with no way to opt one out. Ancillary stores opt in explicitly, exactly as they do for `IInitialData`:
+
+<!-- snippet: sample_registering_a_document_commit_listener_on_ancillary_store -->
+<a id='snippet-sample_registering_a_document_commit_listener_on_ancillary_store'></a>
+```cs
+services.AddMartenStore<IOrdersStore>(opts =>
+{
+    opts.Connection(connectionString);
+    opts.DatabaseSchemaName = "orders";
+});
+
+// Ancillary stores are NOT swept from the container -- otherwise every
+// listener registered anywhere would attach to every store -- so they
+// opt in explicitly
+services.ConfigureMarten<IOrdersStore>(opts => opts.AddCommitListener(new AuditCommitListener()));
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/DocumentCommitListenerSamples.cs#L61-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_a_document_commit_listener_on_ancillary_store' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+:::
+
+Two things to know about the change set it hands you:
+
+* The three collections are **snapshots** taken when the commit is raised, not views over the session. You can stash an `IDocumentChangeSet` and read it later; the Marten `IChangeSet` above is the session's live unit of work and is reset immediately after the listener loop, so it cannot be stashed.
+* `Deleted` carries `{ DocumentType, Id }` descriptors rather than document instances, because `Delete<T>(id)` and `DeleteWhere<T>(...)` never loaded a document to report. If you need the deleted document itself, read it before the delete or use Marten's own `IDocumentSessionListener`.
+
+This is the **session** half only -- it does not fire for the async daemon's projection batches. Use `IChangeListener` (above) or JasperFx's `IDaemonChangeListener` for those, and register both if you want both.
+
 ## Listening for Async Daemon Events
 
 Use `AsyncListeners` to register session listeners that will ONLY be applied within the asynchronous daemon updates.
@@ -246,7 +326,7 @@ public class FakeListener: IChangeListener
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Internals/basic_functionality.cs#L123-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asyncdaemonlistener' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Internals/basic_functionality.cs#L122-L147' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asyncdaemonlistener' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Wiring a Async Daemon listener:
@@ -260,7 +340,7 @@ StoreOptions(x =>
     x.Projections.AsyncListeners.Add(listener);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Internals/basic_functionality.cs#L153-L162' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asynclisteners' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Internals/basic_functionality.cs#L152-L161' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asynclisteners' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Custom Logging
@@ -538,7 +618,7 @@ The `IMartenLogger` can be swapped out on any `IQuerySession` or `IDocumentSessi
 // session to pipe Marten logging to the xUnit.Net output
 theSession.Logger = new TestOutputMartenLogger(_output);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Resiliency/when_skipping_events_in_daemon.cs#L135-L139' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_replacing_logger_per_session' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Resiliency/when_skipping_events_in_daemon.cs#L134-L138' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_replacing_logger_per_session' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Previewing the PostgreSQL Query Plan

--- a/src/CoreTests/Examples/DocumentCommitListenerSamples.cs
+++ b/src/CoreTests/Examples/DocumentCommitListenerSamples.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CoreTests.Examples;
+
+#region sample_writing_a_document_commit_listener
+
+// The store-agnostic post-commit hook. The same class works unchanged against
+// Marten, Polecat and Fisher -- nothing in it names a store.
+public class AuditCommitListener: IDocumentCommitListener
+{
+    private readonly List<string> _audit = new();
+
+    public Task AfterCommitAsync(
+        IDocumentSessionOperations session,
+        IDocumentChangeSet commit,
+        CancellationToken token)
+    {
+        foreach (var document in commit.Inserted) _audit.Add($"Inserted {document.GetType().Name}");
+        foreach (var document in commit.Updated) _audit.Add($"Updated {document.GetType().Name}");
+
+        // Deletions arrive as descriptors rather than as documents, because
+        // Delete<T>(id) and DeleteWhere<T>(...) never loaded one to report
+        foreach (var deletion in commit.Deleted) _audit.Add($"Deleted {deletion.DocumentType.Name} {deletion.Id}");
+
+        return Task.CompletedTask;
+    }
+}
+
+#endregion
+
+public interface IOrdersStore: IDocumentStore;
+
+public static class DocumentCommitListenerSamples
+{
+    public static void register_by_container(IServiceCollection services, string connectionString)
+    {
+        #region sample_registering_a_document_commit_listener
+
+        services.AddMarten(opts =>
+        {
+            opts.Connection(connectionString);
+
+            // Directly, when you have the instance in hand
+            opts.AddCommitListener(new AuditCommitListener());
+        });
+
+        // Or register it in the container, and AddMarten() will find it. Note
+        // that this only reaches the MAIN store
+        services.AddSingleton<IDocumentCommitListener, AuditCommitListener>();
+
+        #endregion
+    }
+
+    public static void register_on_an_ancillary_store(IServiceCollection services, string connectionString)
+    {
+        #region sample_registering_a_document_commit_listener_on_ancillary_store
+
+        services.AddMartenStore<IOrdersStore>(opts =>
+        {
+            opts.Connection(connectionString);
+            opts.DatabaseSchemaName = "orders";
+        });
+
+        // Ancillary stores are NOT swept from the container -- otherwise every
+        // listener registered anywhere would attach to every store -- so they
+        // opt in explicitly
+        services.ConfigureMarten<IOrdersStore>(opts => opts.AddCommitListener(new AuditCommitListener()));
+
+        #endregion
+    }
+}

--- a/src/CoreTests/registering_document_commit_listeners.cs
+++ b/src/CoreTests/registering_document_commit_listeners.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using Marten;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests;
+
+public interface ICommitListenerAncillaryStore: IDocumentStore;
+
+public class RecordingCommitListener: IDocumentCommitListener
+{
+    private readonly List<IDocumentChangeSet> _commits = new();
+
+    public IReadOnlyList<IDocumentChangeSet> Commits
+    {
+        get
+        {
+            lock (_commits) return _commits.ToArray();
+        }
+    }
+
+    public Task AfterCommitAsync(IDocumentSessionOperations session, IDocumentChangeSet commit, CancellationToken token)
+    {
+        lock (_commits) _commits.Add(commit);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// jasperfx#679 (#5258). The container half of the IDocumentCommitListener adoption.
+/// </summary>
+/// <remarks>
+/// <para>
+/// DocumentCommitListenerCompliance pins the behavior — that a registered listener fires, with a
+/// materialized change set — but it structurally CANNOT cover any of this, and that is worth being
+/// explicit about rather than leaving as an accident of where the tests live.
+/// MartenDocumentComplianceFixture builds a bare <c>new StoreOptions()</c> and replays the suite's
+/// listeners through <see cref="StoreOptions.AddCommitListener" /> by hand. No container is involved
+/// at any point, so the sweep in <c>AddMarten</c> — the thing an actual application depends on — is
+/// exercised by nothing over there.
+/// </para>
+/// <para>
+/// The ancillary facts below are the deliberate boundary rather than a limitation. A bare
+/// <c>GetServices&lt;IDocumentCommitListener&gt;()</c> from the StoreOptions factory cannot tell
+/// which store a registration was meant for, so sweeping it onto every AddMartenStore&lt;T&gt; in
+/// the application would attach every listener to every store with no way to opt one out. Primary
+/// store only, matching what IInitialData has always done; ancillary stores opt in explicitly.
+/// </para>
+/// </remarks>
+public class registering_document_commit_listeners: HostedStoreContext
+{
+    [Fact]
+    public async Task container_registered_listener_is_swept_onto_the_primary_store()
+    {
+        var listener = new RecordingCommitListener();
+
+        var host = await StartHostAsync(_ => { },
+            configureServices: services => services.AddSingleton<IDocumentCommitListener>(listener));
+
+        var store = StoreOf(host);
+
+        // Asserted on the options as well as end-to-end below, because the two fail for different
+        // reasons: an empty Listeners collection means the sweep never ran, while a populated one
+        // with no recorded commit means the adapter is not forwarding.
+        store.Options.Listeners.OfType<IDocumentSessionListener>().ShouldNotBeEmpty();
+
+        await using var session = store.LightweightSession();
+        session.Store(Target.Random());
+        await session.SaveChangesAsync();
+
+        var commit = listener.Commits.ShouldHaveSingleItem();
+        commit.Inserted.Concat(commit.Updated).ShouldHaveSingleItem().ShouldBeOfType<Target>();
+    }
+
+    [Fact]
+    public async Task every_container_registered_listener_is_swept()
+    {
+        var first = new RecordingCommitListener();
+        var second = new RecordingCommitListener();
+
+        var host = await StartHostAsync(_ => { },
+            configureServices: services =>
+            {
+                services.AddSingleton<IDocumentCommitListener>(first);
+                services.AddSingleton<IDocumentCommitListener>(second);
+            });
+
+        await using var session = StoreOf(host).LightweightSession();
+        session.Store(Target.Random());
+        await session.SaveChangesAsync();
+
+        // GetServices, not GetService: a sweep written with the singular would forward only the
+        // last registration and would pass every fact above.
+        first.Commits.Count.ShouldBe(1);
+        second.Commits.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task the_sweep_does_NOT_reach_an_ancillary_store()
+    {
+        var listener = new RecordingCommitListener();
+
+        var host = await StartHostAsync(_ => { },
+            configureServices: services =>
+            {
+                services.AddSingleton<IDocumentCommitListener>(listener);
+                services.AddMartenStore<ICommitListenerAncillaryStore>(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DisableNpgsqlLogging = true;
+                    opts.DatabaseSchemaName = $"{SchemaName}_ancillary";
+                });
+            });
+
+        var ancillary = host.Services.GetRequiredService<ICommitListenerAncillaryStore>();
+
+        await using var session = ancillary.LightweightSession();
+        session.Store(Target.Random());
+        await session.SaveChangesAsync();
+
+        // The documented boundary. If this ever goes green the other way round, it is a behavior
+        // change for every application running more than one Marten store, not a bug fix.
+        listener.Commits.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task an_ancillary_store_opts_in_through_ConfigureMarten()
+    {
+        var listener = new RecordingCommitListener();
+
+        var host = await StartHostAsync(_ => { },
+            configureServices: services =>
+            {
+                services.AddMartenStore<ICommitListenerAncillaryStore>(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DisableNpgsqlLogging = true;
+                    opts.DatabaseSchemaName = $"{SchemaName}_optin";
+                });
+
+                services.ConfigureMarten<ICommitListenerAncillaryStore>(opts => opts.AddCommitListener(listener));
+            });
+
+        var ancillary = host.Services.GetRequiredService<ICommitListenerAncillaryStore>();
+
+        await using var session = ancillary.LightweightSession();
+        session.Store(Target.Random());
+        await session.SaveChangesAsync();
+
+        listener.Commits.ShouldHaveSingleItem()
+            .Inserted.Concat(listener.Commits[0].Updated)
+            .ShouldHaveSingleItem().ShouldBeOfType<Target>();
+    }
+
+    [Fact]
+    public async Task a_deletion_is_reported_by_type_and_identity()
+    {
+        var listener = new RecordingCommitListener();
+
+        var host = await StartHostAsync(_ => { },
+            configureServices: services => services.AddSingleton<IDocumentCommitListener>(listener));
+
+        var store = StoreOf(host);
+        var target = Target.Random();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(target);
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Delete(target);
+            await session.SaveChangesAsync();
+        }
+
+        listener.Commits.Count.ShouldBe(2);
+
+        var deletion = listener.Commits[1].Deleted.ShouldHaveSingleItem();
+        deletion.DocumentType.ShouldBe(typeof(Target));
+        deletion.Id.ShouldBe(target.Id);
+    }
+}

--- a/src/EventSourcingTests/Compliance/marten_document_storage_compliance.cs
+++ b/src/EventSourcingTests/Compliance/marten_document_storage_compliance.cs
@@ -66,6 +66,25 @@ public class document_session_events_compliance
 public class pending_stream_actions_compliance
     : PendingStreamActionsCompliance<MartenDocumentComplianceFixture>;
 
+/*
+ * jasperfx#679 (#5258). The seventh suite, and the first that needs NOTHING from the event store --
+ * it is opt-in only in the sense that the fixture has to replay DocumentComplianceConfig.CommitListeners,
+ * which MartenDocumentComplianceFixture now does.
+ *
+ * Different risk from the fifth and sixth suites rather than the same one. IDocumentCommitListener
+ * and IDocumentChangeSet have no default implementations, so a near-miss on either is CS0535 rather
+ * than a silent bind to a throwing default -- which is precisely why Marten bridges them with
+ * DocumentCommitListenerAdapter + MartenDocumentChangeSet instead of widening IChangeSet, whose
+ * IEnumerable<object> members would not satisfy the contract's IReadOnlyList<object> ones and whose
+ * every existing implementor would break. What no compiler sees is the wiring, and that is what
+ * these ten facts pin -- in particular the_change_set_survives_the_session_moving_on, which is the
+ * one Marten can fail while doing everything else right: IChangeSet IS the session's live unit of
+ * work and DocumentSessionBase.SaveChangesAsync resets it immediately after the listener loop.
+ */
+[Collection(DocumentComplianceCollection.Name)]
+public class document_commit_listener_compliance
+    : DocumentCommitListenerCompliance<MartenDocumentComplianceFixture>;
+
 public static class DocumentComplianceCollection
 {
     public const string Name = "document storage compliance";

--- a/src/Marten.Testing/Harness/MartenDocumentComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenDocumentComplianceFixture.cs
@@ -90,6 +90,20 @@ public class MartenDocumentComplianceFixture: DocumentStorageComplianceFixture
             options.Events.AddEventType(eventType);
         }
 
+        // jasperfx#679 (#5258). The one config member that is an INSTANCE rather than a Type,
+        // because the suite has to hold the very listener it registered in order to read back what
+        // the store handed it. Replayed through StoreOptions.AddCommitListener, which wraps each one
+        // in Marten's internal DocumentCommitListenerAdapter and drops it on Options.Listeners.
+        //
+        // ⚠️ Load-bearing in the strongest sense of any line in this fixture: a fixture that drops
+        // it does not make DocumentCommitListenerCompliance skip -- every fact in it fails, because
+        // "the listener was never registered" and "the store never invokes listeners" are the same
+        // observable result.
+        foreach (var listener in config.CommitListeners)
+        {
+            options.AddCommitListener(listener);
+        }
+
         _store = new DocumentStore(options);
 
         await _store.Storage.ApplyAllConfiguredChangesToDatabaseAsync().ConfigureAwait(false);

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -233,6 +233,24 @@ public static class MartenServiceCollectionExtensions
             options.ReadJasperFxOptions(s.GetService<JasperFxOptions>());
 
             options.InitialData.AddRange(s.GetServices<IInitialData>());
+
+            // jasperfx#679 (#5258). Sweep any store-agnostic IDocumentCommitListener out of the
+            // container and adapt it onto Marten's own listener collection. This runs inside the
+            // StoreOptions factory, and session construction copies Options.Listeners strictly
+            // afterwards (QuerySession's constructors), so every session opened from this store
+            // sees them.
+            //
+            // ⚠️ PRIMARY STORE ONLY, deliberately, and it is the IInitialData line above that sets
+            // the precedent: a bare GetServices<T>() sweep from this factory cannot tell which store
+            // a registration was meant for, so applying it to ancillary stores as well would attach
+            // every listener in the container to every AddMartenStore<T>() in the application --
+            // silently, and with no way to opt one out. Ancillary stores configure through
+            // IConfigureMarten<T>, so their opt-in is
+            // services.ConfigureMarten<T>(opts => opts.AddCommitListener(listener)).
+            foreach (var listener in s.GetServices<JasperFx.Events.Documents.IDocumentCommitListener>())
+            {
+                options.AddCommitListener(listener);
+            }
             options.Projections.AttachServiceProvider(s);
             options.Services = s;
 

--- a/src/Marten/Services/DocumentCommitListenerAdapter.cs
+++ b/src/Marten/Services/DocumentCommitListenerAdapter.cs
@@ -1,0 +1,128 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+
+namespace Marten.Services;
+
+/// <summary>
+/// Forwards Marten's post-commit session callback onto the store-agnostic
+/// <see cref="IDocumentCommitListener" /> (jasperfx#679).
+/// </summary>
+/// <remarks>
+/// <para>
+/// An adapter rather than an interface added to <see cref="DocumentSessionListenerBase" />, and
+/// unlike jasperfx#669/#673 that is forced by the compiler rather than chosen. Marten's
+/// <c>AfterCommitAsync(IDocumentSession, IChangeSet, CancellationToken)</c> differs from the
+/// contract's <c>AfterCommitAsync(IDocumentSessionOperations, IDocumentChangeSet,
+/// CancellationToken)</c> in three of its four positions, and neither contract member has a default
+/// implementation — so a store type declaring <see cref="IDocumentCommitListener" /> on top of the
+/// existing method gets CS0535, not a silent bind to a throwing default. What the compiler still
+/// cannot see is the wiring, which is why <c>DocumentCommitListenerCompliance</c> rather than a
+/// green build is the evidence this works.
+/// </para>
+/// <para>
+/// Nothing else about Marten's listener pipeline is adapted. <c>BeforeSaveChangesAsync</c>,
+/// <c>DocumentLoaded</c> and <c>DocumentAddedForStorage</c> stay on the base class's no-ops because
+/// the shared contract is deliberately post-commit only — a pre-commit hook wanting to read what is
+/// about to be appended is served by <c>IDocumentSessionOperations.PendingStreams</c> (jasperfx#673)
+/// instead.
+/// </para>
+/// <para>
+/// ⚠️ This is the SESSION half only. It does not fire for the async daemon's projection batches:
+/// <c>ProjectionUpdateBatch</c> runs its own <see cref="IChangeListener" /> loop, and JasperFx owns
+/// that half separately as <c>IDaemonChangeListener</c>. A consumer wanting both registers both.
+/// </para>
+/// </remarks>
+internal sealed class DocumentCommitListenerAdapter: DocumentSessionListenerBase
+{
+    public DocumentCommitListenerAdapter(IDocumentCommitListener inner)
+    {
+        Inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    }
+
+    /// <summary>
+    /// The listener this adapter wraps. Exposed so that a second registration of the same listener
+    /// instance can be detected, and so tests can assert on what was registered rather than on the
+    /// wrapper.
+    /// </summary>
+    public IDocumentCommitListener Inner { get; }
+
+    public override Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+    {
+        // IDocumentSession derives from IDocumentSessionOperations (#5216), so the session goes
+        // across as-is with no wrapper of its own.
+        return Inner.AfterCommitAsync(session, new MartenDocumentChangeSet(commit), token);
+    }
+}
+
+/// <summary>
+/// A materialized snapshot of one Marten commit, as <see cref="IDocumentChangeSet" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ⚠️ <strong>The three collections are copied in the constructor, and that is load-bearing rather
+/// than defensive.</strong> Marten's <see cref="IChangeSet" /> <em>is</em> the session's live
+/// <c>UnitOfWork</c>: its <c>Inserted</c>, <c>Updated</c> and <c>Deleted</c> are lazy LINQ chains
+/// re-walked over <c>_operations</c> on every read, and
+/// <c>DocumentSessionBase.SaveChangesAsync</c> calls <c>_workTracker.Reset()</c> immediately after
+/// the listener loop returns. A forward that deferred — <c>=&gt; inner.Inserted.ToList()</c> on a
+/// property, let alone handing the sequences straight over — answers correctly inside the callback
+/// and empty to a listener that stashed the change set and read it later. That is exactly what
+/// <c>DocumentCommitListenerCompliance.the_change_set_survives_the_session_moving_on</c> exists to
+/// catch, and it is why the shared contract is declared in <see cref="IReadOnlyList{T}" /> rather
+/// than <see cref="IEnumerable{T}" />.
+/// </para>
+/// <para>
+/// Copying once here is also why nothing calls <see cref="IChangeSet.Clone" />: with the snapshot
+/// taken there is no live object left to defend against. A single enumeration per collection is
+/// additionally the cheaper shape — the compliance suite's own
+/// <c>Inserted.Concat(Updated)</c> would otherwise re-walk the operation list twice per read.
+/// </para>
+/// <para>
+/// <c>GetEvents()</c> and <c>GetStreams()</c> have no counterpart on the shared contract and are
+/// deliberately not projected here; jasperfx#679 shipped the measured surface, and they can be added
+/// additively upstream when a consumer needs them.
+/// </para>
+/// </remarks>
+internal sealed class MartenDocumentChangeSet: IDocumentChangeSet
+{
+    public MartenDocumentChangeSet(IChangeSet inner)
+    {
+        Inserted = inner.Inserted.ToArray();
+        Updated = inner.Updated.ToArray();
+
+        // Descriptors rather than the deleted documents themselves. Marten's Weasel.Storage.IDeletion
+        // does carry a Document, but Polecat's and Fisher's change sets carry only { DocumentType, Id },
+        // so the shared contract cannot expose one -- and Delete<T>(id) / DeleteWhere<T>(...) never
+        // loaded a document to report in the first place.
+        Deleted = inner.Deleted
+            .Select(x => (IDocumentDeletion)new MartenDocumentDeletion(x.DocumentType, x.Id))
+            .ToArray();
+    }
+
+    public IReadOnlyList<object> Inserted { get; }
+    public IReadOnlyList<object> Updated { get; }
+    public IReadOnlyList<IDocumentDeletion> Deleted { get; }
+}
+
+/// <summary>
+/// One document removed by a committed transaction, as <see cref="IDocumentDeletion" />.
+/// </summary>
+/// <remarks>
+/// A wrapper rather than <c>Weasel.Storage.IDeletion : IDocumentDeletion</c>, for two reasons.
+/// Structurally the members already line up — <c>DocumentType</c> comes from
+/// <c>Weasel.Core.IStorageOperation</c> and <c>Id</c> is declared on <c>IDeletion</c> itself — but C#
+/// has no structural implementation, and putting the JasperFx interface on a Weasel type would make
+/// Weasel depend on JasperFx.Events. The contract owns <see cref="IDocumentDeletion" /> precisely so
+/// that a consumer reading a commit never has to name Weasel.
+/// </remarks>
+/// <param name="DocumentType">The document type that was deleted.</param>
+/// <param name="Id">
+/// The identity of the deleted document. Declared nullable to match the contract: a deletion
+/// expressed as criteria (<c>DeleteWhere&lt;T&gt;</c>) names no single identity.
+/// </param>
+internal sealed record MartenDocumentDeletion(Type DocumentType, object? Id): IDocumentDeletion;

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -105,6 +105,33 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
     public List<IDocumentSessionListener> Listeners { get; } = new();
 
     /// <summary>
+    ///     Register a store-agnostic <see cref="JasperFx.Events.Documents.IDocumentCommitListener" />
+    ///     (jasperfx#679) to be invoked after every successful session commit.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Sugar over <see cref="Listeners" />, and the only public way to do this: the adapter that
+    ///     bridges the contract's signature onto Marten's <see cref="IDocumentSessionListener" /> is
+    ///     internal, because it is an implementation detail of the bridge rather than something a
+    ///     user should construct or subclass.
+    ///     </para>
+    ///     <para>
+    ///     Anything registered as an <c>IDocumentCommitListener</c> in the container is swept onto
+    ///     the PRIMARY store automatically by <c>AddMarten</c>. This method is what an ancillary
+    ///     store (<c>AddMartenStore&lt;T&gt;</c>) uses to opt in, via
+    ///     <c>services.ConfigureMarten&lt;T&gt;(opts =&gt; opts.AddCommitListener(listener))</c> —
+    ///     the same split <c>IInitialData</c> already has.
+    ///     </para>
+    /// </remarks>
+    public StoreOptions AddCommitListener(JasperFx.Events.Documents.IDocumentCommitListener listener)
+    {
+        if (listener == null) throw new ArgumentNullException(nameof(listener));
+
+        Listeners.Add(new DocumentCommitListenerAdapter(listener));
+        return this;
+    }
+
+    /// <summary>
     ///     Types that should be treated as "child document" containers (JSONB) when
     ///     resolving LINQ members. The optional <c>Marten.Newtonsoft</c> package
     ///     adds <c>Newtonsoft.Json.Linq.JObject</c> here via its


### PR DESCRIPTION
Bumps the JasperFx line to **2.52.0** and implements `IDocumentCommitListener` / `IDocumentChangeSet` / `IDocumentDeletion` — the store-agnostic post-commit **session** hook from [jasperfx#679](https://github.com/JasperFx/jasperfx/issues/679) / [PR #680](https://github.com/JasperFx/jasperfx/pull/680) — so a listener written once works unchanged on Marten, Polecat and Fisher.

## Adapter, not inheritance — and the compiler forces it

`src/Marten/Services/DocumentCommitListenerAdapter.cs` is a new file holding three internal types. None of the contracts could be bolted onto an existing Marten type:

| contract member | Marten's existing member | satisfies? |
|---|---|---|
| `IReadOnlyList<object> Inserted` | `IEnumerable<object> IChangeSet.Inserted` | no |
| `IReadOnlyList<object> Updated` | `IEnumerable<object> IChangeSet.Updated` | no |
| `IReadOnlyList<IDocumentDeletion> Deleted` | `IEnumerable<Weasel.Storage.IDeletion> IChangeSet.Deleted` | no |
| `AfterCommitAsync(IDocumentSessionOperations, IDocumentChangeSet, CancellationToken)` | `AfterCommitAsync(IDocumentSession, IChangeSet, CancellationToken)` | no — 3 of 4 positions differ |

Putting `IDocumentChangeSet` on `IChangeSet` would be a **breaking change to every existing Marten listener**; putting it on `ISessionWorkTracker` would additionally rope in `ProjectionUpdateBatch`, whose `Inserted`/`Updated`/`Deleted` all throw `NotSupportedException`.

Worth stating explicitly, because it differs from jasperfx#669 and #673: **no member of this contract has a default implementation**, so a near-miss here is CS0535 at build time rather than a silent bind to a throwing default. The trap that remains is the *wiring* — a store that declares the interfaces perfectly and never invokes the listener compiles clean and passes every other suite. That is what the compliance suite catches.

## The snapshot is load-bearing, and it is proven

`MartenDocumentChangeSet` materialises all three collections in its **constructor**. Marten's `IChangeSet` *is* the session's live `UnitOfWork`: its members are lazy LINQ chains re-walked over `_operations` on every read, and `DocumentSessionBase.SaveChangesAsync` calls `_workTracker.Reset()` immediately after the listener loop.

Verified with a negative control rather than asserted — a lazy forward (`=> inner.Inserted.ToArray()` on the property) fails **4 of the 10** compliance facts:

- `the_change_set_survives_the_session_moving_on`
- `the_change_set_carries_the_written_document`
- `each_commit_raises_its_own_callback`
- `a_document_written_twice_is_reported_by_both_commits`

## Ancillary-store decision: PRIMARY STORE ONLY, mirroring `IInitialData`

The sweep in `AddMarten()` sits directly beside `options.InitialData.AddRange(s.GetServices<IInitialData>())` and behaves identically: **the main store only.**

A bare `GetServices<IDocumentCommitListener>()` from the `StoreOptions` factory cannot tell which store a registration was meant for, so sweeping it onto ancillary stores as well would attach every listener in the application to every `AddMartenStore<T>()`, silently and with no way to opt one out. Ancillary stores opt in explicitly through the existing `IConfigureMarten<T>` seam:

```csharp
services.ConfigureMarten<IOrdersStore>(opts => opts.AddCommitListener(listener));
```

`StoreOptions.AddCommitListener(IDocumentCommitListener)` is the one new **public** API — the adapter itself stays internal, since it is a detail of the bridge rather than something a user should construct. It is also what the compliance fixture uses to replay `DocumentComplianceConfig.CommitListeners`.

Both halves are pinned by tests, including `the_sweep_does_NOT_reach_an_ancillary_store` — if that ever goes green the other way round it is a behaviour change for every multi-store application, not a bug fix.

## Tests

- **`DocumentCommitListenerCompliance` — 10/10 passing**, enrolled as `document_commit_listener_compliance` in the existing `DocumentComplianceCollection`.
- **All document + event compliance suites: 319/319 passing.**
- **5 new Marten-side DI facts** in `src/CoreTests/registering_document_commit_listeners.cs`, covering what the compliance suite **structurally cannot**: `MartenDocumentComplianceFixture` builds a bare `new StoreOptions()` and replays listeners by hand, so no container is involved and the `AddMarten` sweep is exercised by nothing over there. They cover the sweep, multiple registrations (`GetServices` vs `GetService`), the ancillary boundary in both directions, and deletion descriptors end-to-end.
- **CoreTests: 535 passed / 5 failed.** Those 5 failures reproduce **identically on clean `origin/master`** on this machine (`530 passed / 5 failed` — the delta is exactly the 5 tests this PR adds). They are DDL/advisory-lock contention in the shared test database (`Unable to attain a global lock`, `constraint "fkey_mt_events_stream_id" ... already exists`) and are unrelated to this change: `Bug_4185_codegen_conflict_projection_with_secondary_store_dependency`, both `Bug_4187_ancillary_store_isolation` facts, `rolling_range_partitioning.the_host_startup_pass_...`, `jasper_fx_mechanics.divergent_application_assembly_reuse_warning_is_buffered_and_logged`.
- **DocumentDbTests `SessionMechanics`: 96/96 passing** — the existing listener pipeline is untouched.

## Also in here

- `Directory.Packages.props` — 2.52.0 across the five JasperFx pins, with the inline changelog comment **extended** per house convention (including why this bump's trap is *not* the 2.50.0/2.51.0 trap).
- `docs/diagnostics.md` — a new "Store-agnostic commit listeners" section under *Listening for Document Store Events*, with three compiled mdsnippets samples from `src/CoreTests/Examples/DocumentCommitListenerSamples.cs`. Verified snippet-stable (a second `mdsnippets` run is a no-op on this file). I deliberately reverted the ~28 unrelated files `mdsnippets` re-synced from **pre-existing** drift on master, so this PR carries only `diagnostics.md`.

⚠️ The docs badge says `9.28` on the assumption the next release is a minor bump; `Directory.Build.props` is left at `9.27.0` since releases are yours.

## Notes against the plan

- `UnitOfWork` lives at `src/Marten/Internal/UnitOfWork.cs`, not `src/Marten/Services/`; the `IChangeSet` members are at lines 184–190 there, as described.
- Marten's `IDocumentSession` already derives from `JasperFx.Events.Documents.IDocumentSessionOperations` (#5216), so the session crosses the adapter as-is with no wrapper.
- `Weasel.Storage.IDeletion` declares `object Id` (non-nullable) and inherits `Type DocumentType` from `Weasel.Core.IStorageOperation` — structurally a match for `IDocumentDeletion`, but C# has no structural implementation and putting a JasperFx interface on a Weasel type would make Weasel depend on JasperFx.Events. Hence `MartenDocumentDeletion`.
- Marten **short-circuits an empty unit of work** (`SaveChangesAsync` returns early when `!HasOutstandingWork()`), so it does not fire for an empty commit. The contract explicitly permits either answer and the suite does not assert it — noting it because the XML docs said Marten's behaviour here "was never stated".