### PR TITLE
Retried batch loses its events: pooled parameter buffers were released after the first execution (#5262)

### DIFF
--- a/docs/configuration/retries.md
+++ b/docs/configuration/retries.md
@@ -28,6 +28,19 @@ return builder
 The general idea is to have _some_ level of retry with an exponential backoff on typical transient errors encountered
 in database usage (network hiccups, a database being too busy, etc.).
 
+Committing a unit of work is held to a stricter policy. A batch of document and event operations is
+**not idempotent** — replaying it appends the same events a second time — so `SaveChangesAsync()` only
+retries when the previous transaction is known to be gone. A command timeout or a dropped connection
+kills the connector, which means the `ROLLBACK` never reaches PostgreSQL and the server may well have
+committed while the response never made it back to the client. Retrying in that situation is what turns
+one lost commit into a duplicated one, so Marten does not do it:
+
+<!-- snippet: sample_default_write_polly_setup -->
+<!-- endSnippet -->
+
+Errors that PostgreSQL itself reports (a serialization failure, a deadlock, a constraint violation) do
+leave the transaction definitively aborted, and are still retried.
+
 You can **replace** Marten's Polly configuration through:
 
 <!-- snippet: sample_configure_polly -->

--- a/src/CoreTests/Bugs/Bug_5262_partial_commit_on_batch_timeout.cs
+++ b/src/CoreTests/Bugs/Bug_5262_partial_commit_on_batch_timeout.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Services;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+/// <summary>
+/// Repro for #5262. A SaveChangesAsync that mixes event appends with document writes and blows the
+/// command timeout
+///
+/// 1. is retried in full by <c>Options.ResiliencePipeline</c> (DocumentSessionBase.SaveChanges.cs:170) -
+///    including the event appends, which are not idempotent, and
+/// 2. leaves state behind - mt_streams.version is bumped for streams whose events were never written.
+///
+/// (2) is the exact fingerprint we see in production: streams whose <c>version</c> runs ahead of their
+/// own event count, on the worst one by 216.
+/// </summary>
+public class Bug_5262_partial_commit_on_batch_timeout: OneOffConfigurationsContext
+{
+    private readonly ITestOutputHelper _output;
+
+    public Bug_5262_partial_commit_on_batch_timeout(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public class Doc
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public record StreamStarted(string Name);
+
+    public record SomethingHappened(string Name);
+
+    private const int Count = 30;
+
+    [Fact]
+    public async Task batch_timeout_rolls_everything_back_and_runs_the_batch_once()
+    {
+        StoreOptions(opts =>
+        {
+            opts.CommandTimeout = 1; // seconds - the Marten default is 5
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps; // the Marten 9 default
+        });
+
+        var streamKeys = Enumerable.Range(0, Count).Select(i => $"stream-{i}").ToArray();
+
+        // Arrange: the streams already exist, exactly like the production case. Appends to an existing
+        // stream go through mt_quick_append_events.
+        await using (var setup = theStore.LightweightSession())
+        {
+            foreach (var key in streamKeys)
+            {
+                setup.Events.StartStream(key, new StreamStarted(key));
+            }
+
+            await setup.SaveChangesAsync();
+        }
+
+        var logger = new RecordingLogger();
+
+        await using var session = theStore.LightweightSession();
+        session.Logger = logger;
+
+        for (var i = 0; i < Count; i++)
+        {
+            session.Events.Append(streamKeys[i], new SomethingHappened($"event-{i}"));
+            session.Store(new Doc { Id = Guid.NewGuid(), Name = $"doc-{i}" });
+        }
+
+        // Pushes the batch past the 1 second command timeout. Event operations go first in the batch
+        // (UnitOfWork.AllOperations), so the appends have already been sent when this one stalls.
+        session.QueueSqlCommand("select pg_sleep(3)");
+
+        Exception caught = null;
+        try
+        {
+            await session.SaveChangesAsync();
+        }
+        catch (Exception e)
+        {
+            caught = e;
+        }
+
+        _output.WriteLine($"exception  : {caught?.GetType().FullName ?? "<none>"} / inner {caught?.InnerException?.GetType().Name}");
+        _output.WriteLine($"batches executed (OnBeforeExecute) : {logger.BatchesStarted}");
+        _output.WriteLine($"batch commands logged as failed    : {logger.FailedCommands.Count}");
+        foreach (var group in logger.FailedCommands.GroupBy(NormalizeSql).OrderByDescending(g => g.Count()))
+        {
+            _output.WriteLine($"  {group.Count(),4} x {group.Key}");
+        }
+
+        // Measure on a fresh connection, bypassing Marten entirely.
+        var (rows, extraEvents, docs, tombstones) = await MeasureAsync();
+
+        _output.WriteLine($"after the failure: {extraEvents} SomethingHappened events, {docs} documents, {tombstones} tombstones");
+        _output.WriteLine("streams whose version does not match their own event count:");
+        var mismatched = rows.Where(x => x.Id != "mt_tombstone" && x.Version != x.Events).ToList();
+        foreach (var row in mismatched)
+        {
+            _output.WriteLine($"  {row.Id}: mt_streams.version = {row.Version}, actual events = {row.Events}");
+        }
+
+        // Marten's contract: one transaction, so all of it or none of it. And the batch belongs to the
+        // caller to retry - re-appending events behind their back is not safe.
+        caught.ShouldNotBeNull("SaveChangesAsync returned normally after the batch failed");
+        logger.BatchesStarted.ShouldBe(1);
+
+        extraEvents.ShouldBe(0);
+        docs.ShouldBe(0);
+        mismatched.ShouldBeEmpty();
+    }
+
+    private async Task<(List<StreamRow>, int, int, int)> MeasureAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        var rows = new List<StreamRow>();
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $"""
+                               select s.id, s.version, (select count(*) from {SchemaName}.mt_events e where e.stream_id = s.id)
+                               from {SchemaName}.mt_streams s order by s.id
+                               """;
+            await using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                rows.Add(new StreamRow
+                {
+                    Id = reader.GetString(0), Version = reader.GetInt64(1), Events = reader.GetInt64(2)
+                });
+            }
+        }
+
+        async Task<int> ScalarAsync(string sql)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+        }
+
+        var extraEvents = await ScalarAsync($"select count(*) from {SchemaName}.mt_events where type = 'something_happened'");
+        var docs = await ScalarAsync($"select count(*) from {SchemaName}.mt_doc_bug_5262_partial_commit_on_batch_timeout_doc");
+        var tombstones = await ScalarAsync($"select count(*) from {SchemaName}.mt_events where type = 'tombstone'");
+
+        return (rows, extraEvents, docs, tombstones);
+    }
+
+    public class StreamRow
+    {
+        public string Id { get; set; }
+        public long Version { get; set; }
+        public long Events { get; set; }
+    }
+
+    private static string NormalizeSql(string sql)
+    {
+        var trimmed = sql.Trim().ReplaceLineEndings(" ");
+        return trimmed.Length <= 70 ? trimmed : trimmed[..70];
+    }
+
+    public class RecordingLogger: IMartenSessionLogger
+    {
+        public List<string> FailedCommands { get; } = new();
+        public int BatchesStarted { get; private set; }
+
+        public void LogSuccess(NpgsqlCommand command) { }
+        public void LogSuccess(NpgsqlBatch batch) { }
+
+        public void LogFailure(NpgsqlCommand command, Exception ex) => FailedCommands.Add(command.CommandText);
+
+        public void LogFailure(NpgsqlBatch batch, Exception ex)
+        {
+            foreach (var command in batch.BatchCommands)
+            {
+                FailedCommands.Add(command.CommandText);
+            }
+        }
+
+        public void LogFailure(Exception ex, string message) { }
+        public void RecordSavedChanges(IDocumentSession session, IChangeSet commit) { }
+        public void OnBeforeExecute(NpgsqlCommand command) { }
+        public void OnBeforeExecute(NpgsqlBatch batch) => BatchesStarted++;
+    }
+}

--- a/src/CoreTests/Bugs/Bug_5262_retry_loses_events.cs
+++ b/src/CoreTests/Bugs/Bug_5262_retry_loses_events.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Exceptions;
+using Marten.Services;
+using Marten.Testing.Harness;
+using Marten.Util;
+using Npgsql;
+using Polly;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+/// <summary>
+/// The other half of #5262: when the resilience pipeline's FIRST attempt times out and a LATER attempt
+/// succeeds, does the retried batch still contain its events?
+///
+/// The first attempt is made to blow the command timeout and every attempt after it is fast, using a
+/// sequence so the counter survives the rollback (nextval is not transactional).
+/// </summary>
+public class Bug_5262_retry_loses_events: OneOffConfigurationsContext
+{
+    private readonly ITestOutputHelper _output;
+
+    public Bug_5262_retry_loses_events(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public class Doc
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public record StreamStarted(string Name);
+
+    public record SomethingHappened(string Name);
+
+    private const int Count = 30;
+
+    [Fact]
+    public async Task a_successful_retry_still_writes_its_events()
+    {
+        StoreOptions(opts =>
+        {
+            opts.CommandTimeout = 1;
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+
+            // The permissive default, explicitly, so this test measures the retry itself and not the
+            // narrowed write policy from this branch.
+            opts.ConfigurePolly(builder => builder.AddMartenDefaults());
+        });
+
+        var streamKeys = Enumerable.Range(0, Count).Select(i => $"stream-{i}").ToArray();
+
+        await using (var setup = theStore.LightweightSession())
+        {
+            foreach (var key in streamKeys)
+            {
+                setup.Events.StartStream(key, new StreamStarted(key));
+            }
+
+            await setup.SaveChangesAsync();
+        }
+
+        // After the setup commit, so the schema exists.
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"drop sequence if exists {SchemaName}.attempt_counter; create sequence {SchemaName}.attempt_counter;";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var logger = new CountingLogger();
+
+        await using var session = theStore.LightweightSession();
+        session.Logger = logger;
+
+        for (var i = 0; i < Count; i++)
+        {
+            session.Events.Append(streamKeys[i], new SomethingHappened($"event-{i}"));
+            session.Store(new Doc { Id = Guid.NewGuid(), Name = $"doc-{i}" });
+        }
+
+        // Sleeps 3 seconds on the first attempt only. nextval survives the rollback.
+        session.QueueSqlCommand(
+            $"select pg_sleep(case when nextval('{SchemaName}.attempt_counter') <= 1 then 3 else 0 end)");
+
+        Exception caught = null;
+        try
+        {
+            await session.SaveChangesAsync();
+        }
+        catch (Exception e)
+        {
+            caught = e;
+        }
+
+        var (events, docs, tombstones, attempts) = await MeasureAsync();
+
+        _output.WriteLine($"exception from SaveChangesAsync : {caught?.GetType().Name ?? "<none>"}");
+        _output.WriteLine($"batches executed                : {logger.BatchesStarted}");
+        _output.WriteLine($"attempt counter (nextval)       : {attempts}");
+        _output.WriteLine($"persisted                       : {events} events, {docs} documents, {tombstones} tombstones");
+        _output.WriteLine($"expected                        : {Count} events, {Count} documents");
+
+        // A retry that commits must commit the whole unit of work, events included.
+        caught.ShouldBeNull();
+        docs.ShouldBe(Count);
+        events.ShouldBe(Count);
+    }
+
+    private async Task<(int, int, int, long)> MeasureAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        async Task<long> ScalarAsync(string sql)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            return Convert.ToInt64(await cmd.ExecuteScalarAsync());
+        }
+
+        var events = (int)await ScalarAsync($"select count(*) from {SchemaName}.mt_events where type = 'something_happened'");
+        var docs = (int)await ScalarAsync($"select count(*) from {SchemaName}.mt_doc_bug_5262_retry_loses_events_doc");
+        var tombstones = (int)await ScalarAsync($"select count(*) from {SchemaName}.mt_events where type = 'tombstone'");
+        var attempts = await ScalarAsync($"select last_value from {SchemaName}.attempt_counter");
+
+        return (events, docs, tombstones, attempts);
+    }
+
+    public class CountingLogger: IMartenSessionLogger
+    {
+        public int BatchesStarted { get; private set; }
+
+        public void LogSuccess(NpgsqlCommand command) { }
+        public void LogSuccess(NpgsqlBatch batch) { }
+        public void LogFailure(NpgsqlCommand command, Exception ex) { }
+        public void LogFailure(NpgsqlBatch batch, Exception ex) { }
+        public void LogFailure(Exception ex, string message) { }
+        public void RecordSavedChanges(IDocumentSession session, IChangeSet commit) { }
+        public void OnBeforeExecute(NpgsqlCommand command) { }
+        public void OnBeforeExecute(NpgsqlBatch batch) => BatchesStarted++;
+    }
+}

--- a/src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs
+++ b/src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics;
@@ -18,7 +18,7 @@ using Weasel.Postgresql;
 
 namespace Marten.Events.Operations;
 
-public abstract class QuickAppendEventsOperationBase : IStorageOperation, IExceptionTransform
+public abstract class QuickAppendEventsOperationBase : IStorageOperation, IExceptionTransform, IDisposable
 {
     // SQLSTATE raised by mt_quick_append_events when the target stream is archived.
     // Keep in sync with QuickAppendEventFunction.WriteCreateStatement.
@@ -57,7 +57,10 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation, IExcep
     }
 
     // 9.0 (#4385): per-batch column-array rentals from ArrayPool<T>.Shared, returned in
-    // PostprocessAsync once Npgsql has written the parameters to the wire.
+    // Dispose() once the whole unit of work is finished. NOT in PostprocessAsync: the resilience
+    // pipeline can re-execute the very same NpgsqlBatch (OperationPage calls ConfigureCommand once,
+    // in its constructor, and Compile() only hands back the already-built batch), and a released
+    // PooledList reports Count = 0, so the retry would send empty event_ids arrays. See #5262.
     // Capacity 12 covers writeBasicParameters (4) + writeCausationIds + writeCorrelationIds
     // + writeHeaders + writeUserNames + writeTimestamps + up-to-N tag-type arrays without
     // a List growth. Lazily-allocated so subclasses that override ConfigureCommand without
@@ -318,67 +321,67 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation, IExcep
 
     public async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
     {
-        try
+        if (await reader.ReadAsync(token).ConfigureAwait(false))
         {
-            if (await reader.ReadAsync(token).ConfigureAwait(false))
+            // #5062: nothing to post-process for an append with no events -- but the row
+            // still has to be consumed above so the reader stays aligned for the rest of
+            // the page. Bail before touching field 0: on a database whose
+            // mt_quick_append_events predates the COALESCE fix, the empty case comes back
+            // as ARRAY[NULL] and GetFieldValueAsync<long[]> throws InvalidCastException,
+            // which would then replace whatever exception actually made the caller fail.
+            // #5062: nothing to post-process for an append with no events -- but the row
+            // still has to be consumed above so the reader stays aligned for the rest of
+            // the page. Bail before touching field 0: on a database whose
+            // mt_quick_append_events predates the COALESCE fix, the empty case comes back
+            // as ARRAY[NULL] and GetFieldValueAsync<long[]> throws InvalidCastException,
+            // which would then replace whatever exception actually made the caller fail.
+            if (Stream.Events.Count == 0)
             {
-                // #5062: nothing to post-process for an append with no events -- but the row
-                // still has to be consumed above so the reader stays aligned for the rest of
-                // the page. Bail before touching field 0: on a database whose
-                // mt_quick_append_events predates the COALESCE fix, the empty case comes back
-                // as ARRAY[NULL] and GetFieldValueAsync<long[]> throws InvalidCastException,
-                // which would then replace whatever exception actually made the caller fail.
-                // #5062: nothing to post-process for an append with no events -- but the row
-                // still has to be consumed above so the reader stays aligned for the rest of
-                // the page. Bail before touching field 0: on a database whose
-                // mt_quick_append_events predates the COALESCE fix, the empty case comes back
-                // as ARRAY[NULL] and GetFieldValueAsync<long[]> throws InvalidCastException,
-                // which would then replace whatever exception actually made the caller fail.
-                if (Stream.Events.Count == 0)
-                {
-                    return;
-                }
+                return;
+            }
 
-                var values = await reader.GetFieldValueAsync<long[]>(0, token).ConfigureAwait(false);
+            var values = await reader.GetFieldValueAsync<long[]>(0, token).ConfigureAwait(false);
 
-                var finalVersion = values[0];
-                var events = Stream.Events;
-                for (int i = events.Count - 1; i >= 0; i--)
-                {
-                    events[i].Version = finalVersion;
-                    finalVersion--;
-                }
+            var finalVersion = values[0];
+            var events = Stream.Events;
+            for (int i = events.Count - 1; i >= 0; i--)
+            {
+                events[i].Version = finalVersion;
+                finalVersion--;
+            }
 
-                // Ignore the first value
-                for (int i = 1; i < values.Length; i++)
-                {
-                    // Only setting the sequence to aid in tombstone processing
-                    events[i - 1].Sequence = values[i];
-                }
+            // Ignore the first value
+            for (int i = 1; i < values.Length; i++)
+            {
+                // Only setting the sequence to aid in tombstone processing
+                events[i - 1].Sequence = values[i];
+            }
 
-                // UseMandatoryStreamTypeDeclaration rejects appending to a stream that does not
-                // exist yet (its first event would come back as version 1). But when
-                // UseTenantPartitionedEvents is on, StartStream actions are also routed through this
-                // bulk-append operation (see QuickEventAppender.registerOperationsForStreams), and a
-                // legitimate StartStream of a brand-new stream likewise produces version 1. Only an
-                // Append — not a Start — to a non-existent stream is the case this guard is meant to
-                // catch, so exclude StartStream actions here. Without this, a partitioned StartStream
-                // throws NonExistentStreamException and the events get tombstoned (#4611).
-                if (Events is { UseMandatoryStreamTypeDeclaration: true }
-                    && events[0].Version == 1
-                    && Stream.ActionType != StreamActionType.Start)
-                {
-                    throw new NonExistentStreamException(Events.StreamIdentity == StreamIdentity.AsGuid
-                        ? Stream.Id
-                        : Stream.Key);
-                }
+            // UseMandatoryStreamTypeDeclaration rejects appending to a stream that does not
+            // exist yet (its first event would come back as version 1). But when
+            // UseTenantPartitionedEvents is on, StartStream actions are also routed through this
+            // bulk-append operation (see QuickEventAppender.registerOperationsForStreams), and a
+            // legitimate StartStream of a brand-new stream likewise produces version 1. Only an
+            // Append — not a Start — to a non-existent stream is the case this guard is meant to
+            // catch, so exclude StartStream actions here. Without this, a partitioned StartStream
+            // throws NonExistentStreamException and the events get tombstoned (#4611).
+            if (Events is { UseMandatoryStreamTypeDeclaration: true }
+                && events[0].Version == 1
+                && Stream.ActionType != StreamActionType.Start)
+            {
+                throw new NonExistentStreamException(Events.StreamIdentity == StreamIdentity.AsGuid
+                    ? Stream.Id
+                    : Stream.Key);
             }
         }
-        finally
-        {
-            // Parameter bytes hit the wire before ExecuteReaderAsync returned, so the
-            // rentals are safe to release here regardless of whether the body threw.
-            releaseColumnRentals();
-        }
+    }
+
+    /// <summary>
+    /// Returns the rented column buffers. Called once the unit of work is finished, because the
+    /// batch these parameters belong to may be executed more than once. See #5262.
+    /// </summary>
+    public void Dispose()
+    {
+        releaseColumnRentals();
     }
 }

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
@@ -194,6 +194,19 @@ public abstract partial class DocumentSessionBase
             await tryApplyTombstoneEventsAsync(token).ConfigureAwait(false);
             throw;
         }
+        finally
+        {
+            // Operations can hold pooled buffers that back their command parameters, and the
+            // resilience pipeline above may execute the same batch more than once - so the rentals
+            // belong to the unit of work, not to a single execution. See #5262.
+            foreach (var page in pages)
+            {
+                foreach (var operation in page.Operations)
+                {
+                    if (operation is IDisposable disposable) disposable.Dispose();
+                }
+            }
+        }
     }
 
     private async Task executeAfterCommitListeners(IUpdateBatch batch)

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -168,7 +168,7 @@ public abstract partial class DocumentSessionBase
 
                 await executeBeforeCommitListeners(batch).ConfigureAwait(false);
 
-                await Options.ResiliencePipeline.ExecuteAsync(
+                await Options.WriteResiliencePipeline.ExecuteAsync(
                     static (e, t) => new ValueTask(e.Connection.ExecuteBatchPagesAsync(e.Pages, e.Exceptions, t, e.Participants)), execution, token).ConfigureAwait(false);
 
                 await executeAfterCommitListeners(batch).ConfigureAwait(false);

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
@@ -212,6 +212,7 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
 
         // Default Polly setup
         ResiliencePipeline = new ResiliencePipelineBuilder().AddMartenDefaults().Build();
+        WriteResiliencePipeline = new ResiliencePipelineBuilder().AddMartenWriteDefaults().Build();
 
         // Add logging into our NpgsqlDataSource
         NpgsqlDataSourceFactory = new DefaultNpgsqlDataSourceFactory(connectionString =>
@@ -243,6 +244,7 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
         configure(builder);
 
         ResiliencePipeline = builder.Build();
+        WriteResiliencePipeline = ResiliencePipeline;
     }
 
     /// <summary>
@@ -255,6 +257,11 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
         configure(builder);
 
         ResiliencePipeline = builder.AddMartenDefaults().Build();
+
+        var writeBuilder = new ResiliencePipelineBuilder();
+        configure(writeBuilder);
+
+        WriteResiliencePipeline = writeBuilder.AddMartenWriteDefaults().Build();
     }
 
     /// <summary>
@@ -307,6 +314,14 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
     /// Polly policies for retries within Marten command execution
     /// </summary>
     internal ResiliencePipeline ResiliencePipeline { get; set; }
+
+    /// <summary>
+    /// Polly policies for retries around a unit of work commit. A batch of document and event
+    /// operations is not idempotent, so unlike <see cref="ResiliencePipeline"/> this one only retries
+    /// failures where PostgreSQL itself reported the error and the transaction is therefore known to
+    /// have been rolled back.
+    /// </summary>
+    internal ResiliencePipeline WriteResiliencePipeline { get; set; }
 
     /// <summary>
     ///     Advisory lock id is used by the ApplyChangesOnStartup() option to serialize access to making

--- a/src/Marten/Util/ResilientPipelineBuilderExtensions.cs
+++ b/src/Marten/Util/ResilientPipelineBuilderExtensions.cs
@@ -1,5 +1,6 @@
-﻿#nullable enable
+#nullable enable
 using System;
+using System.Linq;
 using JasperFx.Events.Daemon;
 using Marten.Events.Daemon.Internals;
 using Marten.Exceptions;
@@ -28,5 +29,51 @@ internal static class ResilientPipelineBuilderExtensions
             });
 
         #endregion
+    }
+
+    /// <summary>
+    /// The retry policy for committing a unit of work. Identical to <see cref="AddMartenDefaults"/>
+    /// except that it does not retry when the fate of the previous attempt is unknown. A batch of
+    /// document and event operations is not idempotent — replaying it appends the same events a second
+    /// time — so it may only be retried when the previous transaction is known to be gone.
+    /// </summary>
+    public static ResiliencePipelineBuilder AddMartenWriteDefaults(this ResiliencePipelineBuilder builder)
+    {
+        #region sample_default_write_polly_setup
+
+        // Marten's policy for committing a unit of work
+        return builder
+            .AddRetry(new()
+            {
+                ShouldHandle = new PredicateBuilder()
+                    .Handle<NpgsqlException>(e => !IsOutcomeInDoubt(e))
+                    .Handle<MartenCommandException>(e => !IsOutcomeInDoubt(e))
+                    .Handle<EventLoaderException>(),
+                MaxRetryAttempts = 3,
+                Delay = TimeSpan.FromMilliseconds(50),
+                BackoffType = DelayBackoffType.Exponential
+            });
+
+        #endregion
+    }
+
+    /// <summary>
+    /// True when we cannot know whether the transaction committed. A command timeout or a dropped
+    /// connection kills the connector, so the ROLLBACK never reaches PostgreSQL and the server may
+    /// well have committed while the response never made it back to us. An error PostgreSQL itself
+    /// reported (<see cref="PostgresException"/>), or a failure raised while post-processing a reader
+    /// that Marten then rolled back, leaves no such doubt.
+    /// </summary>
+    internal static bool IsOutcomeInDoubt(Exception exception)
+    {
+        return exception switch
+        {
+            PostgresException => false,
+            NpgsqlException => true,
+            TimeoutException => true,
+            AggregateException aggregate => aggregate.InnerExceptions.Any(IsOutcomeInDoubt),
+            { InnerException: { } inner } => IsOutcomeInDoubt(inner),
+            _ => false
+        };
     }
 }


### PR DESCRIPTION
Fixes #5262. Two commits, and the second one is the bug that loses data — take that one even if you disagree with the first.

## Commit 2 — a retried batch sends empty event arrays

`OperationPage` calls `ConfigureCommand` **once**, in its constructor; `Compile()` only hands back the already-built `NpgsqlBatch`. So when `Options.ResiliencePipeline` re-executes a page, the same parameter objects go over the wire again.

`QuickAppendEventsOperationBase` rents its parallel column buffers from `ArrayPool` through `PooledList<T>` and released them in `PostprocessAsync`'s `finally`, on the stated assumption that "parameter bytes hit the wire before `ExecuteReaderAsync` returned, so the rentals are safe to release here". True for one execution. On a retry, the released `PooledList` reports `Count = 0` — and `Count` is what Npgsql uses for the array length — so the append sends empty `event_ids` / `event_types` / bodies arrays. `mt_quick_append_events` with an empty array writes nothing, bumps no version and raises no error.

Net effect: the retry's transaction commits the documents, silently skips the events, and `SaveChangesAsync` returns **success**.

`Bug_5262_retry_loses_events` reproduces it on master — first attempt times out, second attempt succeeds:

```
exception from SaveChangesAsync : <none>
batches executed                : 2
attempt counter (nextval)       : 2
persisted                       : 0 events, 30 documents, 0 tombstones
expected                        : 30 events, 30 documents
```

The fix moves ownership of the rentals from a single execution to the unit of work: the operation implements `IDisposable`, `PostprocessAsync` no longer releases, and `SaveChanges` disposes the pages' operations in a `finally` — exactly once, whatever the outcome.

This mechanism also predicted the production data. In the incident, 8 of 69 events survived a retried batch. Since `ApplyCallbacksAsync` walks the operations in order, only the appends it had *not* reached before the timeout still held their payload, so the survivors had to be the last ones in batch order. They were, exactly: positions 58–65 of 65.

## Commit 1 — do not retry a write whose outcome is unknown

Separate concern, and optional as far as I'm concerned. The default policy handles every `NpgsqlException` with 3 retries, and a command timeout is one of those. A client-side read timeout cannot tell a rolled-back transaction from a committed one, so replaying a non-idempotent batch there risks appending the same events twice.

Committing goes through a `WriteResiliencePipeline` built from `AddMartenWriteDefaults()`: same shape, same attempt count, one predicate difference — no retry when the outcome is in doubt.

```csharp
internal static bool IsOutcomeInDoubt(Exception exception)
{
    return exception switch
    {
        PostgresException => false,   // the server answered, so the transaction is definitively aborted
        NpgsqlException => true,      // I/O level: timeout, dropped connection - unknown
        TimeoutException => true,
        AggregateException aggregate => aggregate.InnerExceptions.Any(IsOutcomeInDoubt),
        { InnerException: { } inner } => IsOutcomeInDoubt(inner),
        _ => false
    };
}
```

Everything that retried before still retries: errors PostgreSQL itself reported (serialization failures, deadlocks, constraint violations) leave the transaction definitively aborted, and so does a failure raised in reader post-processing, which `ExecuteBatchPagesAsync` rolls back itself. `CoreTests.retry_mechanism` covers that second case and stays green — its `MartenCommandException` wraps a plain `Exception`, not an I/O failure.

The read path (`MartenDatabase.Execution.cs:58`) keeps the unchanged `ResiliencePipeline`; retrying an idempotent read after a connection blip is useful. `ConfigurePolly` sets both pipelines so a caller who takes over keeps full control; `ExtendPolly` layers the user's policies over the respective defaults.

## Commit order is red, green, red, green

Each test lands in its own commit and is failing at that point, so you can check out either test commit and watch it fail before the fix that follows it:

| commit | |
|---|---|
| `2d006d7c9` | failing test — a successful retry commits its documents but loses its events |
| `10f9511c2` | fix — the pooled parameter buffers belong to the unit of work |
| `b9bdc166e` | failing test — a timed-out batch is retried in full, appends included |
| `d3cabc6ea` | fix — do not retry a unit of work whose outcome is unknown |

Verified at every step, and the first test is red against pristine `origin/master`:

```
exception from SaveChangesAsync : <none>
batches executed                : 2
persisted                       : 0 events, 30 documents, 0 tombstones
expected                        : 30 events, 30 documents
```

## Verification

PostgreSQL 18, `-f net10.0`:

| suite | total | failed | note |
|---|---|---|---|
| `CoreTests` baseline | 548 | 7 | includes the two new tests |
| `CoreTests` with both commits | 549 | 5 | all 5 also fail on the baseline |
| `EventSourcingTests` baseline | 1933 | 5 | `Projections.testing_projections.*` |
| `EventSourcingTests` with both commits | 1933 | 5 | same 5 |

## Corrections to the original issue

The issue as I first filed it claimed a partially committed transaction. That was wrong — `SaveChangesAsync` is one transaction per attempt and it is all-or-nothing. I have rectified that on the issue; the real mechanism is the recycled buffers above.
