### PR TITLE
fix(events): shorten the natural key table's primary key constraint name

### DIFF
--- a/src/Marten/Events/Schema/NaturalKeyTable.cs
+++ b/src/Marten/Events/Schema/NaturalKeyTable.cs
@@ -94,6 +94,14 @@ internal class NaturalKeyTable: Table, ISchemaObject
             IsUnique = false,
             Columns = new[] { streamCol }
         });
+
+        // Every other name this table writes is shortened; the primary key constraint was left on
+        // Weasel's pkey_{table}_{columns} default, which runs past PostgreSQL's 63 character limit
+        // for an aggregate type name of any real length -- 16 characters is enough once tenant_id
+        // joins the key under conjoined tenancy. PostgreSQL used to truncate it silently; Weasel
+        // 9.25 validates primary key constraint names and refuses to emit one that would be cut.
+        PrimaryKeyName = PostgresqlIdentifier.Shorten(
+            $"pkey_{Identifier.Name}_{string.Join("_", PrimaryKeyColumns)}");
     }
 
     /// <summary>


### PR DESCRIPTION
`mt_natural_key_X` shortens every name it writes — both foreign keys and its reverse-lookup index go through `PostgresqlIdentifier.Shorten` — but the primary key constraint was left on Weasel's `pkey_{table}_{columns}` default. That default runs past PostgreSQL's 63 character limit for an aggregate type name of any real length:

```
pkey_ + mt_natural_key_ + <aggregate> + _natural_key_value + _tenant_id
  5         15                              18                  10
```

48 characters before the type name, so **sixteen characters is enough to go over** once `tenant_id` joins the key under conjoined tenancy. Without conjoined tenancy the budget is 25.

PostgreSQL truncated the name silently, which is why this went unnoticed. Weasel 9.25 validates primary key constraint names — they were previously validated by no provider at all ([weasel#448](https://github.com/JasperFx/weasel/issues/448)) — and refuses to emit one that would be cut, so the store now fails to build its schema at all:

```
JasperFx.Resources.ResourceSetupException : Failed to setup resource Main of type WeaselDatabase
---- Weasel.Postgresql.PostgresqlIdentifierTooLongException : Database identifier
     pkey_mt_natural_key_nkorderaggregate_natural_key_value_tenant_id
     would be truncated. The PostgresqlMigratorNameDataLength property is currently 64.
```

That identifier is exactly 64 characters, from a 16-character aggregate name.

## The fix

Set `PrimaryKeyName` through `Shorten`, following `EventTagTable`, which already does exactly this. The expression mirrors Weasel's PostgreSQL default (`pkey_{name}_{cols}`) so nothing else changes.

**`Shorten` is a no-op below the limit**, so a name that already fit is spelled exactly as before and no existing database sees a migration. A name that was *over* the limit moves from PostgreSQL's silent truncation to Weasel's truncate-plus-hash — a constraint rename on first apply, for a database whose constraint name was already not the one Marten declared.

## How this was found

Bumping Wolverine to Weasel 9.25.0 turned three `MartenTests` green-to-red — the only failures in a 610-test suite, and the only ones anywhere in that upgrade attributable to Marten. Verified by baselining: they pass on Weasel 9.24.0 and fail on 9.25.0.

Verified end-to-end by pointing Wolverine's `MartenTests` at a locally-built Marten carrying this commit, on Weasel 9.25.0 — `tenant_partitioned_natural_key_aggregate` goes 0/3 → **3/3**.

Note this affects any `[NaturalKey]` aggregate with a type name of 16+ characters under conjoined tenancy, so it is likely to bite broadly once Marten moves to Weasel 9.25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3