### PR TITLE
EF Core projection storage cannot take concurrent slices (#5266)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -318,15 +318,15 @@
          would additionally rope in ProjectionUpdateBatch, whose Inserted/Updated/Deleted all throw
          NotSupportedException. See DocumentCommitListenerAdapter/MartenDocumentChangeSet and
          StoreOptions.AddCommitListener, pinned by DocumentCommitListenerCompliance. -->
-    <PackageVersion Include="JasperFx" Version="2.52.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.52.0" />
+    <PackageVersion Include="JasperFx" Version="2.53.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.53.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.52.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.53.0" />
     <!--
       Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
       the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
@@ -344,11 +344,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.52.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.53.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.52.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.53.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/Marten.EntityFrameworkCore.Tests/Bug_5266_shared_dbcontext_across_slices.cs
+++ b/src/Marten.EntityFrameworkCore.Tests/Bug_5266_shared_dbcontext_across_slices.cs
@@ -1,0 +1,234 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten.Testing.Harness;
+using Npgsql;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Marten.EntityFrameworkCore.Tests;
+
+public record SearchCriteriaChanged(IReadOnlyList<Guid> CriteriaIds);
+
+public class SearchProjection
+{
+    public Guid Id { get; set; }
+    public int ChangeCount { get; set; }
+}
+
+public class SearchProjectionDbContext: DbContext
+{
+    public SearchProjectionDbContext(DbContextOptions<SearchProjectionDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<SearchProjection> SearchProjections => Set<SearchProjection>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<SearchProjection>(entity =>
+        {
+            entity.ToTable("ef_search_projections");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).HasColumnName("id");
+            entity.Property(x => x.ChangeCount).HasColumnName("change_count");
+        });
+    }
+}
+
+public class SearchProjector:
+    EfCoreMultiStreamProjection<SearchProjection, Guid, SearchProjectionDbContext>
+{
+    // How many slices were ever inside ApplyEventsAsync at the same instant. This is the observable
+    // consequence of jasperfx#683: a storage that says it cannot take concurrent slices gets them
+    // applied inline, so this can only ever reach 1. Before the fix the 10-wide block drove it higher.
+    private static int s_current;
+    public static int MaxObservedConcurrency;
+
+    public static void ResetConcurrencyProbe()
+    {
+        Interlocked.Exchange(ref s_current, 0);
+        Interlocked.Exchange(ref MaxObservedConcurrency, 0);
+    }
+
+    public SearchProjector()
+    {
+        CustomGrouping((_, events, grouping) =>
+        {
+            // A single source event deliberately fans out into more projection slices than the
+            // AggregationRunner's Block<EventSliceExecution>(10, ...) worker count.
+            grouping.AddEvents<SearchCriteriaChanged>(x => x.CriteriaIds, events);
+            return Task.CompletedTask;
+        });
+    }
+
+    protected override async ValueTask<(SearchProjection?, ActionType)> ApplyEventsAsync(
+        SearchProjection? snapshot,
+        Guid identity,
+        IReadOnlyList<IEvent> events,
+        IQuerySession session,
+        SearchProjectionDbContext dbContext,
+        CancellationToken token)
+    {
+        var running = Interlocked.Increment(ref s_current);
+        try
+        {
+            // Record the high-water mark without a lock; a plain compare-and-swap loop is enough.
+            int observed;
+            while (running > (observed = Volatile.Read(ref MaxObservedConcurrency)))
+            {
+                Interlocked.CompareExchange(ref MaxObservedConcurrency, running, observed);
+            }
+
+            // Long enough that genuinely parallel slices overlap here rather than merely interleaving.
+            await Task.Delay(15, token);
+
+            snapshot ??= new SearchProjection { Id = identity };
+            snapshot.ChangeCount += events.Count;
+            return (snapshot, ActionType.Store);
+        }
+        finally
+        {
+            Interlocked.Decrement(ref s_current);
+        }
+    }
+}
+
+/// <summary>
+/// #5266. <c>AggregationRunner</c> applies every slice in a range through a fixed 10-wide block, and
+/// hands each one the <em>same</em> <see cref="IProjectionStorage{TDoc,TId}" />. The EF Core storage
+/// wraps a single <see cref="DbContext" /> per tenant/batch, and a <c>DbContext</c> is not thread-safe:
+/// a multi-stream projection with custom grouping fans one event out into many slices, so up to ten of
+/// them concurrently call <c>Entry()</c> / <c>FindAsync</c> and mutate the same change tracker. That
+/// corrupts EF Core's identity map, surfacing as an <see cref="InvalidOperationException" /> out of
+/// <c>Dictionary.TryInsert</c> or a <see cref="NullReferenceException" /> out of
+/// <c>ChangeDetector.DetectChanges</c>.
+/// <para>
+/// Fixed by jasperfx#683, which lets a storage declare that it cannot take concurrent slices; the runner
+/// then applies them inline instead of posting them into the block.
+/// </para>
+/// </summary>
+public class Bug_5266_shared_dbcontext_across_slices: IAsyncLifetime
+{
+    private DocumentStore _store = null!;
+    private SearchProjector _projection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _projection = new SearchProjector();
+        _store = DocumentStore.For(options =>
+        {
+            options.Connection(ConnectionSource.ConnectionString);
+            options.DatabaseSchemaName = "efcore_rebuild_concurrency";
+            options.Add(_projection, ProjectionLifecycle.Async);
+        });
+
+        await _store.Advanced.Clean.CompletelyRemoveAllAsync();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _store?.Dispose();
+        return default;
+    }
+
+    /// <summary>
+    /// Counted against the EF Core table, not <c>session.Query&lt;SearchProjection&gt;()</c>. The
+    /// projection writes through the DbContext into ef_search_projections; Marten has no document
+    /// storage for this type at all, so querying the session would report zero however the rebuild went.
+    /// </summary>
+    private async Task<int> ProjectionCountAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select count(*) from efcore_rebuild_concurrency.ef_search_projections";
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+    }
+
+    /// <summary>
+    /// The deterministic half. The reporter's repro is a genuine data race and so is flaky by nature —
+    /// it usually throws, which is not something to gate CI on. This pins the contract that removes the
+    /// race instead, and it cannot flake.
+    /// </summary>
+    [Fact]
+    public void the_ef_core_storage_declares_that_it_cannot_take_concurrent_slices()
+    {
+        var storageType = typeof(EfCoreProjectionExtensions).Assembly
+            .GetType("Marten.EntityFrameworkCore.EfCoreProjectionStorage`3")!
+            .MakeGenericType(typeof(SearchProjection), typeof(Guid), typeof(SearchProjectionDbContext));
+
+        var storage = (IProjectionStorage<SearchProjection, Guid>)Activator.CreateInstance(
+            storageType,
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic |
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.CreateInstance,
+            null,
+            [null!, "*DEFAULT*"],
+            null)!;
+
+        storage.IsThreadSafe.ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// The behavioural regression test, and it is deterministic. A storage that declares it cannot take
+    /// concurrent slices must have them applied one at a time, so no two can ever be inside
+    /// <c>ApplyEventsAsync</c> at once. Twenty slices from one event against a 10-wide block is exactly
+    /// the reporter's shape; before jasperfx#683 this reached the block's worker count.
+    /// </summary>
+    [Fact]
+    public async Task slices_are_never_applied_concurrently_against_the_shared_dbcontext()
+    {
+        SearchProjector.ResetConcurrencyProbe();
+
+        var criteriaIds = Enumerable.Range(0, 20).Select(_ => Guid.NewGuid()).ToArray();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream(Guid.NewGuid(), new SearchCriteriaChanged(criteriaIds));
+            await session.SaveChangesAsync();
+        }
+
+        using (var daemon = await _store.BuildProjectionDaemonAsync())
+        {
+            await daemon.RebuildProjectionAsync<SearchProjector>(CancellationToken.None);
+        }
+
+        // Guard the guard: if nothing was applied the concurrency assertion below is vacuous.
+        (await ProjectionCountAsync()).ShouldBe(criteriaIds.Length);
+
+        SearchProjector.MaxObservedConcurrency.ShouldBe(1);
+    }
+
+    /// <summary>
+    /// The reporter's repro, kept as scenario coverage rather than as a race detector: it is a genuine
+    /// data race, so it only <em>usually</em> failed, and it passes on the unfixed build often enough to
+    /// prove nothing on its own. The concurrency assertion above is what actually pins the fix.
+    /// </summary>
+    [Fact]
+    public async Task rebuild_across_slices_creates_all_projections()
+    {
+        var criteriaIds = Enumerable.Range(0, 20).Select(_ => Guid.NewGuid()).ToArray();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream(Guid.NewGuid(), new SearchCriteriaChanged(criteriaIds));
+            await session.SaveChangesAsync();
+        }
+
+        using (var daemon = await _store.BuildProjectionDaemonAsync())
+        {
+            await daemon.RebuildProjectionAsync<SearchProjector>(CancellationToken.None);
+        }
+
+        (await ProjectionCountAsync()).ShouldBe(criteriaIds.Length);
+    }
+}

--- a/src/Marten.EntityFrameworkCore/EfCoreProjectionStorage.cs
+++ b/src/Marten.EntityFrameworkCore/EfCoreProjectionStorage.cs
@@ -48,6 +48,24 @@ internal class EfCoreProjectionStorage<
     public string TenantId => _tenantId;
     public Type IdType => typeof(TId);
 
+    /// <summary>
+    ///     #5266. One <see cref="DbContext" /> is created per tenant/batch and shared by every slice in
+    ///     the range, and a <c>DbContext</c> is not thread-safe. <c>AggregationRunner</c> otherwise applies
+    ///     slices through a fixed 10-wide block, so a multi-stream projection with custom grouping — where
+    ///     one event fans out into many slices — has up to ten of them concurrently calling
+    ///     <see cref="DbContext.Entry(object)" /> / <c>FindAsync</c> and mutating the same change tracker.
+    ///     That corrupts EF Core's identity map, surfacing as an <see cref="InvalidOperationException" />
+    ///     out of <c>Dictionary.TryInsert</c> or a <see cref="NullReferenceException" /> out of
+    ///     <c>ChangeDetector.DetectChanges</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Locking inside this class is not a substitute, which is why the declaration lives here rather
+    ///     than being worked around: a lock around each member still leaves the aggregation on one thread
+    ///     mutating entities while another thread's <c>Entry()</c> runs change detection over them. The
+    ///     fan-out itself has to stop, and only the runner can stop it (jasperfx#683).
+    /// </remarks>
+    public bool IsThreadSafe => false;
+
     public TId Identity(TDoc document)
     {
         var entityType = DbContext.Model.FindEntityType(typeof(TDoc));


### PR DESCRIPTION
Fixes #5266. Bumps JasperFx to **2.53.0** to pick up jasperfx#683 and adopts it.

## The bug

`AggregationRunner` applies every slice in a range through a fixed 10-wide block and hands each one the **same** `IProjectionStorage`. Marten's own document storage is built for that. The EF Core storage is not — it wraps a single `DbContext` per tenant/batch, and a `DbContext` is not thread-safe.

A multi-stream projection with custom grouping fans one event out into many slices, so up to ten of them concurrently call `Entry()` / `FindAsync` and mutate the same change tracker.

## Why it had to be fixed upstream

Locking inside `EfCoreProjectionStorage` does not close it. A lock around each member still leaves the aggregation on one thread mutating entities while another thread's `Entry()` runs change detection over them — which is precisely the reported `ChangeDetector` failure. The fan-out itself has to stop, and nothing reachable from inside the storage can stop it.

jasperfx#683 adds `IProjectionStorage.IsThreadSafe` (a default interface member, so it is additive) and routes slices inline when it is false. This PR is the adoption: `EfCoreProjectionStorage` returns `false`.

## On the test — the reporter's repro is not a regression test

Worth being explicit, because I nearly shipped it as one. The repro is a genuine data race and only *usually* failed. Run against the **unfixed** build here it **passed**, so on its own it demonstrates nothing.

The regression test asserts the observable consequence instead, which is deterministic: with the storage applied inline, no two slices can ever be inside `ApplyEventsAsync` at the same instant. The projection records a high-water mark of concurrent entries; twenty slices from one event against a 10-wide block, with a short delay so genuinely parallel slices overlap rather than merely interleave.

Against 2.52.0 without the seam that fails immediately:

```
System.AggregateException : One or more errors occurred.
  (Index was outside the bounds of the array.) ×20
```

— EF Core's internals being corrupted by concurrent access, the same class the reporter saw as `Dictionary.TryInsert` and `ChangeDetector.DetectChanges`.

One trap in the reporter's repro that is worth recording: it asserts with `session.Query<SearchProjection>()`, but the projection writes **through the DbContext** into `ef_search_projections` and Marten has no document storage for that type. That query reports zero however the rebuild went. The count here is read from the EF table.

## Suites

`Marten.EntityFrameworkCore.Tests` 45/0, `DaemonTests` 307/0 (the bump touches the runner), `EventSourcingTests` 1943/0, `CoreTests` at its known order-dependent baseline.