### PR TITLE
Let the DCB hstore tag index be built out of band (#5268)

### DIFF
--- a/docs/cSpell.json
+++ b/docs/cSpell.json
@@ -127,7 +127,8 @@
     "dedup",
     "unindexed",
     "SQLSTATE",
-    "SQLSTATEs"
+    "SQLSTATEs",
+    "unpartitioned"
   ],
   "ignoreRegExpList": [
     "\\((.*)\\)", // Markdown links

--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -379,6 +379,53 @@ Trade-offs:
 - The `mt_quick_append_events` Postgres function does not take per-tag-type arrays — Marten writes the inline hstore as a follow-up `UPDATE` after the event INSERT.
 - **Each tag type is single-valued per event.** An hstore is a map with unique keys, and Marten uses the registered tag's table-suffix as the key, so there is nowhere to put a second value of one tag type. Appending an event that carries two different values of the same tag type throws `MartenNotSupportedException` rather than silently keeping one of them — a dropped tag is not an error to a DCB query, it is simply absent from the answer, and that is the one failure a consistency boundary must not have. TagTables has no such restriction (see below). Cross-type merging (e.g. adding a `StudentId` tag to an event that already has a `RegionId` tag) works correctly in both modes — HStore uses Postgres' `hstore || hstore` concatenation to preserve the existing keys.
 
+### Enabling HStore on an existing store <Badge type="tip" text="9.29" />
+
+Switching an existing store to `DcbStorageMode.HStore` adds two things to `mt_events`. The `tags hstore`
+column is free — a nullable add is metadata-only. The GIN index over it is not: Marten emits a plain
+`CREATE INDEX`, which holds `ACCESS EXCLUSIVE` for the whole build. On a large event table that is a
+write outage rather than a migration.
+
+There is no flag that fixes this in general. `CREATE INDEX CONCURRENTLY` cannot run inside the
+transaction a migration uses, and under `UseTenantPartitionedEvents` PostgreSQL refuses it on a
+partitioned parent outright (`cannot create index on partitioned table ... concurrently`).
+
+So the index can be handed to the operator instead. Ignore it, and Marten leaves it out of the schema
+diff in **both** directions — it will neither create it nor treat one you built yourself as drift:
+
+```csharp
+opts.Events.DcbStorageMode = DcbStorageMode.HStore;
+
+// Marten adds the tags column, but leaves this index alone
+opts.Events.IgnoreIndex(EventGraph.HStoreTagIndexName);
+```
+
+Apply the schema as usual to get the column, then build the index out of band. On an unpartitioned
+event table:
+
+```sql
+CREATE INDEX CONCURRENTLY idx_mt_events_tags ON mt_events USING gin (tags);
+```
+
+On a tenant-partitioned one, PostgreSQL's supported sequence is three steps — the parent index is
+created invalid and flips to valid once every child is attached:
+
+```sql
+-- 1. metadata only; the parent index is left invalid
+CREATE INDEX idx_mt_events_tags ON ONLY mt_events USING gin (tags);
+
+-- 2. per partition, without blocking writes
+CREATE INDEX CONCURRENTLY idx_mt_events_tags_<partition> ON mt_events_<partition> USING gin (tags);
+
+-- 3. per partition; after the last one the parent is valid
+ALTER INDEX idx_mt_events_tags ATTACH PARTITION idx_mt_events_tags_<partition>;
+```
+
+::: warning
+Tag queries are correct without the index — they just fall back to a sequential scan, which on a large
+event table is slow enough to matter. Build it before you rely on DCB queries in production, not after.
+:::
+
 ### Choosing a Storage Mode
 
 The HStore mode trades native column types and small-table primary-key lookups for index-of-one and JOIN elimination. The right choice depends on your DCB query shape.

--- a/src/EventSourcingTests/Dcb/Bug_5268_hstore_tag_index_can_be_built_out_of_band.cs
+++ b/src/EventSourcingTests/Dcb/Bug_5268_hstore_tag_index_can_be_built_out_of_band.cs
@@ -1,0 +1,187 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace EventSourcingTests.Dcb;
+
+/// <summary>
+/// #5268. Turning <see cref="DcbStorageMode.HStore" /> on for an existing store adds two things to
+/// <c>mt_events</c>: a nullable <c>tags hstore</c> column, which is a metadata-only add, and a GIN index
+/// over it, which is not. Marten emits a plain <c>CREATE INDEX</c>, holding ACCESS EXCLUSIVE for the
+/// build — a write outage on a large event table rather than a migration. And under
+/// <c>UseTenantPartitionedEvents</c> a <c>CONCURRENTLY</c> flag would not help anyway, because
+/// PostgreSQL refuses <c>CREATE INDEX CONCURRENTLY</c> on a partitioned parent outright.
+/// <para>
+/// The escape hatch is <c>Events.IgnoreIndex</c>: the index drops out of the schema diff, so an operator
+/// can build it out of band — <c>CREATE INDEX ... ON ONLY</c> the parent, <c>CONCURRENTLY</c> per
+/// partition, then <c>ALTER INDEX ... ATTACH PARTITION</c> — without a maintenance window. These tests
+/// pin that it genuinely works, because it is the difference between "documented workaround" and
+/// "there is no non-blocking path".
+/// </para>
+/// </summary>
+[Collection("OneOffs")]
+public class Bug_5268_hstore_tag_index_can_be_built_out_of_band: OneOffConfigurationsContext
+{
+    private DocumentStore StoreFor(bool hstore, bool ignoreTagIndex)
+    {
+        return StoreOptions(opts =>
+        {
+            opts.Events.AddEventType<StudentEnrolled>();
+
+            if (hstore)
+            {
+                opts.Events.DcbStorageMode = DcbStorageMode.HStore;
+                opts.Events.RegisterTagType<StudentId>("student");
+            }
+
+            if (ignoreTagIndex)
+            {
+                opts.Events.IgnoreIndex(EventGraph.HStoreTagIndexName);
+            }
+        }, cleanAll: false);
+    }
+
+    private async Task<bool> IndexExistsAsync(string indexName)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select count(*) from pg_indexes where schemaname = @schema and indexname = @name";
+        cmd.Parameters.AddWithValue("schema", SchemaName);
+        cmd.Parameters.AddWithValue("name", indexName);
+
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync()) > 0;
+    }
+
+    private async Task<bool> ColumnExistsAsync(string column)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+                          select count(*) from information_schema.columns
+                          where table_schema = @schema and table_name = 'mt_events' and column_name = @column
+                          """;
+        cmd.Parameters.AddWithValue("schema", SchemaName);
+        cmd.Parameters.AddWithValue("column", column);
+
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync()) > 0;
+    }
+
+    /// <summary>
+    /// Drop the whole schema and seed a store with the event tables but WITHOUT hstore mode, so the
+    /// following migration is the real "turn hstore on for an existing store" case rather than a
+    /// first-time create.
+    /// </summary>
+    private async Task SeedNonHStoreStoreAsync()
+    {
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync(SchemaName);
+        }
+
+        var store = StoreFor(hstore: false, ignoreTagIndex: false);
+
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(Guid.NewGuid(), new StudentEnrolled("Alice", "Math"));
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task turning_hstore_on_adds_the_index_by_default()
+    {
+        // The baseline the escape hatch is measured against: without opting out, the migration adds it.
+        await SeedNonHStoreStoreAsync();
+
+        var store = StoreFor(hstore: true, ignoreTagIndex: false);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await ColumnExistsAsync("tags")).ShouldBeTrue();
+        (await IndexExistsAsync(EventGraph.HStoreTagIndexName)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task the_tag_index_can_be_left_to_the_operator()
+    {
+        await SeedNonHStoreStoreAsync();
+
+        var store = StoreFor(hstore: true, ignoreTagIndex: true);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // The column still arrives -- it is a nullable add, metadata only, and DCB cannot work without it.
+        (await ColumnExistsAsync("tags")).ShouldBeTrue();
+
+        // The expensive half did not.
+        (await IndexExistsAsync(EventGraph.HStoreTagIndexName)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task an_operator_built_index_is_left_alone_by_a_later_migration()
+    {
+        // The other half of the workaround, and the one that would make it useless if it failed: having
+        // built the index out of band, a subsequent schema application must not decide it is drift and
+        // try to recreate or drop it.
+        await SeedNonHStoreStoreAsync();
+
+        var store = StoreFor(hstore: true, ignoreTagIndex: true);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            // What the operator would run out of band. CONCURRENTLY is the point of doing it by hand;
+            // it is omitted here only because a test has no need to avoid the lock.
+            cmd.CommandText =
+                $"create index {EventGraph.HStoreTagIndexName} on {SchemaName}.mt_events using gin (tags)";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        (await IndexExistsAsync(EventGraph.HStoreTagIndexName)).ShouldBeTrue();
+
+        await Should.NotThrowAsync(() => store.Storage.ApplyAllConfiguredChangesToDatabaseAsync());
+
+        // Still there, and the store still reports itself as matching its configuration.
+        (await IndexExistsAsync(EventGraph.HStoreTagIndexName)).ShouldBeTrue();
+        await Should.NotThrowAsync(() => store.Storage.Database.AssertDatabaseMatchesConfigurationAsync());
+    }
+
+    [Fact]
+    public async Task tag_queries_still_work_once_the_index_is_built_out_of_band()
+    {
+        // Guard against a hollow victory: suppressing the index must not suppress the tagging itself.
+        await SeedNonHStoreStoreAsync();
+
+        var store = StoreFor(hstore: true, ignoreTagIndex: true);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var studentId = new StudentId(Guid.NewGuid());
+
+        await using (var session = store.LightweightSession())
+        {
+            var evt = session.Events.BuildEvent(new StudentEnrolled("Bob", "Math"));
+            evt.WithTag(studentId);
+            session.Events.StartStream(Guid.NewGuid(), evt);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.LightweightSession();
+        var found = await query.Events.QueryByTagsAsync(
+            new JasperFx.Events.Tags.EventTagQuery().Or<StudentId>(studentId));
+
+        found.Count.ShouldBe(1);
+    }
+}

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -44,6 +44,26 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     IDisposable, IAsyncDisposable,
     IAggregationSourceFactory<IQuerySession>, IDescribeMyself
 {
+    /// <summary>
+    ///     The name of the GIN index over the <c>tags</c> hstore column in
+    ///     <see cref="DcbStorageMode.HStore" /> mode. Pass it to <see cref="IgnoreIndex" /> to keep the
+    ///     index out of schema migrations and build it yourself.
+    /// </summary>
+    /// <remarks>
+    ///     #5268. Turning HStore mode on for an existing store adds two things to <c>mt_events</c>: the
+    ///     nullable <c>tags</c> column, which is a metadata-only add, and this index, which is not.
+    ///     Marten emits a plain <c>CREATE INDEX</c>, which holds ACCESS EXCLUSIVE for the whole build —
+    ///     on a large event table that is a write outage rather than a migration. And under
+    ///     <see cref="UseTenantPartitionedEvents" /> no flag would fix it: PostgreSQL refuses
+    ///     <c>CREATE INDEX CONCURRENTLY</c> on a partitioned parent at all, and the index has to be built
+    ///     per partition and attached.
+    ///     <para>
+    ///     Ignoring it takes it out of the schema diff in both directions, so Marten will neither create
+    ///     it nor treat an index you built yourself as drift.
+    ///     </para>
+    /// </remarks>
+    public const string HStoreTagIndexName = "idx_mt_events_tags";
+
     private readonly Cache<Type, string> _aggregateNameByType =
         new(type => type.IsGenericType ? type.ShortNameInCode() : type.Name.ToTableAlias());
 

--- a/src/Marten/Events/Schema/EventsTable.cs
+++ b/src/Marten/Events/Schema/EventsTable.cs
@@ -68,7 +68,7 @@ internal class EventsTable: Table
         if (events.DcbStorageMode == DcbStorageMode.HStore)
         {
             AddColumn("tags", "hstore").AllowNulls();
-            Indexes.Add(new IndexDefinition("idx_mt_events_tags")
+            Indexes.Add(new IndexDefinition(EventGraph.HStoreTagIndexName)
             {
                 Method = IndexMethod.gin,
                 Columns = ["tags"]


### PR DESCRIPTION
Addresses #5268 — the second of the two options in the issue, which is the one available without a Weasel release.

## The problem

Turning `DcbStorageMode.HStore` on for an existing store adds two things to `mt_events`. The nullable `tags` column is free. The GIN index over it is not: Marten emits a plain `CREATE INDEX`, holding `ACCESS EXCLUSIVE` for the whole build. On a large event table that is a write outage, not a migration — and the reporter runs this across several hundred shard databases.

## Why option 1 is not in this PR

`CREATE INDEX CONCURRENTLY` cannot run inside the transaction a migration uses, and under `UseTenantPartitionedEvents` PostgreSQL refuses it on a partitioned parent outright. The supported sequence is `CREATE INDEX ... ON ONLY` the parent, `CONCURRENTLY` per partition, then `ALTER INDEX ... ATTACH PARTITION`.

Weasel's `IndexDefinition` has `IsConcurrent`, but there is **no `ATTACH PARTITION` support for indexes anywhere in Weasel**. So Marten emitting that sequence itself needs a Weasel feature and a Weasel release first. Worth filing separately rather than holding this up.

## What this does

`Events.IgnoreIndex` already took the index out of the schema diff in **both** directions — Marten neither creates it nor treats an operator-built one as drift. What was missing was that the index name was a magic string and none of it was written down.

- `EventGraph.HStoreTagIndexName` puts the name on the public surface (`EventsTable` is internal, so the constant had to live somewhere an operator can actually reach).
- `docs/events/dcb.md` gains the procedure, for both the partitioned and unpartitioned cases.

```csharp
opts.Events.DcbStorageMode = DcbStorageMode.HStore;
opts.Events.IgnoreIndex(EventGraph.HStoreTagIndexName);
```

## Tests

Four, and the last two are the ones that matter:

- the default still adds the index — the baseline the opt-out is measured against;
- ignoring it suppresses the **index** while still adding the **column**, since DCB cannot work without the column and the column is free;
- an operator-built index survives a later `ApplyAllConfiguredChangesToDatabaseAsync` **and** `AssertDatabaseMatchesConfigurationAsync` — if a later migration decided it was drift the whole workaround would be worthless;
- tagging and tag queries still work throughout, so suppressing the index cannot quietly suppress the tags.

Each seeds a store *without* hstore first and then migrates, so this is the real "turn it on for an existing store" path rather than a first-time create.

## Note for @erdtsieck

You offered to pick this up and I have taken it instead — apologies for stepping on that; we wanted it in tonight's release. The half you would have had to write from scratch (option 1, the partitioned concurrent build) is still open and still yours if you want it; it needs the Weasel change first.

## Suites

`EventSourcingTests` 1957/0, `TenantPartitionedEventsTests` 243/0, docs lint clean.