### PR TITLE
Add failing tests for empty DCB write updating boundary

### DIFF
--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -286,6 +286,8 @@ Internally, `FetchForWritingByTags` records the captured version of every tag va
 
 Every save that appends a tagged event — boundary or otherwise — also queues a producer-side bump against the same row. That's what keeps a plain `session.Events.Append(streamId, taggedEvent)` from silently committing past an in-flight boundary fetch held by another session: the version moves on every commit, not only on boundary saves.
 
+A boundary that decides there is **nothing to append** is not a save at all as far as the side table is concerned. The check guards an append, so a session that fetches a boundary and then calls `SaveChangesAsync()` without appending anything leaves `mt_dcb_tag_version` exactly as it found it, and never throws `DcbConcurrencyException` — even if another session moved the boundary in the meantime. Two sessions can reach the same "nothing to do" conclusion about one boundary and both commit, and a no-op decision never invalidates a concurrent session that does have events to append. The boundary is released by that commit: to act on it afterwards, fetch it again.
+
 The side table grows with **distinct boundary-tag values**, not with event volume, and is never deleted automatically — the same `StudentId` or `CourseId` reuses its row across every save. Avoid using ephemeral or one-shot values as DCB tags if you want to keep the table compact.
 
 ## Checking Event Existence

--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -286,6 +286,8 @@ Internally, `FetchForWritingByTags` records the captured version of every tag va
 
 Every save that appends a tagged event — boundary or otherwise — also queues a producer-side bump against the same row. That's what keeps a plain `session.Events.Append(streamId, taggedEvent)` from silently committing past an in-flight boundary fetch held by another session: the version moves on every commit, not only on boundary saves.
 
+A save asserts each row once, however many boundaries named it. Fetching one query twice on a session, or fetching two queries that overlap on a tag value, is not a conflict with itself — the oldest captured version of the row is the one enforced, so every read the session made still has to be valid.
+
 A boundary that decides there is **nothing to append** is not a save at all as far as the side table is concerned. The check guards an append, so a session that fetches a boundary and then calls `SaveChangesAsync()` without appending anything leaves `mt_dcb_tag_version` exactly as it found it, and never throws `DcbConcurrencyException` — even if another session moved the boundary in the meantime. Two sessions can reach the same "nothing to do" conclusion about one boundary and both commit, and a no-op decision never invalidates a concurrent session that does have events to append. The boundary is released by that commit: to act on it afterwards, fetch it again.
 
 The side table grows with **distinct boundary-tag values**, not with event volume, and is never deleted automatically — the same `StudentId` or `CourseId` reuses its row across every save. Avoid using ephemeral or one-shot values as DCB tags if you want to keep the table compact.

--- a/src/EventSourcingTests/Dcb/Bug_5280_repeated_boundary_fetch_tests.cs
+++ b/src/EventSourcingTests/Dcb/Bug_5280_repeated_boundary_fetch_tests.cs
@@ -1,0 +1,114 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Dcb;
+
+// #5280: a save asserts each mt_dcb_tag_version row it captured exactly once. Reading one row
+// through two boundaries -- the same query fetched twice, or two queries that overlap on a tag --
+// used to queue two assertions carrying the same captured version, and the first one's bump made the
+// second one's `where version = $captured` miss. The session reported a concurrency conflict against
+// itself.
+[Collection("OneOffs")]
+public class Bug_5280_repeated_boundary_fetch_tests: OneOffConfigurationsContext
+{
+    private void ConfigureStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.AddEventType<StudentGraded>();
+
+            opts.Events.RegisterTagType<StudentId>("student");
+            opts.Events.RegisterTagType<CourseId>("course");
+        });
+    }
+
+    [Fact]
+    public async Task the_same_boundary_fetched_twice_can_still_append()
+    {
+        ConfigureStore();
+        var studentId = new StudentId(Guid.NewGuid());
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        await using var session = theStore.LightweightSession();
+
+        await session.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+        var boundary = await session.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+        boundary.AppendOne(new StudentGraded(studentId, new CourseId(Guid.NewGuid()), 95));
+
+        await Should.NotThrowAsync(() => session.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task two_boundaries_overlapping_on_one_tag_can_still_append()
+    {
+        ConfigureStore();
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        await using var session = theStore.LightweightSession();
+
+        // Both queries name the student row; only the second names the course row.
+        await session.Events.FetchForWritingByTags<StudentCourseEnrollment>(
+            new EventTagQuery().Or<StudentId>(studentId));
+        var boundary = await session.Events.FetchForWritingByTags<StudentCourseEnrollment>(
+            new EventTagQuery().Or<StudentId>(studentId).Or<CourseId>(courseId));
+        boundary.AppendOne(new StudentGraded(studentId, courseId, 95));
+
+        await Should.NotThrowAsync(() => session.SaveChangesAsync());
+    }
+
+    // Collapsing the duplicate must not collapse the check itself.
+    [Fact]
+    public async Task a_twice_fetched_boundary_is_still_checked_against_a_concurrent_append()
+    {
+        ConfigureStore();
+        var studentId = new StudentId(Guid.NewGuid());
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+
+        await using var session1 = theStore.LightweightSession();
+        await session1.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+        var boundary1 = await session1.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+
+        await using (var session2 = theStore.LightweightSession())
+        {
+            var boundary2 = await session2.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+            boundary2.AppendOne(new StudentGraded(studentId, new CourseId(Guid.NewGuid()), 60));
+            await session2.SaveChangesAsync();
+        }
+
+        boundary1.AppendOne(new StudentGraded(studentId, new CourseId(Guid.NewGuid()), 95));
+
+        var ex = await Should.ThrowAsync<DcbConcurrencyException>(() => session1.SaveChangesAsync());
+        ex.Query.ShouldBe(query);
+    }
+
+    // The strictest of the captured versions wins: the first read is the one the caller may have
+    // reasoned from, so a boundary that moved between two fetches is still a conflict.
+    [Fact]
+    public async Task the_oldest_capture_of_a_row_is_the_one_enforced()
+    {
+        ConfigureStore();
+        var studentId = new StudentId(Guid.NewGuid());
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+
+        await using var session1 = theStore.LightweightSession();
+        await session1.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+
+        // Another session moves the boundary in between session1's two reads
+        await using (var session2 = theStore.LightweightSession())
+        {
+            var boundary2 = await session2.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+            boundary2.AppendOne(new StudentGraded(studentId, new CourseId(Guid.NewGuid()), 60));
+            await session2.SaveChangesAsync();
+        }
+
+        var boundary1 = await session1.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+        boundary1.AppendOne(new StudentGraded(studentId, new CourseId(Guid.NewGuid()), 95));
+
+        await Should.ThrowAsync<DcbConcurrencyException>(() => session1.SaveChangesAsync());
+    }
+}

--- a/src/EventSourcingTests/Dcb/dcb_noop_boundary_tag_version_tests.cs
+++ b/src/EventSourcingTests/Dcb/dcb_noop_boundary_tag_version_tests.cs
@@ -1,0 +1,59 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events.Tags;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Dcb;
+
+// A session is allowed to fetch a DCB boundary, decide there is nothing to append, and save.
+// Saving that decision should leave the mt_dcb_tag_version rows the query touched exactly as
+// captured, so it neither conflicts with another session making the same no-op decision nor
+// invalidates a concurrent session that does have events to append.
+[Collection("OneOffs")]
+public class dcb_noop_boundary_tag_version_tests: OneOffConfigurationsContext
+{
+    private void ConfigureStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.AddEventType<StudentGraded>();
+
+            opts.Events.RegisterTagType<StudentId>("student");
+        });
+    }
+
+    [Fact]
+    public async Task two_sessions_that_append_nothing_do_not_conflict()
+    {
+        ConfigureStore();
+        var query = new EventTagQuery().Or<StudentId>(new StudentId(Guid.NewGuid()));
+        await using var session1 = theStore.LightweightSession();
+        await using var session2 = theStore.LightweightSession();
+        await session1.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+        await session2.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+
+        await session2.SaveChangesAsync();
+
+        await Should.NotThrowAsync(() => session1.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task a_session_that_appends_nothing_does_not_invalidate_a_concurrent_append()
+    {
+        ConfigureStore();
+        var studentId = new StudentId(Guid.NewGuid());
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        await using var session1 = theStore.LightweightSession();
+        await using var session2 = theStore.LightweightSession();
+        var boundary = await session1.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+        await session2.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+        boundary.AppendOne(new StudentGraded(studentId, new CourseId(Guid.NewGuid()), 95));
+
+        await session2.SaveChangesAsync();
+
+        await Should.NotThrowAsync(() => session1.SaveChangesAsync());
+    }
+}

--- a/src/EventSourcingTests/Dcb/dcb_noop_boundary_tag_version_tests.cs
+++ b/src/EventSourcingTests/Dcb/dcb_noop_boundary_tag_version_tests.cs
@@ -1,8 +1,10 @@
 #nullable enable
 using System;
 using System.Threading.Tasks;
+using JasperFx.Events;
 using JasperFx.Events.Tags;
 using Marten.Testing.Harness;
+using Npgsql;
 using Shouldly;
 using Xunit;
 
@@ -55,5 +57,107 @@ public class dcb_noop_boundary_tag_version_tests: OneOffConfigurationsContext
         await session2.SaveChangesAsync();
 
         await Should.NotThrowAsync(() => session1.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task a_session_that_appends_nothing_leaves_the_tag_version_row_alone()
+    {
+        ConfigureStore();
+        var studentId = new StudentId(Guid.NewGuid());
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+
+        // Seed the row so this covers the ON CONFLICT branch as well as the missing-row one
+        await using (var seed = theStore.LightweightSession())
+        {
+            var boundary = await seed.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+            boundary.AppendOne(new StudentGraded(studentId, new CourseId(Guid.NewGuid()), 70));
+            await seed.SaveChangesAsync();
+        }
+
+        var before = await CurrentTagVersionAsync(studentId);
+        before.ShouldNotBeNull();
+
+        await using var session = theStore.LightweightSession();
+        await session.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+        await session.SaveChangesAsync();
+
+        (await CurrentTagVersionAsync(studentId)).ShouldBe(before);
+    }
+
+    // A no-op decision writes nothing, so there is nothing for the boundary to guard -- a concurrent
+    // append that moved the boundary underneath it is not a conflict, it is simply news the session
+    // never acted on.
+    [Fact]
+    public async Task a_session_that_appends_nothing_does_not_throw_when_the_boundary_moved()
+    {
+        ConfigureStore();
+        var studentId = new StudentId(Guid.NewGuid());
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        await using var session1 = theStore.LightweightSession();
+        await session1.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+
+        await using (var session2 = theStore.LightweightSession())
+        {
+            var boundary2 = await session2.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+            boundary2.AppendOne(new StudentGraded(studentId, new CourseId(Guid.NewGuid()), 88));
+            await session2.SaveChangesAsync();
+        }
+
+        await Should.NotThrowAsync(() => session1.SaveChangesAsync());
+    }
+
+    // The retry idiom: a no-op save, then a fresh boundary on the same session. The first read must
+    // not still be pending, or its captured version would collide with the second one's.
+    [Fact]
+    public async Task a_boundary_re_fetched_after_a_no_op_save_can_append()
+    {
+        ConfigureStore();
+        var studentId = new StudentId(Guid.NewGuid());
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        await using var session = theStore.LightweightSession();
+
+        await session.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+        await session.SaveChangesAsync();
+
+        var boundary = await session.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+        boundary.AppendOne(new StudentGraded(studentId, new CourseId(Guid.NewGuid()), 91));
+
+        await Should.NotThrowAsync(() => session.SaveChangesAsync());
+    }
+
+    // The other half of the rule: a session that DOES append is still held to the boundary it read.
+    [Fact]
+    public async Task a_session_that_appends_is_still_checked_against_the_boundary()
+    {
+        ConfigureStore();
+        var studentId = new StudentId(Guid.NewGuid());
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        await using var session1 = theStore.LightweightSession();
+        var boundary1 = await session1.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+
+        await using (var session2 = theStore.LightweightSession())
+        {
+            var boundary2 = await session2.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+            boundary2.AppendOne(new StudentGraded(studentId, new CourseId(Guid.NewGuid()), 88));
+            await session2.SaveChangesAsync();
+        }
+
+        boundary1.AppendOne(new StudentGraded(studentId, new CourseId(Guid.NewGuid()), 95));
+
+        await Should.ThrowAsync<DcbConcurrencyException>(() => session1.SaveChangesAsync());
+    }
+
+    private async Task<long?> CurrentTagVersionAsync(StudentId studentId)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            $"select version from {SchemaName}.mt_dcb_tag_version where tag_table = 'student' and tag_value = @value";
+        cmd.Parameters.AddWithValue("value", studentId.Value.ToString());
+
+        var raw = await cmd.ExecuteScalarAsync();
+        return raw == null || raw == DBNull.Value ? null : Convert.ToInt64(raw);
     }
 }

--- a/src/Marten/Events/Dcb/DcbTagVersionAssertion.cs
+++ b/src/Marten/Events/Dcb/DcbTagVersionAssertion.cs
@@ -23,7 +23,14 @@ namespace Marten.Events.Dcb;
 /// </param>
 /// <param name="TagValue">Canonical string form of the tag value (see <see cref="TagValueStringifier"/>).</param>
 /// <param name="CapturedVersion">The version observed at fetch time. The save's UPDATE WHERE version = $captured is the optimistic check.</param>
-internal readonly record struct DcbTagVersionEntry(string TagTable, string TagValue, long CapturedVersion);
+/// <param name="Query">The boundary query this row was captured for — carried per row rather than per assertion so a merged assertion can still name the boundary that failed. See #5280.</param>
+/// <param name="LastSeenSequence">The event sequence <paramref name="Query"/> had read up to, for the exception message.</param>
+internal readonly record struct DcbTagVersionEntry(
+    string TagTable,
+    string TagValue,
+    long CapturedVersion,
+    EventTagQuery Query,
+    long LastSeenSequence);
 
 /// <summary>
 /// Storage operation that enforces the DCB tag boundary by bumping the
@@ -38,35 +45,71 @@ internal readonly record struct DcbTagVersionEntry(string TagTable, string TagVa
 /// tuples are sorted by (tag_table, tag_value) before SQL is built so two
 /// concurrent appenders touching the same tag set acquire locks in identical
 /// order — no risk of deadlock from cross-locking.
+///
+/// #5280: one save carries ONE of these, covering every boundary the session
+/// read. A row named by two boundaries — the same query fetched twice, or two
+/// overlapping queries — appears once. Two assertions over one row would each
+/// carry the same captured version, and the first one's bump would make the
+/// second one's <c>where version = $captured</c> miss: a session reporting a
+/// concurrency conflict against itself.
 /// </remarks>
 internal class DcbTagVersionAssertion: IStorageOperation
 {
     private readonly EventGraph _events;
-    private readonly EventTagQuery _query;
-    private readonly long _lastSeenSequence;
     private readonly IReadOnlyList<DcbTagVersionEntry> _orderedEntries;
 
     public DcbTagVersionAssertion(
         EventGraph events,
-        EventTagQuery query,
-        long lastSeenSequence,
         IReadOnlyList<DcbTagVersionEntry> capturedEntries)
     {
         _events = events;
-        _query = query;
-        _lastSeenSequence = lastSeenSequence;
 
         // Sort once, here — both ConfigureCommand and PostprocessAsync iterate
         // in the same order, and the deterministic order is what keeps two
         // concurrent appenders touching the same tag rows from deadlocking.
+        // Sorting the merged set is also what makes that guarantee hold across
+        // boundaries: two sessions holding the same pair of boundaries in
+        // opposite fetch order would otherwise take the row locks in opposite
+        // order too.
         var sorted = new DcbTagVersionEntry[capturedEntries.Count];
         for (var i = 0; i < capturedEntries.Count; i++) sorted[i] = capturedEntries[i];
         Array.Sort(sorted, static (a, b) =>
         {
             var byTable = string.CompareOrdinal(a.TagTable, b.TagTable);
-            return byTable != 0 ? byTable : string.CompareOrdinal(a.TagValue, b.TagValue);
+            if (byTable != 0) return byTable;
+
+            var byValue = string.CompareOrdinal(a.TagValue, b.TagValue);
+            if (byValue != 0) return byValue;
+
+            // Oldest capture first, so collapsing a duplicate run below keeps the
+            // strictest check of the row: every read the session made has to still
+            // be valid, not just the most recent one.
+            return a.CapturedVersion.CompareTo(b.CapturedVersion);
         });
-        _orderedEntries = sorted;
+
+        _orderedEntries = collapseDuplicateRows(sorted);
+    }
+
+    // Duplicates are adjacent after the sort, so one pass over the run keeps the
+    // first (oldest captured version) of each (tag_table, tag_value).
+    private static DcbTagVersionEntry[] collapseDuplicateRows(DcbTagVersionEntry[] sorted)
+    {
+        if (sorted.Length < 2) return sorted;
+
+        var kept = 1;
+        for (var i = 1; i < sorted.Length; i++)
+        {
+            var previous = sorted[kept - 1];
+            if (sorted[i].TagTable == previous.TagTable && sorted[i].TagValue == previous.TagValue) continue;
+
+            sorted[kept++] = sorted[i];
+        }
+
+        if (kept == sorted.Length) return sorted;
+
+        var collapsed = new DcbTagVersionEntry[kept];
+        Array.Copy(sorted, collapsed, kept);
+        return collapsed;
     }
 
     public void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
@@ -115,7 +158,7 @@ internal class DcbTagVersionAssertion: IStorageOperation
 
     public async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
     {
-        var conflictDetected = false;
+        DcbTagVersionEntry? conflicted = null;
 
         for (var i = 0; i < _orderedEntries.Count; i++)
         {
@@ -129,16 +172,19 @@ internal class DcbTagVersionAssertion: IStorageOperation
             var hasRow = await reader.ReadAsync(token).ConfigureAwait(false);
             if (!hasRow)
             {
-                conflictDetected = true;
+                // First loser wins the exception — the row carries the boundary
+                // query that captured it, so the message names a query the caller
+                // actually made even when the save spans several boundaries.
+                conflicted ??= _orderedEntries[i];
                 // Keep iterating so we consume the remaining result sets — the
                 // batch protocol requires every statement's result set to be
                 // walked before the next operation can read its own.
             }
         }
 
-        if (conflictDetected)
+        if (conflicted.HasValue)
         {
-            exceptions.Add(new DcbConcurrencyException(_query, _lastSeenSequence));
+            exceptions.Add(new DcbConcurrencyException(conflicted.Value.Query, conflicted.Value.LastSeenSequence));
         }
     }
 

--- a/src/Marten/Events/Dcb/FetchForWritingByTagsHandler.cs
+++ b/src/Marten/Events/Dcb/FetchForWritingByTagsHandler.cs
@@ -252,8 +252,12 @@ internal class FetchForWritingByTagsHandler<T>: IQueryHandler<IEventBoundary<T>>
             aggregate = await aggregator.BuildAsync(events, docSession, default, token).ConfigureAwait(false);
         }
 
+        // #5276: registered, not queued. The boundary condition guards an append, so it only belongs
+        // in the unit of work if this session actually appends something -- see
+        // DocumentSessionBase.QueuePendingDcbBoundaryAssertions, which drains this at
+        // ProcessEventsAsync time, ahead of the producer-side bumps.
         var assertion = new DcbTagVersionAssertion(_store.Events, _query, lastSeenSequence, capturedVersions);
-        docSession.QueueOperation(assertion);
+        docSession.RegisterDcbBoundaryAssertion(assertion);
 
         return new EventBoundary<T>(docSession, _store.Events, aggregate, events, lastSeenSequence);
     }

--- a/src/Marten/Events/Dcb/FetchForWritingByTagsHandler.cs
+++ b/src/Marten/Events/Dcb/FetchForWritingByTagsHandler.cs
@@ -237,7 +237,7 @@ internal class FetchForWritingByTagsHandler<T>: IQueryHandler<IEventBoundary<T>>
         // necessarily references at least one tag).
         await reader.NextResultAsync(token).ConfigureAwait(false);
 
-        var capturedVersions = await readCapturedVersions(reader, token).ConfigureAwait(false);
+        var capturedVersions = await readCapturedVersions(reader, lastSeenSequence, token).ConfigureAwait(false);
 
         T? aggregate = default;
         if (events.Count > 0)
@@ -252,18 +252,19 @@ internal class FetchForWritingByTagsHandler<T>: IQueryHandler<IEventBoundary<T>>
             aggregate = await aggregator.BuildAsync(events, docSession, default, token).ConfigureAwait(false);
         }
 
-        // #5276: registered, not queued. The boundary condition guards an append, so it only belongs
-        // in the unit of work if this session actually appends something -- see
+        // #5276/#5280: the captured rows are handed to the session, not turned into an operation
+        // here. The boundary condition guards an append, so it only belongs in the unit of work if
+        // this session appends something -- and every boundary the session reads folds into a single
+        // assertion so one row is never asserted twice. See
         // DocumentSessionBase.QueuePendingDcbBoundaryAssertions, which drains this at
         // ProcessEventsAsync time, ahead of the producer-side bumps.
-        var assertion = new DcbTagVersionAssertion(_store.Events, _query, lastSeenSequence, capturedVersions);
-        docSession.RegisterDcbBoundaryAssertion(assertion);
+        docSession.CaptureDcbBoundary(capturedVersions);
 
         return new EventBoundary<T>(docSession, _store.Events, aggregate, events, lastSeenSequence);
     }
 
     private async Task<IReadOnlyList<DcbTagVersionEntry>> readCapturedVersions(
-        DbDataReader reader, CancellationToken token)
+        DbDataReader reader, long lastSeenSequence, CancellationToken token)
     {
         // SELECT returns only the rows that exist. A missing row means no prior
         // save has touched this tag boundary yet — captured version = 0, and the
@@ -284,7 +285,11 @@ internal class FetchForWritingByTagsHandler<T>: IQueryHandler<IEventBoundary<T>>
         {
             var key = (targets[i].TagTable, targets[i].TagValue);
             byKey.TryGetValue(key, out var version);   // missing → version = 0
-            entries[i] = new DcbTagVersionEntry(targets[i].TagTable, targets[i].TagValue, version);
+
+            // #5280: each row carries the query that captured it, so a merged assertion covering
+            // several boundaries still reports the one that actually lost.
+            entries[i] = new DcbTagVersionEntry(targets[i].TagTable, targets[i].TagValue, version,
+                _query, lastSeenSequence);
         }
 
         return entries;

--- a/src/Marten/Events/EventGraph.Processing.cs
+++ b/src/Marten/Events/EventGraph.Processing.cs
@@ -50,6 +50,13 @@ public partial class EventGraph
             await session.Database.EnsureStorageExistsAsync(typeof(IEvent), token).ConfigureAwait(false);
         }
 
+        // #5276: hand any DCB boundary the session captured to the unit of work, but only if this
+        // save actually appends events -- the boundary is a condition on an append, and a save that
+        // appends nothing has to leave mt_dcb_tag_version exactly as it found it. Done here rather
+        // than at fetch time, and *before* the appender, so the assertion still runs ahead of the
+        // producer-side bumps it would otherwise read as a conflict.
+        session.QueuePendingDcbBoundaryAssertions();
+
         await EventAppender.ProcessEventsAsync(this, session, _inlineProjections.Value, token).ConfigureAwait(false);
 
         if (UseListenNotifyForEventAppends)

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.Dcb.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.Dcb.cs
@@ -1,36 +1,40 @@
 #nullable enable
 using System.Collections.Generic;
+using Marten.Events.Dcb;
 
 namespace Marten.Internal.Sessions;
 
 public abstract partial class DocumentSessionBase
 {
-    // #5276: boundary assertions captured by FetchForWritingByTags are held here rather than being
-    // queued straight into the unit of work. The DCB boundary is a condition on an *append* -- a
-    // session that reads a boundary, decides there is nothing to do, and saves has written nothing
-    // for the condition to guard, so bumping mt_dcb_tag_version for it would both fail a second
-    // no-op save of the same boundary and invalidate a concurrent session that does have events.
+    // #5276: the rows FetchForWritingByTags captured are held here rather than queued into the unit
+    // of work as they are read. The DCB boundary is a condition on an *append* -- a session that
+    // reads a boundary, decides there is nothing to do, and saves has written nothing for the
+    // condition to guard, so bumping mt_dcb_tag_version for it would both fail a second no-op save
+    // of the same boundary and invalidate a concurrent session that does have events.
     //
-    // EventGraph.ProcessEventsAsync drains this list into the unit of work only when the save
-    // actually appends events, and it drains it *before* the appender queues its own producer-side
-    // DcbTagVersionBumpOperations so the assertion still reads the pre-bump version.
-    private List<Weasel.Storage.IStorageOperation>? _pendingDcbAssertions;
+    // #5280: holding the rows rather than one operation per fetch is also what lets a save that read
+    // the same row through two boundaries assert it once. Two assertions over one row carry the same
+    // captured version, and the first one's bump makes the second one's WHERE miss.
+    private List<DcbTagVersionEntry>? _capturedDcbRows;
 
-    internal void RegisterDcbBoundaryAssertion(Weasel.Storage.IStorageOperation assertion)
+    internal void CaptureDcbBoundary(IReadOnlyList<DcbTagVersionEntry> rows)
     {
-        (_pendingDcbAssertions ??= new List<Weasel.Storage.IStorageOperation>()).Add(assertion);
+        _capturedDcbRows ??= new List<DcbTagVersionEntry>(rows.Count);
+        for (var i = 0; i < rows.Count; i++)
+        {
+            _capturedDcbRows.Add(rows[i]);
+        }
     }
 
     /// <summary>
-    /// Move every boundary assertion captured since the last commit into the unit of work, provided
-    /// this save has events to append. Called by
-    /// <see cref="Marten.Events.EventGraph.ProcessEventsAsync" />.
+    /// Queue the single assertion covering every boundary this session has read, provided the save
+    /// has events to append. Called by <see cref="Marten.Events.EventGraph.ProcessEventsAsync" />.
     /// </summary>
     internal void QueuePendingDcbBoundaryAssertions()
     {
         // The overwhelming majority of saves never touch a DCB boundary, so this returns before
         // looking at the streams at all.
-        if (_pendingDcbAssertions is not { Count: > 0 }) return;
+        if (_capturedDcbRows is not { Count: > 0 }) return;
 
         var appendsEvents = false;
         foreach (var stream in _workTracker.Streams)
@@ -42,22 +46,18 @@ public abstract partial class DocumentSessionBase
 
         if (!appendsEvents) return;
 
-        foreach (var assertion in _pendingDcbAssertions)
-        {
-            QueueOperation(assertion);
-        }
-
-        _pendingDcbAssertions.Clear();
+        // The assertion sorts and de-duplicates the rows itself -- see #5280.
+        QueueOperation(new DcbTagVersionAssertion(Options.EventGraph, _capturedDcbRows.ToArray()));
+        _capturedDcbRows.Clear();
     }
 
     /// <summary>
     /// Drop any boundary the session read but never appended to. A commit ends the unit of work the
     /// boundary was read for, so it must not outlive it: the retry idiom re-fetches the boundary
-    /// after a no-op save, and two assertions over one tag row with the same captured version would
-    /// have the second one fail against the first one's bump.
+    /// after a no-op save, and the re-read row would otherwise be asserted twice.
     /// </summary>
     internal void ForgetPendingDcbBoundaryAssertions()
     {
-        _pendingDcbAssertions?.Clear();
+        _capturedDcbRows?.Clear();
     }
 }

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.Dcb.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.Dcb.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace Marten.Internal.Sessions;
+
+public abstract partial class DocumentSessionBase
+{
+    // #5276: boundary assertions captured by FetchForWritingByTags are held here rather than being
+    // queued straight into the unit of work. The DCB boundary is a condition on an *append* -- a
+    // session that reads a boundary, decides there is nothing to do, and saves has written nothing
+    // for the condition to guard, so bumping mt_dcb_tag_version for it would both fail a second
+    // no-op save of the same boundary and invalidate a concurrent session that does have events.
+    //
+    // EventGraph.ProcessEventsAsync drains this list into the unit of work only when the save
+    // actually appends events, and it drains it *before* the appender queues its own producer-side
+    // DcbTagVersionBumpOperations so the assertion still reads the pre-bump version.
+    private List<Weasel.Storage.IStorageOperation>? _pendingDcbAssertions;
+
+    internal void RegisterDcbBoundaryAssertion(Weasel.Storage.IStorageOperation assertion)
+    {
+        (_pendingDcbAssertions ??= new List<Weasel.Storage.IStorageOperation>()).Add(assertion);
+    }
+
+    /// <summary>
+    /// Move every boundary assertion captured since the last commit into the unit of work, provided
+    /// this save has events to append. Called by
+    /// <see cref="Marten.Events.EventGraph.ProcessEventsAsync" />.
+    /// </summary>
+    internal void QueuePendingDcbBoundaryAssertions()
+    {
+        // The overwhelming majority of saves never touch a DCB boundary, so this returns before
+        // looking at the streams at all.
+        if (_pendingDcbAssertions is not { Count: > 0 }) return;
+
+        var appendsEvents = false;
+        foreach (var stream in _workTracker.Streams)
+        {
+            if (stream.Events.Count == 0) continue;
+            appendsEvents = true;
+            break;
+        }
+
+        if (!appendsEvents) return;
+
+        foreach (var assertion in _pendingDcbAssertions)
+        {
+            QueueOperation(assertion);
+        }
+
+        _pendingDcbAssertions.Clear();
+    }
+
+    /// <summary>
+    /// Drop any boundary the session read but never appended to. A commit ends the unit of work the
+    /// boundary was read for, so it must not outlive it: the retry idiom re-fetches the boundary
+    /// after a no-op save, and two assertions over one tag row with the same captured version would
+    /// have the second one fail against the first one's bump.
+    /// </summary>
+    internal void ForgetPendingDcbBoundaryAssertions()
+    {
+        _pendingDcbAssertions?.Clear();
+    }
+}

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
@@ -24,6 +24,10 @@ public abstract partial class DocumentSessionBase
         processChangeTrackers();
         if (!_workTracker.HasOutstandingWork())
         {
+            // #5276: a session whose only work was reading a DCB boundary lands here. Nothing is
+            // written, so nothing enforces the boundary -- and the read does not carry over to the
+            // next unit of work either.
+            ForgetPendingDcbBoundaryAssertions();
             return;
         }
 
@@ -78,6 +82,9 @@ public abstract partial class DocumentSessionBase
 
         // Need to clear the unit of work here
         _workTracker.Reset();
+
+        // #5276: and with it any boundary this save read but never appended to.
+        ForgetPendingDcbBoundaryAssertions();
     }
 
     private IMessageBatch? _messageBatch;


### PR DESCRIPTION
A session that fetches a boundary decides it has nothing to append and saves still bumps the mt_dcb_tag_version rows. This invalidates a concurrent session that does have something to append.

This PR only contains failing tests and not a fix so CI is expected to be red.