### PR TITLE
Fix enum value-collection filters: MemoryExtensions.Contains comparer overload and bare-parameter Any()

### DIFF
--- a/src/LinqTests/Bugs/Bug_5278_enum_value_collection_filters.cs
+++ b/src/LinqTests/Bugs/Bug_5278_enum_value_collection_filters.cs
@@ -1,0 +1,112 @@
+// `using System;` is load-bearing for this repro: it brings the
+// System.MemoryExtensions.Contains(span, value, comparer) extension into scope, which
+// wins overload resolution over Enumerable.Contains for enum arrays (enums do not
+// implement IEquatable<T>). Real applications get it implicitly via <ImplicitUsings>.
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core;
+
+namespace LinqTests.Bugs;
+
+// Companion to Bug 2946: that fix covered Contains(Colors.Blue) only when the
+// expression binds to Enumerable.Contains. With `using System;`, enum arrays bind to
+// MemoryExtensions.Contains(..., comparer: null), so the old parser read the null
+// comparer as the search value and generated {"Colors":[null]}. Any(c => c == value)
+// crashed the parser with IndexOutOfRangeException.
+public class Bug_5278_enum_value_collection_filters : BugIntegrationContext
+{
+    public record MyDoc(string Id, Colors[] Colors);
+
+    private async Task seedAsync()
+    {
+        var doc1 = new MyDoc("one", [Colors.Blue, Colors.Green]);
+        var doc2 = new MyDoc("two", [Colors.Blue, Colors.Red]);
+        var doc3 = new MyDoc("three", [Colors.Orange, Colors.Yellow]);
+
+        theSession.Store(doc1, doc2, doc3);
+        await theSession.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task contains_with_literal_as_int_when_system_namespace_is_in_scope()
+    {
+        StoreOptions(opts => opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger));
+        await seedAsync();
+
+        var results = await theSession.Query<MyDoc>()
+            .Where(x => x.Colors.Contains(Colors.Blue))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        results.ShouldBe(new string[] { "one", "two" });
+    }
+
+    [Fact]
+    public async Task contains_with_captured_variable_as_int()
+    {
+        StoreOptions(opts => opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger));
+        await seedAsync();
+
+        var color = Colors.Blue;
+        var results = await theSession.Query<MyDoc>()
+            .Where(x => x.Colors.Contains(color))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        results.ShouldBe(new string[] { "one", "two" });
+    }
+
+    [Fact]
+    public async Task contains_with_captured_variable_as_string()
+    {
+        StoreOptions(opts => opts.UseSystemTextJsonForSerialization(EnumStorage.AsString));
+        await seedAsync();
+
+        var color = Colors.Blue;
+        var results = await theSession.Query<MyDoc>()
+            .Where(x => x.Colors.Contains(color))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        results.ShouldBe(new string[] { "one", "two" });
+    }
+
+    [Fact]
+    public async Task any_with_equality_on_literal_as_int()
+    {
+        StoreOptions(opts => opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger));
+        await seedAsync();
+
+        var results = await theSession.Query<MyDoc>()
+            .Where(x => x.Colors.Any(c => c == Colors.Blue))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        results.ShouldBe(new string[] { "one", "two" });
+    }
+
+    [Fact]
+    public async Task any_with_equality_on_captured_variable_as_int()
+    {
+        StoreOptions(opts => opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger));
+        await seedAsync();
+
+        var color = Colors.Blue;
+        var results = await theSession.Query<MyDoc>()
+            .Where(x => x.Colors.Any(c => c == color))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        results.ShouldBe(new string[] { "one", "two" });
+    }
+}

--- a/src/Marten/Linq/Members/ChildCollectionMember.cs
+++ b/src/Marten/Linq/Members/ChildCollectionMember.cs
@@ -238,7 +238,7 @@ public class ChildCollectionMember: QueryableMember, ICollectionMember, IQueryab
         // containment semantics: an element matches when it contains every serialized
         // member of the argument, so documents written with extra/evolved properties
         // still match
-        var constant = body.Arguments.Last().ReduceToConstant();
+        var constant = body.ContainsValueArgument().ReduceToConstant();
         if (constant.Value() != null)
         {
             return ContainmentWhereFilter.ForValue(this, constant.Value()!, options.Serializer());

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryKeysMember.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryKeysMember.cs
@@ -106,7 +106,7 @@ internal class DictionaryKeysMember: QueryableMember, ICollectionMember, IValueC
 
     public ISqlFragment ParseWhereForContains(MethodCallExpression body, IReadOnlyStoreOptions options)
     {
-        var value = body.Arguments.Last().ReduceToConstant();
+        var value = body.ContainsValueArgument().ReduceToConstant();
         return new DictionaryContainsKeyFilter(_parent, options.Serializer(), value);
     }
 

--- a/src/Marten/Linq/Members/DuplicatedArrayField.cs
+++ b/src/Marten/Linq/Members/DuplicatedArrayField.cs
@@ -110,7 +110,7 @@ internal class DuplicatedArrayField: DuplicatedField, ICollectionMember, IQuerya
 
     public ISqlFragment ParseWhereForContains(MethodCallExpression body, IReadOnlyStoreOptions options)
     {
-        return new WhereFragment($"? = ANY({TypedLocator})", body.Arguments.Last().Value());
+        return new WhereFragment($"? = ANY({TypedLocator})", body.ContainsValueArgument().Value());
     }
 
     public IQueryableMember FindMember(MemberInfo member)

--- a/src/Marten/Linq/Members/ValueCollections/ValueCollectionMember.cs
+++ b/src/Marten/Linq/Members/ValueCollections/ValueCollectionMember.cs
@@ -150,7 +150,7 @@ public class ValueCollectionMember: QueryableMember, ICollectionMember, IValueCo
 
     public ISqlFragment ParseWhereForContains(MethodCallExpression body, IReadOnlyStoreOptions options)
     {
-        var value = body.Arguments.Last().ReduceToConstant();
+        var value = body.ContainsValueArgument().ReduceToConstant();
 
         return new ContainmentWhereFilter(this, value, options.Serializer());
     }

--- a/src/Marten/Linq/Parsing/LinqInternalExtensions.cs
+++ b/src/Marten/Linq/Parsing/LinqInternalExtensions.cs
@@ -164,6 +164,19 @@ public static class LinqInternalExtensions
 
     public static IQueryableMember MemberFor(this IHasChildrenMembers collection, MemberInfo[] members)
     {
+        if (members.Length == 0)
+        {
+            // A bare lambda parameter over a value collection, e.g. x.Colors.Any(c => c == value),
+            // has no member chain at all -- the "member" is the collection element itself
+            if (collection is IValueCollectionMember valueCollection)
+            {
+                return valueCollection.Element;
+            }
+
+            throw new BadLinqExpressionException(
+                $"Marten cannot derive a queryable member from an empty member chain against {collection}");
+        }
+
         var member = collection.FindMember(members[0]);
         for (var i = 1; i < members.Length; i++)
         {
@@ -313,6 +326,20 @@ public static class LinqInternalExtensions
     {
         typeof(ConstantExpression)
     };
+
+    /// <summary>
+    ///     Returns the searched-for value argument of a Contains() call. The last argument
+    ///     is not necessarily the value: on modern TFMs array.Contains(value) can bind to
+    ///     MemoryExtensions.Contains(span, value, IEqualityComparer) whenever the element
+    ///     type does not implement IEquatable (enums, most classes), and the compiler
+    ///     supplies a null comparer as the trailing argument.
+    /// </summary>
+    public static Expression ContainsValueArgument(this MethodCallExpression call)
+    {
+        // Instance method (List<T>.Contains(value)) vs extension method
+        // (Enumerable/MemoryExtensions.Contains(source, value, ...))
+        return call.Object is null ? call.Arguments[1] : call.Arguments[0];
+    }
 
     public static object Value(this Expression expression)
     {


### PR DESCRIPTION
Closes #5278

## What this fixes

Two related LINQ failures on value collections of enums (full analysis in #5278):

1. **`x.EnumArray.Contains(value)` silently returns zero rows.** With `using System;` in scope (implicit in most apps via `<ImplicitUsings>`), overload resolution binds `MemoryExtensions.Contains(span, value, IEqualityComparer<T>?)` for enum element types — enums don't implement `IEquatable<T>`, so the 2-arg span overload's constraint fails — and the compiler supplies a `null` comparer as the trailing argument. The collection members' `ParseWhereForContains` implementations read `Arguments.Last()` as the search value, generating a containment filter of `{"Member":[null]}` that matches nothing, with no error.
2. **`x.EnumArray.Any(c => c == value)` throws `IndexOutOfRangeException`.** Enum equality compiles to a converted bare lambda parameter (`Convert(c, Int32)`, no member access), producing an empty member chain that `LinqInternalExtensions.MemberFor` indexed unguarded.

## Changes

- New `LinqInternalExtensions.ContainsValueArgument()` helper selects the `Contains` value argument positionally (`Arguments[1]` for extension-method shapes — `Enumerable`/`MemoryExtensions`: source, value, [comparer] — and `Arguments[0]` for instance methods like `List<T>.Contains(value)`), applied to every collection member that parsed `Contains` via `Arguments.Last()`: `ValueCollectionMember`, `ChildCollectionMember`, `DuplicatedArrayField`, `DictionaryKeysMember`.
- Empty-member-chain guard in `MemberFor`: against an `IValueCollectionMember`, a bare or converted lambda parameter resolves to the collection's `Element` member; anything else gets a descriptive `BadLinqExpressionException` instead of the index crash.
- `Bug_5278_enum_value_collection_filters`: five tests — captured-variable `Contains` under both `EnumStorage.AsInteger` and `AsString`, literal `Contains` with `System` in scope, and `Any(c => c == …)` with literal and captured variable. The file's `using System;` is load-bearing for the repro and commented as such (it's also why the existing `Bug_2946` tests never caught this — that file binds `Enumerable.Contains`).

## Verification

- Baseline (master `src/Marten`): all 5 new tests fail — the two `Any` shapes with `IndexOutOfRangeException`, the three `Contains` shapes with empty results from `@> '{"Colors":[null]}'`.
- With the fix: 5/5 pass on both `net9.0` and `net10.0`.
- Full `LinqTests` suite: 1439/1439 passing (net10.0, PostgreSQL 18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
