### PR TITLE
Tag rules: derive a DCB tag from the event's own data

### DIFF
--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -99,6 +99,37 @@ await theSession.SaveChangesAsync();
 
 Events can have multiple tags of different types. Tags are persisted to their respective tag tables in the same transaction as the event.
 
+### Tag Rules <Badge type="tip" text="9.30" />
+
+Tagging every event at its call site is a rule nothing enforces, and a forgotten tag is not an error to a
+tag query -- it is simply absent from the answer. A tag rule states the rule once, and Marten applies it
+wherever the event is built:
+
+```cs
+opts.Events.RegisterTagType<InvoiceId>("invoice");
+opts.Events.RegisterTagType<LineId>("line");
+
+// Declared on an interface, so it reaches every event that belongs to an invoice
+opts.Events.TagWith<IInvoiceEvent>(e => new InvoiceId(e.Invoice));
+opts.Events.TagWith<LineInvoiced>(e => new LineId(e.Line));
+```
+
+This closes the two gaps that [tag inference](#tag-routing) leaves open. Inference matches a property by
+its *type*, so an event that names its identifiers as `Guid` or `string` can never be inferred, and it only
+runs on the `IEventBoundary` path. A rule applies to ordinary appends, `StartStream`, aggregate handlers
+and bulk inserts alike, because it runs where the event is built.
+
+Rules compose the way you would expect:
+
+- returning `null` leaves the event untagged;
+- a rule declared on a base type or interface applies to every event assignable to it;
+- several rules may contribute different tag types to one event;
+- a tag type already on the event is left alone, so a rule never fights an explicit `WithTag` -- and never
+  adds a second value of one tag type, which HStore mode refuses.
+
+A rule that produces a tag type you never registered throws, rather than writing an event whose tag no
+query can ever match.
+
 ## Querying Events by Tags
 
 Use `EventTagQuery` to build a query, then execute it with `QueryByTagsAsync`:

--- a/src/EventSourcingTests/Dcb/declarative_event_tag_rules.cs
+++ b/src/EventSourcingTests/Dcb/declarative_event_tag_rules.cs
@@ -1,0 +1,166 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Dcb;
+
+public interface IInvoiceEvent
+{
+    Guid Invoice { get; }
+}
+
+public record InvoiceId(Guid Value);
+
+public record LineId(Guid Value);
+
+public record InvoiceRaised(Guid Invoice, decimal Amount): IInvoiceEvent;
+
+public record LineInvoiced(Guid Invoice, Guid Line): IInvoiceEvent;
+
+public record UnrelatedThingHappened(string Description);
+
+/// <summary>
+/// Tag rules derive a tag from the event's own data, wherever the event is built.
+/// <para>
+/// <see cref="EventTagInference" /> covers neither case here: it matches a property by its <i>type</i>, so
+/// an event naming its identifiers as <c>Guid</c> can never be inferred, and it only runs on the
+/// <c>IEventBoundary</c> path. These events reach the store through an ordinary append.
+/// </para>
+/// </summary>
+[Collection("OneOffs")]
+public class declarative_event_tag_rules: OneOffConfigurationsContext
+{
+    private void ConfigureStore(Action<StoreOptions>? extra = null)
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsGuid;
+            opts.Events.DcbStorageMode = DcbStorageMode.HStore;
+
+            opts.Events.RegisterTagType<InvoiceId>("invoice");
+            opts.Events.RegisterTagType<LineId>("line");
+
+            // One rule per tag type. The first is declared on the interface, so it reaches every event that
+            // belongs to an invoice without naming them one by one.
+            opts.Events.TagWith<IInvoiceEvent>(e => new InvoiceId(e.Invoice));
+            opts.Events.TagWith<LineInvoiced>(e => new LineId(e.Line));
+
+            extra?.Invoke(opts);
+        });
+    }
+
+    [Fact]
+    public async Task a_rule_tags_an_ordinary_append()
+    {
+        ConfigureStore();
+
+        var invoice = Guid.NewGuid();
+        var line = Guid.NewGuid();
+
+        theSession.Events.StartStream(Guid.NewGuid(), new InvoiceRaised(invoice, 12.5m));
+        theSession.Events.StartStream(Guid.NewGuid(), new LineInvoiced(invoice, line));
+        await theSession.SaveChangesAsync();
+
+        // The interface rule reaches both events, across the two streams they were appended to.
+        var byInvoice = await theSession.Events.QueryByTagsAsync(new EventTagQuery().Or(new InvoiceId(invoice)));
+        byInvoice.Count.ShouldBe(2);
+
+        // The second rule contributes a different tag type to one of the same events.
+        var byLine = await theSession.Events.QueryByTagsAsync(new EventTagQuery().Or(new LineId(line)));
+        byLine.Count.ShouldBe(1);
+        byLine[0].Data.ShouldBeOfType<LineInvoiced>().Line.ShouldBe(line);
+    }
+
+    [Fact]
+    public async Task an_event_no_rule_matches_is_left_alone()
+    {
+        ConfigureStore();
+
+        theSession.Events.StartStream(Guid.NewGuid(), new UnrelatedThingHappened("nothing to see"));
+        await theSession.SaveChangesAsync();
+
+        var found = await theSession.Events.QueryByTagsAsync(
+            new EventTagQuery().Or(new InvoiceId(Guid.NewGuid())));
+
+        found.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_rule_that_returns_null_leaves_the_event_untagged()
+    {
+        var invoice = Guid.NewGuid();
+        ConfigureStore(opts => opts.Events.TagWith<UnrelatedThingHappened>(_ => null));
+
+        theSession.Events.StartStream(Guid.NewGuid(), new UnrelatedThingHappened("still nothing"));
+        await theSession.SaveChangesAsync();
+
+        (await theSession.Events.QueryByTagsAsync(new EventTagQuery().Or(new InvoiceId(invoice))))
+            .Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task an_explicit_tag_wins_over_the_rule()
+    {
+        ConfigureStore();
+
+        var claimed = Guid.NewGuid();
+        var overridden = Guid.NewGuid();
+
+        var tagged = new Event<InvoiceRaised>(new InvoiceRaised(claimed, 1m));
+        tagged.WithTag(new InvoiceId(overridden));
+
+        theSession.Events.StartStream(Guid.NewGuid(), tagged);
+        await theSession.SaveChangesAsync();
+
+        (await theSession.Events.QueryByTagsAsync(new EventTagQuery().Or(new InvoiceId(overridden))))
+            .Count.ShouldBe(1);
+
+        // A tag type already on the event is left alone rather than added a second time, which in HStore
+        // mode would throw instead of overwriting.
+        (await theSession.Events.QueryByTagsAsync(new EventTagQuery().Or(new InvoiceId(claimed))))
+            .Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task tags_from_a_rule_survive_a_bulk_insert()
+    {
+        ConfigureStore();
+
+        var invoice = Guid.NewGuid();
+        var action = StreamAction.Start(theStore.Events, Guid.NewGuid(), new InvoiceRaised(invoice, 3m));
+
+        await theStore.BulkInsertEventsAsync(new List<StreamAction> { action });
+
+        var found = await theSession.Events.QueryByTagsAsync(new EventTagQuery().Or(new InvoiceId(invoice)));
+        found.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_rule_producing_an_unregistered_tag_type_says_so()
+    {
+        ConfigureStore(opts => opts.Events.TagWith<UnrelatedThingHappened>(e => new LineId(Guid.NewGuid())));
+        // LineId *is* registered above, so use a type that is not.
+        var options = new StoreOptions();
+        options.Connection(ConnectionSource.ConnectionString);
+        options.Events.DcbStorageMode = DcbStorageMode.HStore;
+        options.Events.TagWith<UnrelatedThingHappened>(_ => new InvoiceId(Guid.NewGuid()));
+
+        await using var store = new DocumentStore(options);
+        await using var session = store.LightweightSession();
+
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            session.Events.StartStream(Guid.NewGuid(), new UnrelatedThingHappened("boom")));
+
+        ex.Message.ShouldContain("not a registered tag type");
+        ex.Message.ShouldContain("RegisterTagType<InvoiceId>()");
+    }
+}

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -90,6 +90,7 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     internal DocumentStore Store => _store;
 
     private readonly List<ITagTypeRegistration> _tagTypes = new();
+    private readonly List<IEventTagRule> _tagRules = new();
 
     // Roots EventMapping<>'s constructor for trimming / Native AOT. Without this root the constructor metadata is trimmed
     // and Activator throws MissingMethodException at StoreOptions construction.
@@ -258,12 +259,15 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
             var mapping = EventMappingFor(e.EventType);
             e.EventTypeName = mapping.EventTypeName;
             e.DotNetTypeName = mapping.DotNetTypeName;
+            if (_tagRules.Count > 0) applyTagRules(e);
             return e;
         }
         else
         {
             var mapping = EventMappingFor(eventData.GetType());
-            return mapping.Wrap(eventData);
+            var wrapped = mapping.Wrap(eventData);
+            if (_tagRules.Count > 0) applyTagRules(wrapped);
+            return wrapped;
         }
 
 
@@ -546,6 +550,77 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     /// The registered tag types for DCB support.
     /// </summary>
     public IReadOnlyList<ITagTypeRegistration> TagTypes => _tagTypes;
+
+    /// <summary>
+    /// Derive a DCB tag from an event's own data, for every event appended through this store.
+    /// <para>
+    /// <see cref="Tags.EventTagInference" /> can only find a tag when the event exposes a property whose
+    /// <i>type</i> is the tag type, and it only runs on the <c>IEventBoundary</c> path. A rule closes both
+    /// gaps: it works for an event that names its identifiers as primitives, and it applies wherever the
+    /// event is built -- ordinary appends, <c>StartStream</c>, aggregate handlers and bulk inserts alike.
+    /// </para>
+    /// <para>
+    /// Return <c>null</c> to leave an event untagged. A rule declared on a base type or interface applies
+    /// to every event assignable to it, and several rules may contribute different tag types to one event.
+    /// A tag type already present on the event is left alone, so a rule never fights an explicit
+    /// <c>WithTag</c> call.
+    /// </para>
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// opts.Events.RegisterTagType&lt;InvoiceId&gt;("invoice");
+    /// opts.Events.TagWith&lt;InvoiceCreated&gt;(e =&gt; new InvoiceId(e.Invoice));
+    /// </code>
+    /// </example>
+    public void TagWith<TEvent>(Func<TEvent, object?> rule) where TEvent : notnull
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        _tagRules.Add(new EventTagRule<TEvent>(rule));
+    }
+
+    /// <summary>
+    /// The registered tag rules. See <see cref="TagWith{TEvent}" />.
+    /// </summary>
+    public IReadOnlyList<IEventTagRule> TagRules => _tagRules;
+
+    private void applyTagRules(IEvent @event)
+    {
+        for (var i = 0; i < _tagRules.Count; i++)
+        {
+            var tag = _tagRules[i].Resolve(@event.Data);
+            if (tag == null) continue;
+
+            var tagType = tag.GetType();
+
+            // An explicit WithTag wins, and re-building an event that already carries the tag must not add
+            // it twice -- in HStore mode a second value of one tag type throws rather than overwriting.
+            if (@event.Tags != null)
+            {
+                var alreadyTagged = false;
+                for (var t = 0; t < @event.Tags.Count; t++)
+                {
+                    if (@event.Tags[t].TagType == tagType)
+                    {
+                        alreadyTagged = true;
+                        break;
+                    }
+                }
+
+                if (alreadyTagged) continue;
+            }
+
+            if (!_tagTypes.Any(x => x.TagType == tagType))
+            {
+                throw new InvalidOperationException(
+                    $"The tag rule for '{_tagRules[i].EventType.FullName}' produced a tag of type "
+                    + $"'{tagType.FullName}', which is not a registered tag type. A tag Marten does not know "
+                    + "cannot be stored or queried, so this would silently write nothing. Call "
+                    + $"RegisterTagType<{tagType.Name}>() when configuring the store.");
+            }
+
+            @event.AddTag(new EventTag(tagType, tag));
+        }
+    }
 
     private DcbStorageMode _dcbStorageMode = DcbStorageMode.TagTables;
 

--- a/src/Marten/Events/EventTagRule.cs
+++ b/src/Marten/Events/EventTagRule.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using System;
+
+namespace Marten.Events;
+
+/// <summary>
+/// A rule that derives a DCB tag from an event's own data. Registered with
+/// <see cref="EventGraph.TagWith{TEvent}"/>.
+/// </summary>
+public interface IEventTagRule
+{
+    /// <summary>The event type the rule applies to. Events assignable to it match.</summary>
+    Type EventType { get; }
+
+    /// <summary>The tag value for this event, or <c>null</c> when the rule does not apply to it.</summary>
+    object? Resolve(object eventData);
+}
+
+internal sealed class EventTagRule<TEvent>: IEventTagRule
+{
+    private readonly Func<TEvent, object?> _rule;
+
+    public EventTagRule(Func<TEvent, object?> rule)
+    {
+        _rule = rule;
+    }
+
+    public Type EventType => typeof(TEvent);
+
+    public object? Resolve(object eventData) => eventData is TEvent typed ? _rule(typed) : null;
+}

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -571,6 +571,25 @@ namespace Marten.Events
         ITagTypeRegistration RegisterTagType<TTag>(string tableSuffix) where TTag : notnull;
 
         /// <summary>
+        /// Derive a DCB tag from an event's own data, for every event appended through this store.
+        /// <para>
+        /// Tag inference can only find a tag when the event exposes a property whose <i>type</i> is the tag
+        /// type, and it only runs on the <c>IEventBoundary</c> path. A rule closes both gaps: it works for
+        /// an event that names its identifiers as primitives, and it applies wherever the event is built --
+        /// ordinary appends, <c>StartStream</c>, aggregate handlers and bulk inserts alike.
+        /// </para>
+        /// <para>
+        /// Return <c>null</c> to leave an event untagged. A rule declared on a base type or interface
+        /// applies to every event assignable to it, and several rules may contribute different tag types to
+        /// one event. A tag type already on the event is left alone, so a rule never fights an explicit
+        /// <c>WithTag</c>.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="TEvent">The event type, or a base type or interface of it</typeparam>
+        /// <param name="rule">Returns the tag value for an event, or null to leave it untagged</param>
+        void TagWith<TEvent>(Func<TEvent, object?> rule) where TEvent : notnull;
+
+        /// <summary>
         /// The registered tag types for DCB support.
         /// </summary>
         IReadOnlyList<ITagTypeRegistration> TagTypes { get; }


### PR DESCRIPTION
Tagging every event at its call site is a rule nothing enforces, and a forgotten tag is not an error to a
tag query — it is simply absent from the answer, which is the one failure a consistency boundary must not
have.

`EventTagInference` already answers this, but only halfway:

- it matches a property by its **type**, so an event that names its identifiers as `Guid` or `string` can
  never be inferred;
- it is called from exactly one place, `EventBoundary.RouteEventByTags`. An application appending through a
  session, a Wolverine aggregate handler or a bulk insert gets no inference at all.

## What this adds

```cs
opts.Events.RegisterTagType<InvoiceId>("invoice");
opts.Events.RegisterTagType<LineId>("line");

// Declared on an interface, so it reaches every event that belongs to an invoice
opts.Events.TagWith<IInvoiceEvent>(e => new InvoiceId(e.Invoice));
opts.Events.TagWith<LineInvoiced>(e => new LineId(e.Line));
```

The rule is applied in `EventGraph.BuildEvent`, which is the single point every append path passes through —
ordinary appends, `StartStream`, `IEventStream.AppendMany`, and the `StreamAction`s a bulk insert is built
from. With no rules registered the added work is one `Count` check.

Composition follows from that:

- returning `null` leaves the event untagged;
- a rule on a base type or interface reaches every event assignable to it;
- several rules may contribute different tag types to one event;
- a tag type already on the event is left alone, so a rule never fights an explicit `WithTag` — and never
  adds a second value of one tag type, which HStore mode refuses outright.

A rule producing an unregistered tag type throws where it happens, naming the `RegisterTagType` call it
wants, rather than storing an event whose tag no query can ever match.

## Deliberately not changed

Tag inference stays where it is. Running it on every append path would add tags to stores that never asked
for them, and there is no way to opt out of it; a rule is explicit.

## Tests

`src/EventSourcingTests/Dcb/declarative_event_tag_rules.cs`, six cases: an ordinary append (the path
inference does not reach), an interface rule spanning two streams, an unmatched event left alone, a rule
returning null, an explicit tag winning over the rule, tags surviving a bulk insert, and the unregistered
tag type error.

Green on net10.0, and the whole `EventSourcingTests.Dcb` namespace is green with it (128 passed, 2
pre-existing skips).

## Where this comes from

We are moving a healthcare claims platform onto DCB tags — ~2M invoices over 512 shards — and the claim-line
events reach the store three different ways: creation handlers with a session, Wolverine aggregate handlers
that return events the framework appends, and a bulk-insert migration path. Keeping "which tag does this
event carry" correct in three places is exactly the kind of rule that goes quietly wrong, and a missing tag
is silent by design.
