### PR TITLE
Keep the async daemon's skip-ahead probe on the index (#5277)

### DIFF
--- a/docs/events/optimizing.md
+++ b/docs/events/optimizing.md
@@ -279,7 +279,7 @@ Even without the index, the async daemon automatically adapts when event loading
 It will fall back to progressively simpler query strategies:
 
 1. **Normal**: Standard range query with type filter
-2. **Skip-ahead**: Find the MIN(seq_id) matching the type filter, then fetch from there
+2. **Skip-ahead**: Find the first `seq_id` matching the type filter, then fetch from there
 3. **Window-step**: Advance through the sequence in fixed 10,000-event windows
 
 This adaptive behavior is automatic and requires no configuration.

--- a/src/DaemonTests/Internals/Bug_5277_skip_ahead_probe_stays_on_the_index.cs
+++ b/src/DaemonTests/Internals/Bug_5277_skip_ahead_probe_stays_on_the_index.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.MultiTenancy;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Archiving;
+using Marten.Events.Daemon.Internals;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Postgresql.SqlGeneration;
+using Xunit;
+
+namespace DaemonTests.Internals;
+
+/// <summary>
+/// #5277 — the skip-ahead probe asked for <c>min(d.seq_id)</c> over a join to <c>mt_streams</c>.
+/// Postgres only rewrites <c>MIN</c> into an ordered index scan when the aggregate's input is a
+/// single relation, so the joined form planned as a bitmap heap scan of every remaining row in the
+/// partition: on a 1M-event store, 77ms and 27k buffers where the index scan needs 0.9ms and 536.
+/// That is O(events after the floor) on the one code path that exists BECAUSE the store is too
+/// large for the normal query to finish.
+///
+/// <para>
+/// Two changes: the probe orders by seq_id and takes one row instead of aggregating, which keeps
+/// the index scan even when the join IS required; and it only joins <c>mt_streams</c> when a filter
+/// actually references the <c>s</c> alias, which today means an <see cref="AggregateTypeFilter" />
+/// and nothing else.
+/// </para>
+/// </summary>
+public class Bug_5277_skip_ahead_probe_sql_shape
+{
+    private static string UniqueSchema() =>
+        $"bug5277_{Guid.NewGuid().ToString("N")[..16]}_{Environment.ProcessId}";
+
+    // Pure SQL-shape assertions -- EventLoader builds its commands from StoreOptions with no
+    // database round-trip, so the store is never applied. Mirrors Bug_4745's approach.
+    private static EventLoader BuildLoader(ISqlFragment[] filters, bool usePartitioning = false,
+        bool includeArchivedEvents = false)
+    {
+        var store = DocumentStore.For(o =>
+        {
+            o.Connection(ConnectionSource.ConnectionString);
+            o.DatabaseSchemaName = UniqueSchema();
+            o.Events.UseArchivedStreamPartitioning = usePartitioning;
+        });
+
+        var db = (MartenDatabase)store.Storage.Database;
+        return new EventLoader(store, db, new AsyncOptions(), filters, includeArchivedEvents);
+    }
+
+    [Fact]
+    public void probe_takes_the_first_row_in_seq_id_order_rather_than_aggregating()
+    {
+        var loader = BuildLoader(Array.Empty<ISqlFragment>());
+
+        loader.SkipAheadCommandText.ShouldNotContain("min(", Case.Insensitive,
+            "MIN over the filtered set cannot be served by an ordered index scan");
+        loader.SkipAheadCommandText.ShouldContain("order by d.seq_id limit 1", Case.Insensitive);
+    }
+
+    [Fact]
+    public void probe_does_not_join_streams_when_no_filter_references_them()
+    {
+        var store = DocumentStore.For(o =>
+        {
+            o.Connection(ConnectionSource.ConnectionString);
+            o.DatabaseSchemaName = UniqueSchema();
+        });
+
+        // The reported shape: d.type = ANY(...) and d.is_archived = FALSE, nothing touching s
+        var loader = new EventLoader(store, (MartenDatabase)store.Storage.Database, new AsyncOptions(),
+            [new EventTypeFilter(store.Events, [typeof(MTAEvent)]), IsNotArchivedFilter.Instance]);
+
+        loader.SkipAheadCommandText.ShouldNotContain("mt_streams", Case.Insensitive,
+            "mt_events.stream_id is a foreign key into mt_streams, so the join matches every row and only costs work");
+    }
+
+    [Fact]
+    public void probe_still_joins_streams_when_a_filter_references_them()
+    {
+        var store = DocumentStore.For(o =>
+        {
+            o.Connection(ConnectionSource.ConnectionString);
+            o.DatabaseSchemaName = UniqueSchema();
+        });
+
+        var loader = new EventLoader(store, (MartenDatabase)store.Storage.Database, new AsyncOptions(),
+            [new AggregateTypeFilter(typeof(Letters), store.Events)]);
+
+        // #4744: without the join, "s.type = ?" references a missing FROM-clause entry (42P01).
+        loader.SkipAheadCommandText.ShouldContain("mt_streams", Case.Insensitive);
+        loader.SkipAheadCommandText.ShouldContain("order by d.seq_id limit 1", Case.Insensitive);
+    }
+
+    [Fact]
+    public void probe_prunes_the_archived_stream_partition_when_it_joins()
+    {
+        var store = DocumentStore.For(o =>
+        {
+            o.Connection(ConnectionSource.ConnectionString);
+            o.DatabaseSchemaName = UniqueSchema();
+            o.Events.UseArchivedStreamPartitioning = true;
+        });
+
+        var loader = new EventLoader(store, (MartenDatabase)store.Storage.Database, new AsyncOptions(),
+            [new AggregateTypeFilter(typeof(Letters), store.Events)]);
+
+        // The same predicate #4745 gave the normal fetch. Without it the planner visits the archived
+        // mt_streams partition on every row the probe walks.
+        loader.SkipAheadCommandText.ShouldContain("s.is_archived = FALSE", Case.Insensitive);
+    }
+
+    [Fact]
+    public void probe_does_not_prune_streams_when_it_does_not_join()
+    {
+        var loader = BuildLoader(Array.Empty<ISqlFragment>(), usePartitioning: true);
+
+        loader.SkipAheadCommandText.ShouldNotContain("s.is_archived", Case.Insensitive);
+    }
+
+    [Fact]
+    public void probe_does_not_prune_streams_when_including_archived_events()
+    {
+        var store = DocumentStore.For(o =>
+        {
+            o.Connection(ConnectionSource.ConnectionString);
+            o.DatabaseSchemaName = UniqueSchema();
+            o.Events.UseArchivedStreamPartitioning = true;
+        });
+
+        var loader = new EventLoader(store, (MartenDatabase)store.Storage.Database, new AsyncOptions(),
+            [new AggregateTypeFilter(typeof(Letters), store.Events)], includeArchivedEvents: true);
+
+        loader.SkipAheadCommandText.ShouldNotContain("s.is_archived", Case.Insensitive);
+    }
+}
+
+public class Bug_5277_skip_ahead_probe_behaviour: OneOffConfigurationsContext
+{
+    // The join-free probe has to find the same events the joined one did.
+    [Fact]
+    public async Task skip_ahead_probe_finds_events_without_the_streams_join()
+    {
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<Letters>(streamId, new MTAEvent(), new MTBEvent(), new MTCEvent());
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Only a d-side filter, so the probe drops the join entirely
+        var filters = new ISqlFragment[]
+        {
+            new EventTypeFilter(theStore.Events, [typeof(MTAEvent), typeof(MTBEvent), typeof(MTCEvent)])
+        };
+
+        var loader = new EventLoader(theStore, (MartenDatabase)theStore.Tenancy.Default.Database,
+            new AsyncOptions(), filters);
+
+        loader.SkipAheadCommandText.ShouldNotContain("mt_streams");
+
+        var page = await loader.LoadWithSkipAheadAsync(Request(), CancellationToken.None);
+
+        page.Count.ShouldBe(3);
+    }
+
+    // No matching event at all: MIN() answered with one NULL row, LIMIT 1 answers with no row.
+    [Fact]
+    public async Task skip_ahead_probe_returns_an_empty_page_when_nothing_matches()
+    {
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
+
+        theSession.Events.StartStream<Letters>(Guid.NewGuid(), new MTAEvent());
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var filters = new ISqlFragment[]
+        {
+            // Nothing in the store carries this type
+            new EventTypeFilter(theStore.Events, [typeof(MTCEvent)])
+        };
+
+        var loader = new EventLoader(theStore, (MartenDatabase)theStore.Tenancy.Default.Database,
+            new AsyncOptions(), filters);
+
+        var page = await loader.LoadWithSkipAheadAsync(Request(), CancellationToken.None);
+
+        page.Count.ShouldBe(0);
+    }
+
+    private static EventRequest Request() => new()
+    {
+        Floor = 0,
+        HighWater = 1000,
+        BatchSize = 1000,
+        ErrorOptions = new ErrorHandlingOptions(),
+        Runtime = new NulloDaemonRuntime(),
+        Name = new ShardName("Letters", "All", 1)
+    };
+}

--- a/src/Marten/Events/Daemon/Internals/EventLoader.cs
+++ b/src/Marten/Events/Daemon/Internals/EventLoader.cs
@@ -28,7 +28,7 @@ namespace Marten.Events.Daemon.Internals;
 ///
 /// Strategy progression on timeout:
 /// 1. Normal: seq_id range + type filter (standard query)
-/// 2. Skip-ahead: find MIN(seq_id) matching the type filter, then fetch from there
+/// 2. Skip-ahead: find the first seq_id matching the type filter, then fetch from there
 /// 3. Window-step: advance through the sequence in fixed windows until events are found
 /// </summary>
 internal sealed class EventLoader: IEventLoader
@@ -44,6 +44,17 @@ internal sealed class EventLoader: IEventLoader
     private readonly string _schemaName;
     private readonly bool _hasTypeFilter;
     private readonly bool _hasEventTypeIndex;
+    private readonly bool _includeArchivedEvents;
+
+    /// <summary>
+    /// #5277: whether the skip-ahead probe has to join <c>mt_streams</c> at all. Only
+    /// <see cref="AggregateTypeFilter"/> emits a predicate against the <c>s</c> alias
+    /// ("s.type = ?", see #4744); every other filter Marten builds is on <c>d</c> alone, and
+    /// <c>mt_events.stream_id</c> is a foreign key into <c>mt_streams</c>, so for those the join
+    /// matches every row and only costs work. Postgres does not eliminate provably-redundant
+    /// inner joins on its own.
+    /// </summary>
+    private readonly bool _skipAheadJoinsStreams;
 
     // Adaptive strategy state
     private LoadStrategy _currentStrategy = LoadStrategy.Normal;
@@ -98,6 +109,8 @@ internal sealed class EventLoader: IEventLoader
         _schemaName = store.Options.Events.DatabaseSchemaName;
         _hasTypeFilter = filters.OfType<EventTypeFilter>().Any();
         _hasEventTypeIndex = store.Options.EventGraph.EnableEventTypeIndex;
+        _includeArchivedEvents = includeArchivedEvents;
+        _skipAheadJoinsStreams = filters.OfType<AggregateTypeFilter>().Any();
 
         TenantFilterValue = (shardName?.TenantId != null && store.Options.Events.UseTenantPartitionedEvents)
             ? shardName!.TenantId
@@ -300,7 +313,7 @@ internal sealed class EventLoader: IEventLoader
         return page;
     }
 
-    // #4744 test seam: drive the skip-ahead MIN probe directly so a regression test can prove
+    // #4744 test seam: drive the skip-ahead probe directly so a regression test can prove
     // its SQL is valid (the probe must join mt_streams whenever a filter references the s alias,
     // e.g. AggregateTypeFilter's "s.type = ?") without having to provoke a real statement
     // timeout. Not used at runtime.
@@ -313,55 +326,90 @@ internal sealed class EventLoader: IEventLoader
     internal Task<EventPage> LoadWithWindowStepAsync(EventRequest request, CancellationToken token)
         => loadWithWindowStepAsync(request, token);
 
+    // Exposed for the #5277 SQL-shape regression tests, same rationale as CommandText above:
+    // the probe's SQL is built from StoreOptions alone, so its shape can be asserted with no
+    // database round-trip. Not used at runtime.
+    internal string SkipAheadCommandText => buildSkipAheadCommand(0).CommandText;
+
     /// <summary>
-    /// Skip-ahead strategy: find the MIN(seq_id) matching the type filter after the floor,
+    /// #5277: find the first matching seq_id after the floor with an ORDER BY … LIMIT 1 rather than
+    /// MIN(d.seq_id). The two return the same sequence, but MIN is an aggregate over the whole
+    /// filtered set and Postgres only rewrites it into an ordered index scan when its input is a
+    /// single relation — joined to mt_streams it degrades to a bitmap heap scan of every remaining
+    /// row in the partition. That made this probe O(events after the floor) on the one code path
+    /// that exists precisely BECAUSE the store is too large for the normal query. The explicit
+    /// ORDER BY … LIMIT 1 keeps the index scan in every shape, joined or not.
+    /// </summary>
+    private NpgsqlCommand buildSkipAheadCommand(long floor)
+    {
+        var builder = new CommandBuilder();
+        builder.Append($"select d.seq_id from {_schemaName}.mt_events as d");
+
+        // #4744: the probe replays the same _filters as the normal query, and an AggregateTypeFilter
+        // (from a projection that filters on stream type) emits "s.type = ?" — without the join that
+        // predicate references a missing FROM-clause entry and Postgres throws 42P01. #5277: but
+        // that is the ONLY filter referencing s, so join only when one is present. mt_events.stream_id
+        // is a foreign key into mt_streams, so otherwise the join matches every row and buys nothing.
+        if (_skipAheadJoinsStreams)
+        {
+            builder.Append($" inner join {_schemaName}.mt_streams as s on d.stream_id = s.id");
+
+            if (_store.Options.Events.TenancyStyle == TenancyStyle.Conjoined)
+            {
+                builder.Append(" and d.tenant_id = s.tenant_id");
+            }
+
+            if (_store.Options.Events.UseArchivedStreamPartitioning && !_includeArchivedEvents)
+            {
+                // #5277: the same pruning predicate #4745 gave the normal query. Without it the
+                // planner has to visit the archived mt_streams partition on every row the probe
+                // walks; the event-row predicate only prunes mt_events.
+                builder.Append($" and s.{IsArchivedColumn.ColumnName} = FALSE");
+            }
+        }
+
+        builder.Append(" where d.seq_id > ");
+        builder.AppendParameter(floor, NpgsqlDbType.Bigint);
+
+        if (TenantFilterValue != null)
+        {
+            // Same per-tenant scoping the normal SELECT applies (see TenantFilterValue
+            // doc) — partition-prunes mt_events so the probe doesn't scan other tenants'
+            // events looking for the next match.
+            builder.Append(" and d.tenant_id = '");
+            builder.Append(TenantFilterValue.Replace("'", "''"));
+            builder.Append("'");
+        }
+
+        foreach (var filter in _filters)
+        {
+            builder.Append(" and ");
+            filter.Apply(builder);
+        }
+
+        builder.Append(" order by d.seq_id limit 1");
+
+        return builder.Compile();
+    }
+
+    /// <summary>
+    /// Skip-ahead strategy: find the first seq_id matching the type filter after the floor,
     /// then run the normal query starting from there. Avoids scanning non-matching events.
     /// </summary>
     private async Task<EventPage> loadWithSkipAheadAsync(EventRequest request, CancellationToken token)
     {
         await using var session = (QuerySession)_store.QuerySession(SessionOptions.ForDatabase(Database));
 
-        // Build a MIN query to find the next matching event. #4744: this MUST mirror the normal
-        // query's FROM clause — including the join to mt_streams — because the same _filters are
-        // replayed below, and an AggregateTypeFilter (from a projection that filters on stream
-        // type) emits "s.type = ?". Without the join that predicate references a missing FROM-clause
-        // entry and Postgres throws 42P01. seq_id lives only on mt_events, so qualify it as d.seq_id.
-        var minBuilder = new CommandBuilder();
-        minBuilder.Append(
-            $"select min(d.seq_id) from {_schemaName}.mt_events as d inner join {_schemaName}.mt_streams as s on d.stream_id = s.id");
-
-        if (_store.Options.Events.TenancyStyle == TenancyStyle.Conjoined)
-        {
-            minBuilder.Append(" and d.tenant_id = s.tenant_id");
-        }
-
-        minBuilder.Append(" where d.seq_id > ");
-        minBuilder.AppendParameter(request.Floor, NpgsqlDbType.Bigint);
-
-        if (TenantFilterValue != null)
-        {
-            // Same per-tenant scoping the normal SELECT applies (see TenantFilterValue
-            // doc) — partition-prunes mt_events so the MIN doesn't scan other tenants'
-            // events looking for the next match.
-            minBuilder.Append(" and d.tenant_id = '");
-            minBuilder.Append(TenantFilterValue.Replace("'", "''"));
-            minBuilder.Append("'");
-        }
-
-        foreach (var filter in _filters)
-        {
-            minBuilder.Append(" and ");
-            filter.Apply(minBuilder);
-        }
-
-        var minCommand = minBuilder.Compile();
+        var probeCommand = buildSkipAheadCommand(request.Floor);
         long? nextMatchingSeqId;
 
-        await using (var reader = await session.ExecuteReaderAsync(minCommand, token).ConfigureAwait(false))
+        await using (var reader = await session.ExecuteReaderAsync(probeCommand, token).ConfigureAwait(false))
         {
-            await reader.ReadAsync(token).ConfigureAwait(false);
-            nextMatchingSeqId = await reader.IsDBNullAsync(0, token).ConfigureAwait(false)
-                ? null : reader.GetInt64(0);
+            // LIMIT 1, so "no row" is the no-match answer. MIN() returned a single NULL row for that
+            // case and the old code tested IsDBNull; d.seq_id is NOT NULL, so there is nothing to test.
+            nextMatchingSeqId = await reader.ReadAsync(token).ConfigureAwait(false)
+                ? reader.GetInt64(0)
+                : null;
             await reader.CloseAsync().ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Closes #5277.

## What the reporter saw

```sql
select min(d.seq_id)
from public.mt_events as d
inner join public.mt_streams as s on d.stream_id = s.id
where d.seq_id > :p0 and d.type = ANY(:p1) and d.is_archived = FALSE
```

The join references no `mt_streams` column, and `mt_events.stream_id` is a foreign key into `mt_streams`, so it matches every row. On a large `is_archived`-partitioned store the reporter expected it to be dead weight blocking partition pruning.

## What it actually costs

It is worse than dead weight. Postgres only rewrites `MIN` into an ordered index scan when the aggregate's input is a **single relation**. Joined, the probe plans as a bitmap heap scan of every remaining row in the partition — so it is `O(events after the floor)`, on the one code path that exists *precisely because* the store is too large for the normal query to finish. The skip-ahead fallback fires after a timeout, and was itself doing a full partition scan.

Measured on 1M events / 50k streams / PG17, `UseArchivedStreamPartitioning = true`, warm cache, `seq_id > 900000`, parameterized the way Npgsql sends it:

| probe shape | time | plan |
|---|---|---|
| `min()` + join (today) | **45.0 ms** | bitmap heap scan, 100k rows |
| `min()`, join dropped | 0.9 ms | index scan + `LIMIT 1` |
| `order by … limit 1` + join + `s.type` filter | 1.7 ms | index scan + nested loop |
| `order by … limit 1`, no join (this PR) | **0.22 ms** | index scan + `LIMIT 1` |

## The change

**1. `order by d.seq_id limit 1` instead of `min(d.seq_id)`.** Same answer, but it keeps the index scan in *every* shape — including the joined one, which matters because the join is genuinely required when a projection filters on stream type (#4744, `AggregateTypeFilter` emits `s.type = ?`). That case goes 76.9 ms → 1.7 ms.

**2. Only join `mt_streams` when a filter references the `s` alias.** `AggregateTypeFilter` is the only one that does; every other filter Marten builds is on `d` alone. Postgres does not eliminate provably-redundant inner joins on its own, so this has to be done in the SQL.

**3. When the join does survive, prune the archived stream partition.** The probe was missing the `s.is_archived = FALSE` predicate #4745 gave the normal fetch — the plans show it seq-scanning `mt_streams_archived` on every row the probe walks.

## Safety

Dropping a filter can only make the probe's answer *smaller*, so it skips ahead less, never past a matching event — and the normal query re-runs immediately afterwards with the full join and the complete filter set, so nothing that the join would have excluded is actually processed. The only behavioural difference is internal to `loadWithSkipAheadAsync`: `LIMIT 1` answers "no match" with no row where `MIN()` answered with a single NULL row.

One honest caveat: when **nothing** matches, both shapes still scan the range (~28 ms here). Proving absence requires the scan. The fix is neutral there, not a regression.

## Not changed

The reporter's second query — the batch fetch — keeps its join, and I'd argue it should. It carries `s.type as stream_type`, which populates the public `IEvent.AggregateTypeName`, and its `s.is_archived = FALSE` is a deliberate filter from #4745 rather than decoration. Its cost is bounded by `LIMIT 500`, not by table size: measured 2.6 ms vs 0.23 ms per batch, a nested loop with Memoize over 500 primary-key lookups.

## Tests

`src/DaemonTests/Internals/Bug_5277_skip_ahead_probe_stays_on_the_index.cs` — six SQL-shape assertions (no database round-trip, mirroring #4745's approach) plus two behavioural tests driving the probe through the existing `LoadWithSkipAheadAsync` seam, including the no-match case that used to read a NULL row.

Full `DaemonTests` (315) and `EventSourcingTests` (1974) green on net9.0, #4744's and #4745's regression tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)