### PR TITLE
Add TagEventsBy for applications that already own the translator

### DIFF
--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -130,6 +130,21 @@ Rules compose the way you would expect:
 A rule that produces a tag type you never registered throws, rather than writing an event whose tag no
 query can ever match.
 
+When an application already owns a single place that knows what an event is about, hand that over whole
+instead of restating it as one registration per tag type:
+
+```cs
+opts.Events.TagEventsBy(data => data switch
+{
+    LineInvoiced e => [new InvoiceId(e.Invoice), new LineId(e.Line)],
+    IInvoiceEvent e => [new InvoiceId(e.Invoice)],
+    _ => Array.Empty<object>()
+});
+```
+
+Return an empty sequence to leave an event untagged. The rule receives the event body: the stream is
+assigned after the event is built, so it is not available here.
+
 ## Querying Events by Tags
 
 Use `EventTagQuery` to build a query, then execute it with `QueryByTagsAsync`:

--- a/src/EventSourcingTests/Dcb/declarative_event_tag_rules.cs
+++ b/src/EventSourcingTests/Dcb/declarative_event_tag_rules.cs
@@ -144,6 +144,44 @@ public class declarative_event_tag_rules: OneOffConfigurationsContext
         found.Count.ShouldBe(1);
     }
 
+    /// <summary>
+    /// One store-wide rule, for an application that already owns a single place that knows what an event is
+    /// about. Without it the same translator has to be restated as one registration per tag type.
+    /// </summary>
+    [Fact]
+    public async Task one_store_wide_rule_can_carry_every_tag()
+    {
+        var invoice = Guid.NewGuid();
+        var line = Guid.NewGuid();
+
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsGuid;
+            opts.Events.DcbStorageMode = DcbStorageMode.HStore;
+            opts.Events.RegisterTagType<InvoiceId>("invoice");
+            opts.Events.RegisterTagType<LineId>("line");
+
+            opts.Events.TagEventsBy(data => data switch
+            {
+                LineInvoiced e => [new InvoiceId(e.Invoice), new LineId(e.Line)],
+                IInvoiceEvent e => [new InvoiceId(e.Invoice)],
+                _ => Array.Empty<object>()
+            });
+        });
+
+        theSession.Events.StartStream(Guid.NewGuid(), new InvoiceRaised(invoice, 4m));
+        theSession.Events.StartStream(Guid.NewGuid(), new LineInvoiced(invoice, line));
+        theSession.Events.StartStream(Guid.NewGuid(), new UnrelatedThingHappened("no tags here"));
+        await theSession.SaveChangesAsync();
+
+        (await theSession.Events.QueryByTagsAsync(new EventTagQuery().Or(new InvoiceId(invoice))))
+            .Count.ShouldBe(2);
+
+        var byLine = await theSession.Events.QueryByTagsAsync(new EventTagQuery().Or(new LineId(line)));
+        byLine.Count.ShouldBe(1);
+        byLine[0].Data.ShouldBeOfType<LineInvoiced>();
+    }
+
     [Fact]
     public async Task a_rule_producing_an_unregistered_tag_type_says_so()
     {

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -579,7 +579,17 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     }
 
     /// <summary>
-    /// The registered tag rules. See <see cref="TagWith{TEvent}" />.
+    /// Derive every DCB tag an event carries from one store-wide rule. See
+    /// <see cref="IEventStoreOptions.TagEventsBy" />.
+    /// </summary>
+    public void TagEventsBy(Func<object, IEnumerable<object>?> tagger)
+    {
+        ArgumentNullException.ThrowIfNull(tagger);
+        _tagRules.Add(new StoreWideEventTagRule(tagger));
+    }
+
+    /// <summary>
+    /// The registered tag rules. See <see cref="TagWith{TEvent}" /> and <see cref="TagEventsBy" />.
     /// </summary>
     public IReadOnlyList<IEventTagRule> TagRules => _tagRules;
 
@@ -587,8 +597,17 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     {
         for (var i = 0; i < _tagRules.Count; i++)
         {
-            var tag = _tagRules[i].Resolve(@event.Data);
-            if (tag == null) continue;
+            foreach (var tag in _tagRules[i].Resolve(@event.Data))
+            {
+                applyTag(@event, _tagRules[i], tag);
+            }
+        }
+    }
+
+    private void applyTag(IEvent @event, IEventTagRule rule, object? tag)
+    {
+        {
+            if (tag == null) return;
 
             var tagType = tag.GetType();
 
@@ -606,13 +625,13 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
                     }
                 }
 
-                if (alreadyTagged) continue;
+                if (alreadyTagged) return;
             }
 
             if (!_tagTypes.Any(x => x.TagType == tagType))
             {
                 throw new InvalidOperationException(
-                    $"The tag rule for '{_tagRules[i].EventType.FullName}' produced a tag of type "
+                    $"The tag rule for '{rule.Description}' produced a tag of type "
                     + $"'{tagType.FullName}', which is not a registered tag type. A tag Marten does not know "
                     + "cannot be stored or queried, so this would silently write nothing. Call "
                     + $"RegisterTagType<{tagType.Name}>() when configuring the store.");

--- a/src/Marten/Events/EventTagRule.cs
+++ b/src/Marten/Events/EventTagRule.cs
@@ -1,19 +1,21 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Marten.Events;
 
 /// <summary>
-/// A rule that derives a DCB tag from an event's own data. Registered with
-/// <see cref="EventGraph.TagWith{TEvent}"/>.
+/// A rule that derives DCB tags from an event's own data. Registered with
+/// <see cref="EventGraph.TagWith{TEvent}"/> or <see cref="EventGraph.TagEventsBy"/>.
 /// </summary>
 public interface IEventTagRule
 {
-    /// <summary>The event type the rule applies to. Events assignable to it match.</summary>
-    Type EventType { get; }
+    /// <summary>What the rule applies to, for error messages.</summary>
+    string Description { get; }
 
-    /// <summary>The tag value for this event, or <c>null</c> when the rule does not apply to it.</summary>
-    object? Resolve(object eventData);
+    /// <summary>The tags for this event. Empty when the rule does not apply to it.</summary>
+    IEnumerable<object?> Resolve(object eventData);
 }
 
 internal sealed class EventTagRule<TEvent>: IEventTagRule
@@ -25,7 +27,27 @@ internal sealed class EventTagRule<TEvent>: IEventTagRule
         _rule = rule;
     }
 
-    public Type EventType => typeof(TEvent);
+    public string Description => typeof(TEvent).FullName!;
 
-    public object? Resolve(object eventData) => eventData is TEvent typed ? _rule(typed) : null;
+    public IEnumerable<object?> Resolve(object eventData)
+    {
+        if (eventData is not TEvent typed) yield break;
+
+        var tag = _rule(typed);
+        if (tag != null) yield return tag;
+    }
+}
+
+internal sealed class StoreWideEventTagRule: IEventTagRule
+{
+    private readonly Func<object, IEnumerable<object>?> _tagger;
+
+    public StoreWideEventTagRule(Func<object, IEnumerable<object>?> tagger)
+    {
+        _tagger = tagger;
+    }
+
+    public string Description => "the store-wide rule registered with TagEventsBy()";
+
+    public IEnumerable<object?> Resolve(object eventData) => _tagger(eventData) ?? Enumerable.Empty<object>();
 }

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -590,6 +590,22 @@ namespace Marten.Events
         void TagWith<TEvent>(Func<TEvent, object?> rule) where TEvent : notnull;
 
         /// <summary>
+        /// Derive every DCB tag an event carries from one store-wide rule, for applications that already
+        /// have a single place that knows what an event is about.
+        /// <para>
+        /// <see cref="TagWith{TEvent}" /> states one tag for one event type. This states all of them for
+        /// all of them, so a translator an application already owns can be handed over whole instead of
+        /// being restated as one registration per tag type.
+        /// </para>
+        /// <para>
+        /// Return an empty sequence or <c>null</c> to leave an event untagged. The rule receives the event
+        /// body: the stream is assigned after the event is built, so it is not available here.
+        /// </para>
+        /// </summary>
+        /// <param name="tagger">Returns the tags for an event body, or nothing to leave it untagged</param>
+        void TagEventsBy(Func<object, IEnumerable<object>?> tagger);
+
+        /// <summary>
         /// The registered tag types for DCB support.
         /// </summary>
         IReadOnlyList<ITagTypeRegistration> TagTypes { get; }


### PR DESCRIPTION
Follow-up to #5283, which added `TagWith<TEvent>`.

`TagWith<TEvent>` states one tag for one event type. That is the right shape when the tags are few and the
events are known. It is the wrong shape when an application already has a single place that knows what an
event is about: that translator then has to be restated as one registration per tag type, and each
registration reads `TagWith<object>(...)`, where the type parameter says nothing.

```cs
opts.Events.TagEventsBy(data => data switch
{
    LineInvoiced e => [new InvoiceId(e.Invoice), new LineId(e.Line)],
    IInvoiceEvent e => [new InvoiceId(e.Invoice)],
    _ => Array.Empty<object>()
});
```

A rule may now yield more than one tag, so both forms share one path: the typed rule yields nothing or one,
the store-wide rule yields as many as it likes. Everything else is unchanged — an already present tag type
is left alone, and an unregistered tag type still throws, now naming which rule produced it.

## One design note

The rule takes the event body rather than the `IEvent`, on purpose. Rules are applied in
`EventGraph.BuildEvent`, and the stream is assigned to the event *after* it is built — so an `IEvent` here
would hand callers a `StreamKey` that is always null. Given the whole point of this feature is that a
missing tag is silent, an API that quietly offers a null stream key seemed like the wrong trade.

## Tests

One case added to `declarative_event_tag_rules.cs`: a single store-wide rule carrying two tag types across
three events, one of which it deliberately leaves untagged. The `EventSourcingTests.Dcb` namespace is green
on net10.0 (129 passed, 2 pre-existing skips).

## Where this comes from

Same platform as #5283. We have one `EventFlattener.TryFrom` that answers "what is this event about", used
by every projection; `TagEventsBy` is what lets us hand that over instead of copying its knowledge into a
second list that someone has to remember to update.
