### PR TITLE
Project a HashSet of enums for Npgsql in Contains (#5287)

### DIFF
--- a/src/LinqTests/Bugs/Bug_5287_hashset_of_enums_contains.cs
+++ b/src/LinqTests/Bugs/Bug_5287_hashset_of_enums_contains.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core;
+
+namespace LinqTests.Bugs;
+
+// #5287: `hashSet.Contains(x.EnumMember)` threw InvalidCastException out of Npgsql --
+// "Writing values of 'Colors[]' is not supported for parameters having NpgsqlDbType
+// '-2147483639'" -- because HashSetEnumerableContains handed the raw EnumType[] straight
+// to a `= ANY(?)` parameter. Its two sibling parsers already project the constant
+// collection through EnumIsOneOfWhereFragment for exactly this reason: EnumerableContains
+// (the array and List shapes, #2946) and MemoryExtensionsContains (net10's span binding,
+// #4610). This is the same fix in the third parser.
+public class Bug_5287_hashset_of_enums_contains: BugIntegrationContext
+{
+    public record ScalarDoc(string Id, Colors Color);
+
+    private async Task seedAsync()
+    {
+        theSession.Store(
+            new ScalarDoc("one", Colors.Blue),
+            new ScalarDoc("two", Colors.Red),
+            new ScalarDoc("three", Colors.Green));
+
+        await theSession.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task hashset_of_enums_contains_member_as_int()
+    {
+        StoreOptions(opts => opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger));
+        await seedAsync();
+
+        var wanted = new HashSet<Colors> { Colors.Blue, Colors.Red };
+
+        var results = await theSession.Query<ScalarDoc>()
+            .Where(x => wanted.Contains(x.Color))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        results.ShouldBe(new[] { "one", "two" });
+    }
+
+    [Fact]
+    public async Task hashset_of_enums_contains_member_as_string()
+    {
+        StoreOptions(opts => opts.UseSystemTextJsonForSerialization(EnumStorage.AsString));
+        await seedAsync();
+
+        var wanted = new HashSet<Colors> { Colors.Blue, Colors.Red };
+
+        var results = await theSession.Query<ScalarDoc>()
+            .Where(x => wanted.Contains(x.Color))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        results.ShouldBe(new[] { "one", "two" });
+    }
+
+    [Fact]
+    public async Task hashset_of_enums_matching_nothing_returns_nothing()
+    {
+        StoreOptions(opts => opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger));
+        await seedAsync();
+
+        var wanted = new HashSet<Colors> { Colors.Orange };
+
+        var results = await theSession.Query<ScalarDoc>()
+            .Where(x => wanted.Contains(x.Color))
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        results.ShouldBeEmpty();
+    }
+
+    // The non-enum path through the same parser has to keep working -- it never went through
+    // EnumIsOneOfWhereFragment and must not start now.
+    [Fact]
+    public async Task hashset_of_strings_contains_member()
+    {
+        StoreOptions(opts => opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger));
+        await seedAsync();
+
+        var wanted = new HashSet<string> { "one", "two" };
+
+        var results = await theSession.Query<ScalarDoc>()
+            .Where(x => wanted.Contains(x.Id))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        results.ShouldBe(new[] { "one", "two" });
+    }
+
+    // The shapes that already worked, pinned here beside the one that did not so the family
+    // stays together.
+    [Fact]
+    public async Task array_and_list_of_enums_still_work()
+    {
+        StoreOptions(opts => opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger));
+        await seedAsync();
+
+        var wantedArray = new[] { Colors.Blue, Colors.Red };
+        var byArray = await theSession.Query<ScalarDoc>()
+            .Where(x => wantedArray.Contains(x.Color))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        byArray.ShouldBe(new[] { "one", "two" });
+
+        var wantedList = new List<Colors> { Colors.Blue, Colors.Red };
+        var byList = await theSession.Query<ScalarDoc>()
+            .Where(x => wantedList.Contains(x.Color))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        byList.ShouldBe(new[] { "one", "two" });
+    }
+}

--- a/src/Marten/Linq/Parsing/Methods/EnumerableContains.cs
+++ b/src/Marten/Linq/Parsing/Methods/EnumerableContains.cs
@@ -56,6 +56,9 @@ internal class EnumerableContains: IMethodCallParser
             // EnumIsOneOfWhereFragment already does exactly that for the parallel
             // LinqExtensions.IsOneOf path (IsOneOf.cs:36) — route the Contains shape through
             // it too so HotChocolate's `[UseFiltering]` `in` operator works on enum members.
+            // Three parsers need this same branch, one per binding the C# compiler can pick:
+            // here, MemoryExtensionsContains (net10's span binding, #4610) and
+            // HashSetEnumerableContains (#5287). Fix one, check the other two.
             if (collectionMember.MemberType.IsEnum && constant.Value is not null)
             {
                 // EnumIsOneOfWhereFragment requires a System.Array — HotChocolate hands an
@@ -118,7 +121,23 @@ internal class HashSetEnumerableContains: IMethodCallParser
         if ((expression.Object ?? expression.Arguments[0]).TryToParseConstant(out var constant))
         {
             // This is the value.Contains() pattern
-            var collectionMember = memberCollection.MemberFor(expression.Arguments.Last());
+            var collectionMember = memberCollection.MemberFor(expression.ContainsValueArgument());
+
+            // #5287: the same enum handling EnumerableContains and MemoryExtensionsContains already
+            // do for the array and List shapes of this pattern. correctToArray below hands Npgsql a
+            // raw EnumType[], which it has no parameter mapping for ("Writing values of
+            // 'YourEnum[]' is not supported for parameters having NpgsqlDbType '-2147483639'"), so
+            // the constant has to be projected to string[]/int[] per the active EnumStorage first.
+            if (collectionMember.MemberType.IsEnum && constant.Value is not null)
+            {
+                // EnumIsOneOfWhereFragment requires a System.Array, and here the constant is a
+                // HashSet<TEnum> rather than one -- correctToArray does that conversion for the
+                // non-enum path below and is reused for exactly the same reason.
+                return new EnumIsOneOfWhereFragment(
+                    (Array)correctToArray(constant.Value),
+                    options.Serializer().EnumStorage,
+                    collectionMember.TypedLocator);
+            }
 
             return new WhereFragment($"{collectionMember.TypedLocator} = ANY(?)", correctToArray(constant.Value!));
         }

--- a/src/Marten/Linq/Parsing/Methods/MemoryExtensionsContains.cs
+++ b/src/Marten/Linq/Parsing/Methods/MemoryExtensionsContains.cs
@@ -42,6 +42,9 @@ internal class MemoryExtensionsContains: IMethodCallParser
             // NpgsqlDbType '-2147483639'`) and the same fix: project the constant
             // collection through EnumIsOneOfWhereFragment so it becomes a string[]/int[]
             // with the right NpgsqlDbType for the active EnumStorage.
+            // Three parsers need this same branch, one per binding the C# compiler can pick:
+            // here, EnumerableContains (#2946) and HashSetEnumerableContains (#5287).
+            // Fix one, check the other two.
             if (collectionMember.MemberType.IsEnum && constant.Value is not null)
             {
                 // EnumIsOneOfWhereFragment requires a System.Array; for net10's


### PR DESCRIPTION
Closes #5287.

## The bug

`hashSet.Contains(x.EnumMember)` threw instead of querying:

```
System.InvalidCastException : Writing values of 'Colors[]' is not supported
for parameters having NpgsqlDbType '-2147483639'
```

`HashSetEnumerableContains.Parse` builds `member = ANY(?)` and hands Npgsql the raw `TEnum[]` that `correctToArray` produces. Npgsql has no parameter mapping for an arbitrary enum array.

Every neighbouring shape worked, which is what made this a narrow gap rather than a general enum problem:

| shape | before | after |
|---|---|---|
| `Colors[].Contains(x.Color)` | works | works |
| `List<Colors>.Contains(x.Color)` | works | works |
| `HashSet<string>.Contains(x.Id)` | works | works |
| `x.ColorSet.Contains(Colors.Blue)` (member direction) | works | works |
| **`HashSet<Colors>.Contains(x.Color)`** | **throws** | works |

## The fix

Both sibling parsers already solve exactly this; `HashSetEnumerableContains` was never given the same branch. `EnumerableContains` handles the array and List shapes (#2946) and `MemoryExtensionsContains` handles net10's span binding (#4610), each detecting an enum member and projecting the constant collection through `EnumIsOneOfWhereFragment` into a `string[]`/`int[]` per the active `EnumStorage`. This adds that branch to the third parser, reusing `correctToArray` for the `HashSet` → `Array` step the fragment requires.

## Two things beyond the minimum, both worth calling out

**The member argument now comes from `ContainsValueArgument()`** rather than `Arguments.Last()`. This is the helper #5279 introduced last week for precisely this call shape. It cannot change behaviour for anything reaching this parser today — `MemoryExtensions` bindings go to their own parser, so the last argument is already the right one — but it closes the same trailing-comparer trap by construction rather than by luck.

**Each of the three enum branches now names the other two.** This is the fourth time this family has been fixed one parser at a time (#2946, #4610, #5278, this one). A reader landing on any one of them can now find the others.

## Tests

`src/LinqTests/Bugs/Bug_5287_hashset_of_enums_contains.cs` — the `HashSet<TEnum>` case under both `EnumStorage.AsInteger` and `AsString`, the empty-result case, plus two guards that the paths which already worked keep working: `HashSet<string>` through the same parser (it must *not* start going through `EnumIsOneOfWhereFragment`), and the array/List shapes.

Three of the five fail on master with the `InvalidCastException` above; all five pass with the fix.

Full `LinqTests` green on both TFMs run separately: 1458 on net9.0 and 1458 on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)