### PR TITLE
Pass raw values to MatchesJsonPath parameters instead of CommandParameter wrappers

### DIFF
--- a/src/LinqTests/Acceptance/matches_sql_queries.cs
+++ b/src/LinqTests/Acceptance/matches_sql_queries.cs
@@ -37,6 +37,35 @@ public class matches_sql_queries: IntegrationContext
     }
 
     [Fact]
+    public async Task query_using_matches_json_path_with_parameters()
+    {
+        var user1 = new User { UserName = "foo" };
+        var user2 = new User { UserName = "bar" };
+        var user3 = new User { UserName = "baz" };
+
+        using var session = theStore.LightweightSession();
+        session.Store(user1, user2, user3);
+        await session.SaveChangesAsync();
+
+        // The JSONPath itself travels as a bound parameter rather than being concatenated into the
+        // SQL, which is the reason to reach for the overload that takes them.
+        (await session.Query<User>()
+                .Where(x => x.MatchesJsonPath("d.data @? ^::jsonpath", "$ ? (@.UserName == \"baz\")"))
+                .Select(x => x.UserName)
+                .ToListAsync())
+            .ShouldHaveTheSameElementsAs("baz");
+
+        // More than one, to prove the parameters are not transposed or reused.
+        (await session.Query<User>()
+                .Where(x => x.MatchesJsonPath("d.data @? ^::jsonpath or d.data @? ^::jsonpath",
+                    "$ ? (@.UserName == \"baz\")", "$ ? (@.UserName == \"foo\")"))
+                .OrderBy(x => x.UserName)
+                .Select(x => x.UserName)
+                .ToListAsync())
+            .ShouldHaveTheSameElementsAs("baz", "foo");
+    }
+
+    [Fact]
     public async Task query_using_where_fragment()
     {
         var user1 = new User { UserName = "foo" };

--- a/src/Marten/Linq/MatchesSql/MatchesSqlParser.cs
+++ b/src/Marten/Linq/MatchesSql/MatchesSqlParser.cs
@@ -68,7 +68,10 @@ public class MatchesJsonPathParser: IMethodCallParser
     public ISqlFragment Parse(IQueryableMemberCollection memberCollection, IReadOnlyStoreOptions options,
         MethodCallExpression expression)
     {
-        var arguments = expression.Arguments[2].Value().As<object[]>().Select(x => new CommandParameter(x)).ToArray();
+        // The raw values, not CommandParameter wrappers. LiteralSqlWithJsonPath assigns each element
+        // straight to NpgsqlParameter.Value, so wrapping here made Npgsql try to write a
+        // CommandParameter into a text parameter and throw.
+        var arguments = expression.Arguments[2].Value().As<object[]>();
 
         return new LiteralSqlWithJsonPath(expression.Arguments[1].Value().As<string>(), arguments);
     }


### PR DESCRIPTION
The parameterised `MatchesJsonPath(sql, params object[])` overload cannot be used at all. Any call throws:

```
System.InvalidCastException : Writing values of 'Weasel.Postgresql.SqlGeneration.CommandParameter'
is not supported for parameters having NpgsqlDbType 'Text'.
```

## Cause

`MatchesJsonPathParser.Parse` wraps each argument:

```csharp
var arguments = expression.Arguments[2].Value().As<object[]>()
    .Select(x => new CommandParameter(x)).ToArray();
```

but `LiteralSqlWithJsonPath.Apply` assigns each element straight to the parameter value:

```csharp
parameters[i].Value = _parameters[i];   // a CommandParameter, never unwrapped
```

so Npgsql receives a `CommandParameter` where it expects the value. `MatchesSqlParser` passes the raw `object[]` through for exactly this reason; this makes the JSONPath variant match.

## Why it went unnoticed

`Bug_3087_using_JsonPath_with_MatchesSql` only exercises `MatchesJsonPath` with the JSONPath written as a literal inside the SQL string. The overload that takes parameters has no coverage, so the broken path is never executed.

This PR adds `query_using_matches_json_path_with_parameters` to `matches_sql_queries`, covering one parameter and two, the second to show the parameters are neither transposed nor reused.

Verified by mutation: with the fix reverted the new test fails with the exception above; with it applied all four tests in the class pass.

## How I hit it

Building field filtering for the public delivery API in [barakoCMS](https://github.com/BaryoDev/barakoCMS), a .NET headless CMS on Marten. Content lives in a JSONB bag, so a filter like `?filter[price][lte]=500` becomes a JSONPath predicate. The field name is validated against the content type's schema first, but the **value** is caller-supplied, so it has to travel as a bound parameter rather than be concatenated into the SQL.

That left no usable option. `MatchesSql` uses `?` as its placeholder, which collides with the `@?` JSONPath operator, and `MatchesJsonPath` exists to resolve exactly that but throws when given parameters. The remaining route is string concatenation, which reintroduces the injection surface the parameterised form exists to close, so the work is parked: [BaryoDev/barakoCMS#140](https://github.com/BaryoDev/barakoCMS/issues/140).

Note for anyone landing here from a search: the parameter still needs a cast, `d.data @? ^::jsonpath`, since `jsonb @? text` is not an operator. That part is Postgres, not Marten, and the new test shows the working shape.