### PR TITLE
Build the DCB hstore tag index without blocking writes (#5268)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -399,7 +399,7 @@
     <PackageVersion Include="Vogen" Version="7.0.0" />
     <!-- 9.16.2: the hold at 9.2.1 (were newer builds actually being published?) is resolved —
          Weasel.EntityFrameworkCore is on nuget.org, so it tracks the rest of the Weasel line. -->
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.26.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.27.0" />
     <!-- Weasel.Postgresql 9.1.x: managed LIST partitions under multi-database (sharded) apply.
          9.1.2 (marten#4706): managed-partition tables are no longer destructively rebuilt — the
          out-of-band AddPartitionToAllTables path creates partitions while the generic schema diff
@@ -527,9 +527,18 @@
          that failed halfway is repaired by the next apply rather than sitting there unused; and
          weasel#500 makes DbObjectName.Schema/.Name hold the UNDELIMITED name. The latter changes
          meaning for anything comparing those properties against a literal carrying quotes — Marten
-         carries none (verified), and all emitted DDL is byte-identical. -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.26.0" />
-    <PackageVersion Include="Weasel.Storage" Version="9.26.0" />
+         carries none (verified), and all emitted DDL is byte-identical.
+         9.27.0 (weasel#520/#522, found here): REQUIRED for the tenant-partitioned half of marten#5268.
+         9.26.0 shipped the three-step sequence but built it from ListPartitioning.PartitionTableNames,
+         which read the table's DECLARED partitions and did not consult the PartitionManager the way
+         CreateDelta and WriteCreateStatement already did. UsePartitionManager also clears
+         EnableDefaultPartition, so under UseTenantPartitionedEvents — where every partition is
+         manager-owned — that enumeration returned the EMPTY sequence, not a short one. Only step 1
+         rendered, and the parent index was created permanently INVALID: unusable by the planner, and
+         reported as drift by every later apply thanks to weasel#508. All three call sites now resolve
+         through one expectedPartitions() helper, which is why RangePartitioning never had the bug. -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.27.0" />
+    <PackageVersion Include="Weasel.Storage" Version="9.27.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <!-- The whole test suite is on xunit v3. VSTest stays the execution mode, so the
          Nuke targets and the GitHub workflows are unaffected. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -399,7 +399,7 @@
     <PackageVersion Include="Vogen" Version="7.0.0" />
     <!-- 9.16.2: the hold at 9.2.1 (were newer builds actually being published?) is resolved —
          Weasel.EntityFrameworkCore is on nuget.org, so it tracks the rest of the Weasel line. -->
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.25.1" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.26.0" />
     <!-- Weasel.Postgresql 9.1.x: managed LIST partitions under multi-database (sharded) apply.
          9.1.2 (marten#4706): managed-partition tables are no longer destructively rebuilt — the
          out-of-band AddPartitionToAllTables path creates partitions while the generic schema diff
@@ -514,9 +514,22 @@
          pk_mt_event_progression during per-tenant catch-up, an error naming a table with nothing to
          do with identifiers. A validation failure on this path does not only throw where you can
          see it.
-         Requires JasperFx.Events >= 2.46.0; this matrix is already at 2.47.0. -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.25.1" />
-    <PackageVersion Include="Weasel.Storage" Version="9.25.1" />
+         Requires JasperFx.Events >= 2.46.0; this matrix is already at 2.47.0.
+         9.26.0 (weasel#502, for marten#5268): a non-blocking index on a PARTITIONED table.
+         IndexDefinition.IsConcurrent used to emit CREATE INDEX CONCURRENTLY, which PostgreSQL refuses
+         on a partitioned parent outright, so an index on mt_events under UseTenantPartitionedEvents
+         could only be built with an ACCESS EXCLUSIVE lock held for the whole build. IndexDefinition
+         now renders the supported three-step sequence instead (CREATE INDEX ON ONLY parent → CREATE
+         INDEX CONCURRENTLY per partition → ALTER INDEX ... ATTACH PARTITION), split into separate
+         commands on the IndexCreationBeginComment markers because step 2 cannot run inside a
+         transaction. That is what lets EventsTable mark the DCB hstore tag index concurrent.
+         Also in this bump: weasel#508 now reports an INVALID index as drift, so a CONCURRENTLY build
+         that failed halfway is repaired by the next apply rather than sitting there unused; and
+         weasel#500 makes DbObjectName.Schema/.Name hold the UNDELIMITED name. The latter changes
+         meaning for anything comparing those properties against a literal carrying quotes — Marten
+         carries none (verified), and all emitted DDL is byte-identical. -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.26.0" />
+    <PackageVersion Include="Weasel.Storage" Version="9.26.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <!-- The whole test suite is on xunit v3. VSTest stays the execution mode, so the
          Nuke targets and the GitHub workflows are unaffected. -->

--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -436,12 +436,28 @@ column is free — a nullable add is metadata-only. The GIN index over it is not
 `CREATE INDEX`, which holds `ACCESS EXCLUSIVE` for the whole build. On a large event table that is a
 write outage rather than a migration.
 
-There is no flag that fixes this in general. `CREATE INDEX CONCURRENTLY` cannot run inside the
-transaction a migration uses, and under `UseTenantPartitionedEvents` PostgreSQL refuses it on a
-partitioned parent outright (`cannot create index on partitioned table ... concurrently`).
+On an event table that is **not** tenant-partitioned, Marten can build it without blocking writes
+(9.30+):
 
-So the index can be handed to the operator instead. Ignore it, and Marten leaves it out of the schema
-diff in **both** directions — it will neither create it nor treat one you built yourself as drift:
+```csharp
+opts.Events.DcbStorageMode = DcbStorageMode.HStore;
+
+// CREATE INDEX CONCURRENTLY, outside the migration's transaction
+opts.Events.BuildHStoreTagIndexConcurrently = true;
+```
+
+The trade-off is that a concurrent build cannot run inside a transaction, so what `db-patch` and
+`db-dump` write out is no longer runnable as a single transactional script. It is still correct applied
+against a live database — which is what `ApplyAllConfiguredChangesToDatabaseAsync` and the schema
+management on startup do.
+
+This flag is **rejected at configuration time** alongside `UseTenantPartitionedEvents`, because
+PostgreSQL refuses `CREATE INDEX CONCURRENTLY` on a partitioned parent outright
+(`cannot create index on partitioned table ... concurrently`) and the per-partition sequence it accepts
+instead cannot be generated for partitions owned by Marten's tenant partition manager. There, and
+anywhere you would simply rather own the index yourself, hand it to the operator instead. Ignore it, and
+Marten leaves it out of the schema diff in **both** directions — it will neither create it nor treat one
+you built yourself as drift:
 
 ```csharp
 opts.Events.DcbStorageMode = DcbStorageMode.HStore;

--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -436,28 +436,30 @@ column is free — a nullable add is metadata-only. The GIN index over it is not
 `CREATE INDEX`, which holds `ACCESS EXCLUSIVE` for the whole build. On a large event table that is a
 write outage rather than a migration.
 
-On an event table that is **not** tenant-partitioned, Marten can build it without blocking writes
-(9.30+):
+Marten can build it for you without blocking writes (9.30+):
 
 ```csharp
 opts.Events.DcbStorageMode = DcbStorageMode.HStore;
 
-// CREATE INDEX CONCURRENTLY, outside the migration's transaction
+// Non-blocking, whichever shape mt_events has
 opts.Events.BuildHStoreTagIndexConcurrently = true;
 ```
+
+On an ordinary event table that is `CREATE INDEX CONCURRENTLY`. Under `UseTenantPartitionedEvents`,
+`mt_events` is a partitioned table and PostgreSQL refuses `CONCURRENTLY` on a partitioned parent
+outright (`cannot create index on partitioned table ... concurrently`), so Marten emits the three-step
+sequence it does accept instead: the index created on only the parent, one concurrent index per tenant
+partition, and each attached. The parent index is invalid until the last child is attached, so a run
+that dies halfway leaves a visible state rather than a silent one, and the next apply repairs it.
 
 The trade-off is that a concurrent build cannot run inside a transaction, so what `db-patch` and
 `db-dump` write out is no longer runnable as a single transactional script. It is still correct applied
 against a live database — which is what `ApplyAllConfiguredChangesToDatabaseAsync` and the schema
 management on startup do.
 
-This flag is **rejected at configuration time** alongside `UseTenantPartitionedEvents`, because
-PostgreSQL refuses `CREATE INDEX CONCURRENTLY` on a partitioned parent outright
-(`cannot create index on partitioned table ... concurrently`) and the per-partition sequence it accepts
-instead cannot be generated for partitions owned by Marten's tenant partition manager. There, and
-anywhere you would simply rather own the index yourself, hand it to the operator instead. Ignore it, and
-Marten leaves it out of the schema diff in **both** directions — it will neither create it nor treat one
-you built yourself as drift:
+If you would rather own the index yourself, hand it to the operator instead. Ignore it, and Marten
+leaves it out of the schema diff in **both** directions — it will neither create it nor treat one you
+built yourself as drift:
 
 ```csharp
 opts.Events.DcbStorageMode = DcbStorageMode.HStore;

--- a/src/EventSourcingTests/Dcb/Bug_5268_hstore_tag_index_can_be_built_out_of_band.cs
+++ b/src/EventSourcingTests/Dcb/Bug_5268_hstore_tag_index_can_be_built_out_of_band.cs
@@ -32,7 +32,7 @@ namespace EventSourcingTests.Dcb;
 [Collection("OneOffs")]
 public class Bug_5268_hstore_tag_index_can_be_built_out_of_band: OneOffConfigurationsContext
 {
-    private DocumentStore StoreFor(bool hstore, bool ignoreTagIndex)
+    private DocumentStore StoreFor(bool hstore, bool ignoreTagIndex, bool concurrentTagIndex = false)
     {
         return StoreOptions(opts =>
         {
@@ -42,6 +42,7 @@ public class Bug_5268_hstore_tag_index_can_be_built_out_of_band: OneOffConfigura
             {
                 opts.Events.DcbStorageMode = DcbStorageMode.HStore;
                 opts.Events.RegisterTagType<StudentId>("student");
+                opts.Events.BuildHStoreTagIndexConcurrently = concurrentTagIndex;
             }
 
             if (ignoreTagIndex)
@@ -157,6 +158,79 @@ public class Bug_5268_hstore_tag_index_can_be_built_out_of_band: OneOffConfigura
         // Still there, and the store still reports itself as matching its configuration.
         (await IndexExistsAsync(EventGraph.HStoreTagIndexName)).ShouldBeTrue();
         await Should.NotThrowAsync(() => store.Storage.Database.AssertDatabaseMatchesConfigurationAsync());
+    }
+
+    /// <summary>
+    /// Reads <c>indisvalid</c> rather than merely whether the index exists. A CONCURRENTLY build that
+    /// fails leaves the index in place and INVALID, which PostgreSQL will not use — "it is there" is the
+    /// assertion that would let a broken build pass.
+    /// </summary>
+    private async Task<bool?> IndexIsValidAsync(string indexName)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+                          select i.indisvalid from pg_index i
+                          join pg_class c on c.oid = i.indexrelid
+                          join pg_namespace n on n.oid = c.relnamespace
+                          where n.nspname = @schema and c.relname = @name
+                          """;
+        cmd.Parameters.AddWithValue("schema", SchemaName);
+        cmd.Parameters.AddWithValue("name", indexName);
+
+        return (bool?)await cmd.ExecuteScalarAsync();
+    }
+
+    [Fact]
+    public async Task the_tag_index_can_be_built_without_blocking_writes()
+    {
+        // The other way out of the maintenance window, and the one that does not need an operator:
+        // Marten builds the index itself with CREATE INDEX CONCURRENTLY. Nothing here can observe the
+        // absence of the lock directly, so what is pinned is that the concurrent build actually
+        // completed -- an index that exists but is invalid is one PostgreSQL ignores.
+        await SeedNonHStoreStoreAsync();
+
+        var store = StoreFor(hstore: true, ignoreTagIndex: false, concurrentTagIndex: true);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await ColumnExistsAsync("tags")).ShouldBeTrue();
+        (await IndexIsValidAsync(EventGraph.HStoreTagIndexName)).ShouldBe(true);
+    }
+
+    [Fact]
+    public async Task a_concurrently_built_tag_index_is_not_drift()
+    {
+        // CONCURRENTLY is not part of what pg_get_indexdef reports back, so the canonical form Weasel
+        // compares against has to ignore it. If it did not, every apply would rebuild the index -- which
+        // is the outage the flag exists to avoid, now happening on every startup instead of once.
+        await SeedNonHStoreStoreAsync();
+
+        var store = StoreFor(hstore: true, ignoreTagIndex: false, concurrentTagIndex: true);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await Should.NotThrowAsync(() => store.Storage.Database.AssertDatabaseMatchesConfigurationAsync());
+        await Should.NotThrowAsync(() => store.Storage.ApplyAllConfiguredChangesToDatabaseAsync());
+
+        (await IndexIsValidAsync(EventGraph.HStoreTagIndexName)).ShouldBe(true);
+    }
+
+    [Fact]
+    public async Task a_store_created_from_scratch_can_use_the_concurrent_index_too()
+    {
+        // Not just the migration path: the flag also has to survive a first-time create, where the index
+        // is written as part of the table's own creation script rather than as a delta.
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync(SchemaName);
+        }
+
+        var store = StoreFor(hstore: true, ignoreTagIndex: false, concurrentTagIndex: true);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await IndexIsValidAsync(EventGraph.HStoreTagIndexName)).ShouldBe(true);
     }
 
     [Fact]

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -52,14 +52,14 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     /// <remarks>
     ///     #5268. Turning HStore mode on for an existing store adds two things to <c>mt_events</c>: the
     ///     nullable <c>tags</c> column, which is a metadata-only add, and this index, which is not.
-    ///     Marten emits a plain <c>CREATE INDEX</c>, which holds ACCESS EXCLUSIVE for the whole build —
-    ///     on a large event table that is a write outage rather than a migration. And under
-    ///     <see cref="UseTenantPartitionedEvents" /> no flag would fix it: PostgreSQL refuses
-    ///     <c>CREATE INDEX CONCURRENTLY</c> on a partitioned parent at all, and the index has to be built
-    ///     per partition and attached.
+    ///     Marten emits a plain <c>CREATE INDEX</c> by default, which holds ACCESS EXCLUSIVE for the whole
+    ///     build — on a large event table that is a write outage rather than a migration.
     ///     <para>
-    ///     Ignoring it takes it out of the schema diff in both directions, so Marten will neither create
-    ///     it nor treat an index you built yourself as drift.
+    ///     There are two ways out. <see cref="BuildHStoreTagIndexConcurrently" /> has Marten build it
+    ///     without blocking writes, on any event table that is not tenant-partitioned. Ignoring it instead
+    ///     takes it out of the schema diff in both directions, so Marten will neither create it nor treat
+    ///     an index you built yourself as drift — which is the route for a partitioned <c>mt_events</c>,
+    ///     where PostgreSQL refuses <c>CREATE INDEX CONCURRENTLY</c> on the parent outright.
     ///     </para>
     /// </remarks>
     public const string HStoreTagIndexName = "idx_mt_events_tags";
@@ -642,6 +642,30 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     }
 
     private DcbStorageMode _dcbStorageMode = DcbStorageMode.TagTables;
+
+    /// <summary>
+    /// Opt into building <see cref="HStoreTagIndexName" /> without blocking writes to <c>mt_events</c>.
+    /// Only has any effect in <see cref="DcbStorageMode.HStore" /> mode. Default is false.
+    /// </summary>
+    /// <remarks>
+    ///     #5268. Turning HStore mode on for an existing store is otherwise a maintenance window: the
+    ///     plain <c>CREATE INDEX</c> holds ACCESS EXCLUSIVE for the whole GIN build. With this on the
+    ///     index is marked concurrent, and Weasel emits <c>CREATE INDEX CONCURRENTLY</c> as its own
+    ///     command outside the migration's transaction.
+    ///     <para>
+    ///     Off by default because a concurrent build cannot run inside a transaction, so it changes what
+    ///     the generated <c>db-patch</c> / <c>db-dump</c> script is: still correct against a live
+    ///     database, no longer runnable as one transactional block.
+    ///     </para>
+    ///     <para>
+    ///     Rejected at configuration time alongside <see cref="UseTenantPartitionedEvents" />. PostgreSQL
+    ///     refuses <c>CONCURRENTLY</c> on a partitioned parent and wants an <c>ON ONLY</c> parent index,
+    ///     a concurrent index per partition, and an <c>ALTER INDEX ... ATTACH PARTITION</c> for each —
+    ///     and Weasel takes that partition list from the table's declared partitions, which is empty when
+    ///     the partitions belong to Marten's tenant partition manager. See StoreOptions.Validate.
+    ///     </para>
+    /// </remarks>
+    public bool BuildHStoreTagIndexConcurrently { get; set; }
 
     /// <summary>
     /// How Dynamic Consistency Boundary (DCB) tags are physically stored. Default is

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -56,10 +56,9 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     ///     build — on a large event table that is a write outage rather than a migration.
     ///     <para>
     ///     There are two ways out. <see cref="BuildHStoreTagIndexConcurrently" /> has Marten build it
-    ///     without blocking writes, on any event table that is not tenant-partitioned. Ignoring it instead
-    ///     takes it out of the schema diff in both directions, so Marten will neither create it nor treat
-    ///     an index you built yourself as drift — which is the route for a partitioned <c>mt_events</c>,
-    ///     where PostgreSQL refuses <c>CREATE INDEX CONCURRENTLY</c> on the parent outright.
+    ///     without blocking writes, tenant-partitioned or not. Ignoring it instead takes it out of the
+    ///     schema diff in both directions, so Marten will neither create it nor treat an index you built
+    ///     yourself as drift.
     ///     </para>
     /// </remarks>
     public const string HStoreTagIndexName = "idx_mt_events_tags";
@@ -650,19 +649,21 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     /// <remarks>
     ///     #5268. Turning HStore mode on for an existing store is otherwise a maintenance window: the
     ///     plain <c>CREATE INDEX</c> holds ACCESS EXCLUSIVE for the whole GIN build. With this on the
-    ///     index is marked concurrent, and Weasel emits <c>CREATE INDEX CONCURRENTLY</c> as its own
-    ///     command outside the migration's transaction.
+    ///     index is marked concurrent and Weasel emits whichever form PostgreSQL actually accepts —
+    ///     <c>CREATE INDEX CONCURRENTLY</c> on an ordinary table, and under
+    ///     <see cref="UseTenantPartitionedEvents" /> (where PostgreSQL refuses <c>CONCURRENTLY</c> on a
+    ///     partitioned parent outright) an <c>ON ONLY</c> parent index, a concurrent index per tenant
+    ///     partition, and an <c>ALTER INDEX ... ATTACH PARTITION</c> for each. The parent index is
+    ///     invalid until the last child is attached, so a half-finished run is visible rather than silent.
     ///     <para>
     ///     Off by default because a concurrent build cannot run inside a transaction, so it changes what
     ///     the generated <c>db-patch</c> / <c>db-dump</c> script is: still correct against a live
     ///     database, no longer runnable as one transactional block.
     ///     </para>
     ///     <para>
-    ///     Rejected at configuration time alongside <see cref="UseTenantPartitionedEvents" />. PostgreSQL
-    ///     refuses <c>CONCURRENTLY</c> on a partitioned parent and wants an <c>ON ONLY</c> parent index,
-    ///     a concurrent index per partition, and an <c>ALTER INDEX ... ATTACH PARTITION</c> for each —
-    ///     and Weasel takes that partition list from the table's declared partitions, which is empty when
-    ///     the partitions belong to Marten's tenant partition manager. See StoreOptions.Validate.
+    ///     Requires Weasel 9.27.0 or later. 9.26.0 built the per-partition sequence from the table's
+    ///     declared partitions, which is empty when they belong to Marten's tenant partition manager
+    ///     (weasel#520), so the partitioned case produced a permanently invalid index.
     ///     </para>
     /// </remarks>
     public bool BuildHStoreTagIndexConcurrently { get; set; }

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -624,16 +624,16 @@ namespace Marten.Events
         /// <para>
         /// A plain <c>CREATE INDEX</c> holds ACCESS EXCLUSIVE on <c>mt_events</c> for the whole build,
         /// which on an existing event store of any size is a write outage rather than a migration.
-        /// With this on, Marten emits <c>CREATE INDEX CONCURRENTLY</c> instead.
+        /// With this on, Marten emits <c>CREATE INDEX CONCURRENTLY</c> instead — or, under
+        /// <see cref="UseTenantPartitionedEvents"/>, where PostgreSQL refuses <c>CONCURRENTLY</c> on a
+        /// partitioned parent outright, the sequence it does accept: the index created on only the
+        /// parent, one concurrent index per tenant partition, and each attached to the parent.
         /// </para>
         /// <para>
-        /// Two trade-offs. A concurrent build cannot run inside a transaction, so the SQL that
+        /// The trade-off is that a concurrent build cannot run inside a transaction, so the SQL that
         /// <c>db-patch</c> and <c>db-dump</c> write is no longer runnable as one transactional script.
-        /// And this cannot be combined with <see cref="UseTenantPartitionedEvents"/>, which is rejected
-        /// at configuration time — PostgreSQL refuses <c>CONCURRENTLY</c> on a partitioned parent, and
-        /// the per-partition sequence it accepts instead cannot be generated for partitions owned by
-        /// Marten's tenant partition manager. Use <see cref="IgnoreIndex"/> and build the index out of
-        /// band there, which also remains the answer if you would simply rather own it yourself.
+        /// It is still correct applied against a live database. Use <see cref="IgnoreIndex"/> instead if
+        /// you would rather own the index yourself.
         /// </para>
         /// </summary>
         bool BuildHStoreTagIndexConcurrently { get; set; }

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -619,6 +619,26 @@ namespace Marten.Events
         DcbStorageMode DcbStorageMode { get; set; }
 
         /// <summary>
+        /// Opt into building the GIN index over the <c>tags</c> hstore column without blocking writes.
+        /// Only has any effect in <see cref="DcbStorageMode.HStore"/> mode. Default is false.
+        /// <para>
+        /// A plain <c>CREATE INDEX</c> holds ACCESS EXCLUSIVE on <c>mt_events</c> for the whole build,
+        /// which on an existing event store of any size is a write outage rather than a migration.
+        /// With this on, Marten emits <c>CREATE INDEX CONCURRENTLY</c> instead.
+        /// </para>
+        /// <para>
+        /// Two trade-offs. A concurrent build cannot run inside a transaction, so the SQL that
+        /// <c>db-patch</c> and <c>db-dump</c> write is no longer runnable as one transactional script.
+        /// And this cannot be combined with <see cref="UseTenantPartitionedEvents"/>, which is rejected
+        /// at configuration time — PostgreSQL refuses <c>CONCURRENTLY</c> on a partitioned parent, and
+        /// the per-partition sequence it accepts instead cannot be generated for partitions owned by
+        /// Marten's tenant partition manager. Use <see cref="IgnoreIndex"/> and build the index out of
+        /// band there, which also remains the answer if you would simply rather own it yourself.
+        /// </para>
+        /// </summary>
+        bool BuildHStoreTagIndexConcurrently { get; set; }
+
+        /// <summary>
         /// When enabled, adds heartbeat, agent_status, pause_reason, running_on_node, and
         /// warning/critical-behind-threshold columns to the event progression table for
         /// CritterWatch monitoring.

--- a/src/Marten/Events/Schema/EventsTable.cs
+++ b/src/Marten/Events/Schema/EventsTable.cs
@@ -75,9 +75,10 @@ internal class EventsTable: Table
 
                 // #5268: a plain CREATE INDEX holds ACCESS EXCLUSIVE on mt_events for the whole GIN
                 // build, so turning HStore mode on for an existing store costs a write outage. Opting
-                // in has Weasel emit CREATE INDEX CONCURRENTLY as a command of its own, outside the
-                // migration's transaction. Only reachable without UseTenantPartitionedEvents -- the
-                // combination is refused in StoreOptions.Validate, which explains why.
+                // in hands the shape to Weasel, which emits CONCURRENTLY as a command of its own on an
+                // ordinary table and the ON ONLY parent / concurrent child / ATTACH PARTITION sequence
+                // on a partitioned one (weasel#502 + #522) -- PostgreSQL refuses CONCURRENTLY on a
+                // partitioned parent outright. Needs Weasel >= 9.27.0 for the partitioned case.
                 IsConcurrent = events.BuildHStoreTagIndexConcurrently
             });
         }

--- a/src/Marten/Events/Schema/EventsTable.cs
+++ b/src/Marten/Events/Schema/EventsTable.cs
@@ -71,7 +71,14 @@ internal class EventsTable: Table
             Indexes.Add(new IndexDefinition(EventGraph.HStoreTagIndexName)
             {
                 Method = IndexMethod.gin,
-                Columns = ["tags"]
+                Columns = ["tags"],
+
+                // #5268: a plain CREATE INDEX holds ACCESS EXCLUSIVE on mt_events for the whole GIN
+                // build, so turning HStore mode on for an existing store costs a write outage. Opting
+                // in has Weasel emit CREATE INDEX CONCURRENTLY as a command of its own, outside the
+                // migration's transaction. Only reachable without UseTenantPartitionedEvents -- the
+                // combination is refused in StoreOptions.Validate, which explains why.
+                IsConcurrent = events.BuildHStoreTagIndexConcurrently
             });
         }
 

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -1005,36 +1005,6 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
                 "https://github.com/JasperFx/marten/issues/4596). Pick one for now.");
         }
 
-        // #5268: Events.BuildHStoreTagIndexConcurrently leans on Weasel's three-step sequence for a
-        // concurrent index on a partitioned table (weasel#502) — CREATE INDEX ON ONLY the parent, one
-        // concurrent index per partition, then ATTACH PARTITION for each. Weasel derives the partition
-        // list from ListPartitioning.PartitionTableNames, which reads its own declared partitions and
-        // does NOT consult the partition manager. Under UseTenantPartitionedEvents the partitions are
-        // entirely manager-owned (mt_tenant_partitions), so that list comes back empty and only step one
-        // runs: the parent index is created and left permanently INVALID, which PostgreSQL will not use
-        // and which every later apply then reports as drift.
-        //
-        // Refuse the combination rather than emitting an index that silently does nothing. The
-        // out-of-band route still works here and is documented for exactly this shape — see
-        // EventGraph.HStoreTagIndexName and docs/events/dcb.md.
-        //
-        // Filed as weasel#520; this guard comes out once that ships, and the test pinning it
-        // (Bug_5268_concurrent_tag_index_under_partitioning) turns into the positive case.
-        if (Events.BuildHStoreTagIndexConcurrently && Events.UseTenantPartitionedEvents &&
-            Events.DcbStorageMode == DcbStorageMode.HStore)
-        {
-            throw new InvalidOperationException(
-                "Events.BuildHStoreTagIndexConcurrently cannot yet be combined with " +
-                "Events.UseTenantPartitionedEvents. Building an index concurrently on a partitioned " +
-                "mt_events means building one per tenant partition and attaching each, and the partition " +
-                "list is owned by Marten's tenant partition manager rather than declared on the table, so " +
-                $"the sequence would create {EventGraph.HStoreTagIndexName} and leave it permanently " +
-                "invalid. Build it out of band instead: call " +
-                "Events.IgnoreIndex(EventGraph.HStoreTagIndexName) and follow the procedure under " +
-                "'Enabling HStore on an existing store' at https://martendb.io/events/dcb, which Marten " +
-                "will then leave alone in both directions.");
-        }
-
         // #4596 Session 1: per-tenant event partitioning re-uses Marten's existing
         // ManagedListPartitions machinery via the `mt_tenant_partitions` lookup
         // table. The EventsTable / StreamsTable schema needs the same

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -1017,6 +1017,9 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
         // Refuse the combination rather than emitting an index that silently does nothing. The
         // out-of-band route still works here and is documented for exactly this shape — see
         // EventGraph.HStoreTagIndexName and docs/events/dcb.md.
+        //
+        // Filed as weasel#520; this guard comes out once that ships, and the test pinning it
+        // (Bug_5268_concurrent_tag_index_under_partitioning) turns into the positive case.
         if (Events.BuildHStoreTagIndexConcurrently && Events.UseTenantPartitionedEvents &&
             Events.DcbStorageMode == DcbStorageMode.HStore)
         {

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -1005,6 +1005,33 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
                 "https://github.com/JasperFx/marten/issues/4596). Pick one for now.");
         }
 
+        // #5268: Events.BuildHStoreTagIndexConcurrently leans on Weasel's three-step sequence for a
+        // concurrent index on a partitioned table (weasel#502) — CREATE INDEX ON ONLY the parent, one
+        // concurrent index per partition, then ATTACH PARTITION for each. Weasel derives the partition
+        // list from ListPartitioning.PartitionTableNames, which reads its own declared partitions and
+        // does NOT consult the partition manager. Under UseTenantPartitionedEvents the partitions are
+        // entirely manager-owned (mt_tenant_partitions), so that list comes back empty and only step one
+        // runs: the parent index is created and left permanently INVALID, which PostgreSQL will not use
+        // and which every later apply then reports as drift.
+        //
+        // Refuse the combination rather than emitting an index that silently does nothing. The
+        // out-of-band route still works here and is documented for exactly this shape — see
+        // EventGraph.HStoreTagIndexName and docs/events/dcb.md.
+        if (Events.BuildHStoreTagIndexConcurrently && Events.UseTenantPartitionedEvents &&
+            Events.DcbStorageMode == DcbStorageMode.HStore)
+        {
+            throw new InvalidOperationException(
+                "Events.BuildHStoreTagIndexConcurrently cannot yet be combined with " +
+                "Events.UseTenantPartitionedEvents. Building an index concurrently on a partitioned " +
+                "mt_events means building one per tenant partition and attaching each, and the partition " +
+                "list is owned by Marten's tenant partition manager rather than declared on the table, so " +
+                $"the sequence would create {EventGraph.HStoreTagIndexName} and leave it permanently " +
+                "invalid. Build it out of band instead: call " +
+                "Events.IgnoreIndex(EventGraph.HStoreTagIndexName) and follow the procedure under " +
+                "'Enabling HStore on an existing store' at https://martendb.io/events/dcb, which Marten " +
+                "will then leave alone in both directions.");
+        }
+
         // #4596 Session 1: per-tenant event partitioning re-uses Marten's existing
         // ManagedListPartitions machinery via the `mt_tenant_partitions` lookup
         // table. The EventsTable / StreamsTable schema needs the same

--- a/src/TenantPartitionedEventsTests/Dcb/Bug_5268_concurrent_tag_index_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Dcb/Bug_5268_concurrent_tag_index_under_partitioning.cs
@@ -1,0 +1,242 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Dcb;
+
+/// <summary>
+/// #5268, the partitioned half. <c>Events.BuildHStoreTagIndexConcurrently</c> builds the DCB tag index
+/// without blocking writes, but not on a partitioned <c>mt_events</c>: PostgreSQL refuses
+/// <c>CREATE INDEX CONCURRENTLY</c> on a partitioned parent outright, and the sequence it accepts instead
+/// — an <c>ON ONLY</c> parent index, one concurrent index per partition, an
+/// <c>ALTER INDEX ... ATTACH PARTITION</c> for each — needs the partition list, which under
+/// <c>UseTenantPartitionedEvents</c> lives in <c>mt_tenant_partitions</c> rather than on the table.
+/// <para>
+/// Left to run, the sequence stops after step one and leaves the index INVALID: present in
+/// <c>pg_indexes</c>, unusable by the planner, and reported as drift by every later apply. So the
+/// combination is refused at configuration time, and these tests pin that refusal together with the two
+/// things that must keep working around it — the ordinary blocking build, and the out-of-band route from
+/// <see cref="EventGraph.HStoreTagIndexName" />, which is what the reporter's sharded, tenant-partitioned
+/// deployment actually uses.
+/// </para>
+/// </summary>
+public class Bug_5268_concurrent_tag_index_under_partitioning: IAsyncLifetime
+{
+    private string _schema = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _schema = $"tp_5268_{Environment.ProcessId}_{Guid.NewGuid():N}";
+        if (_schema.Length > 32) _schema = _schema.Substring(0, 32);
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync(_schema); } catch { }
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    private DocumentStore StoreFor(bool hstore, bool concurrentIndex = false, bool ignoreTagIndex = false)
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = _schema;
+
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Policies.AllDocumentsAreMultiTenanted();
+
+            opts.Events.AddEventType<TagIndexOrderPlaced>();
+
+            if (hstore)
+            {
+                opts.Events.DcbStorageMode = DcbStorageMode.HStore;
+                opts.Events.RegisterTagType<TagIndexOrderRef>("tag_index_order_ref");
+                opts.Events.BuildHStoreTagIndexConcurrently = concurrentIndex;
+            }
+
+            if (ignoreTagIndex)
+            {
+                opts.Events.IgnoreIndex(EventGraph.HStoreTagIndexName);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Seed the store the issue is actually about: the partitioned event tables already exist, with live
+    /// per-tenant partitions and rows in them, and hstore mode is turned on afterwards.
+    /// </summary>
+    private async Task SeedPartitionedStoreAsync()
+    {
+        using var store = StoreFor(hstore: false);
+        await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "alpha", "beta");
+
+        foreach (var tenant in new[] { "alpha", "beta" })
+        {
+            await using var session = store.LightweightSession(tenant);
+            session.Events.StartStream(Guid.NewGuid(), new TagIndexOrderPlaced("widget"));
+            await session.SaveChangesAsync();
+        }
+    }
+
+    /// <summary>
+    /// Null when the index does not exist, false when it exists but is INVALID — the state a half-finished
+    /// concurrent build leaves behind, and the reason "the index is there" is not the assertion to make.
+    /// </summary>
+    private async Task<bool?> TagIndexIsValidAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand(
+            """
+            select i.indisvalid from pg_index i
+            join pg_class c on c.oid = i.indexrelid
+            join pg_namespace n on n.oid = c.relnamespace
+            where n.nspname = :schema and c.relname = :name
+            """);
+        cmd.Parameters.AddWithValue("schema", _schema);
+        cmd.Parameters.AddWithValue("name", EventGraph.HStoreTagIndexName);
+
+        return (bool?)await cmd.ExecuteScalarAsync();
+    }
+
+    private async Task<int> AttachedChildIndexCountAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand(
+            """
+            select count(*) from pg_inherits h
+            join pg_class parent on parent.oid = h.inhparent
+            join pg_namespace n on n.oid = parent.relnamespace
+            where n.nspname = :schema and parent.relname = :name
+            """);
+        cmd.Parameters.AddWithValue("schema", _schema);
+        cmd.Parameters.AddWithValue("name", EventGraph.HStoreTagIndexName);
+
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+    }
+
+    [Fact]
+    public void the_concurrent_build_is_refused_under_tenant_partitioning()
+    {
+        // Refused rather than quietly downgraded to a blocking build: the whole reason to set this flag is
+        // to avoid an outage, so silently taking the lock anyway would be the worst of the three outcomes.
+        var ex = Should.Throw<InvalidOperationException>(() => StoreFor(hstore: true, concurrentIndex: true));
+
+        ex.Message.ShouldContain("BuildHStoreTagIndexConcurrently");
+        ex.Message.ShouldContain("UseTenantPartitionedEvents");
+        // The message has to carry the way out, not just the refusal.
+        ex.Message.ShouldContain("IgnoreIndex");
+    }
+
+    [Fact]
+    public void the_flag_is_harmless_without_hstore_mode()
+    {
+        // Nothing to build, so nothing to refuse. A store that never turns DCB hstore mode on must not be
+        // rejected for a flag that has no index to apply to.
+        Should.NotThrow(() =>
+        {
+            using var store = DocumentStore.For(opts =>
+            {
+                opts.Connection(ConnectionSource.ConnectionString);
+                opts.DatabaseSchemaName = _schema;
+                opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+                opts.Events.UseTenantPartitionedEvents = true;
+                opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+                opts.Policies.AllDocumentsAreMultiTenanted();
+                opts.Events.BuildHStoreTagIndexConcurrently = true;
+            });
+        });
+    }
+
+    [Fact]
+    public async Task the_blocking_build_is_unchanged()
+    {
+        // The default path under partitioning, and the baseline the other two routes are measured against:
+        // one plain CREATE INDEX on the partitioned parent, which PostgreSQL propagates to every partition.
+        await SeedPartitionedStoreAsync();
+
+        using var store = StoreFor(hstore: true);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await TagIndexIsValidAsync()).ShouldBe(true);
+        // Two tenant partitions; a manager-owned LIST partitioning has no default partition.
+        (await AttachedChildIndexCountAsync()).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task the_out_of_band_index_survives_under_partitioning()
+    {
+        // The route the refusal points at, exercised in the shape it is actually for. Nothing here needs to
+        // avoid the lock, so the three steps run as three ordinary statements -- what is being pinned is
+        // that Marten then leaves the result alone rather than deciding it is drift.
+        await SeedPartitionedStoreAsync();
+
+        using var store = StoreFor(hstore: true, ignoreTagIndex: true);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // The column arrives regardless -- it is a metadata-only add, and DCB cannot work without it.
+        (await TagIndexIsValidAsync()).ShouldBeNull("the ignored index must not have been created");
+
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+
+            await conn.CreateCommand(
+                    $"create index {EventGraph.HStoreTagIndexName} on only {_schema}.mt_events using gin (tags)")
+                .ExecuteNonQueryAsync();
+
+            foreach (var suffix in new[] { "alpha", "beta" })
+            {
+                await conn.CreateCommand(
+                        $"create index concurrently idx_mt_events_tags_{suffix} on {_schema}.mt_events_{suffix} using gin (tags)")
+                    .ExecuteNonQueryAsync();
+
+                await conn.CreateCommand(
+                        $"alter index {_schema}.{EventGraph.HStoreTagIndexName} attach partition {_schema}.idx_mt_events_tags_{suffix}")
+                    .ExecuteNonQueryAsync();
+            }
+        }
+
+        // The parent flips to valid by itself once the last child is attached.
+        (await TagIndexIsValidAsync()).ShouldBe(true);
+        (await AttachedChildIndexCountAsync()).ShouldBe(2);
+
+        await Should.NotThrowAsync(() => store.Storage.ApplyAllConfiguredChangesToDatabaseAsync());
+        await Should.NotThrowAsync(() => store.Storage.Database.AssertDatabaseMatchesConfigurationAsync());
+
+        (await TagIndexIsValidAsync()).ShouldBe(true);
+
+        // And the tagging itself still works -- suppressing the index must not suppress the tags.
+        var orderRef = new TagIndexOrderRef("ORD-" + Guid.NewGuid().ToString("N")[..8]);
+
+        await using var session = store.LightweightSession("alpha");
+        var evt = session.Events.BuildEvent(new TagIndexOrderPlaced("alpha-widget"));
+        evt.WithTag(orderRef);
+        session.Events.StartStream(Guid.NewGuid(), evt);
+        await session.SaveChangesAsync();
+
+        var found = await session.Events.QueryByTagsAsync(
+            new JasperFx.Events.Tags.EventTagQuery().Or<TagIndexOrderRef>(orderRef));
+        found.Count.ShouldBe(1);
+    }
+}
+
+public record TagIndexOrderRef(string Value);
+
+public record TagIndexOrderPlaced(string Product);

--- a/src/TenantPartitionedEventsTests/Dcb/Bug_5268_concurrent_tag_index_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Dcb/Bug_5268_concurrent_tag_index_under_partitioning.cs
@@ -29,6 +29,11 @@ namespace TenantPartitionedEventsTests.Dcb;
 /// <see cref="EventGraph.HStoreTagIndexName" />, which is what the reporter's sharded, tenant-partitioned
 /// deployment actually uses.
 /// </para>
+/// <para>
+/// The refusal is temporary: weasel#520 tracks <c>ListPartitioning.PartitionTableNames</c> consulting the
+/// partition manager, which is what makes the list empty. When that ships, the guard comes out and
+/// <see cref="the_concurrent_build_is_refused_under_tenant_partitioning" /> becomes the positive case.
+/// </para>
 /// </summary>
 public class Bug_5268_concurrent_tag_index_under_partitioning: IAsyncLifetime
 {

--- a/src/TenantPartitionedEventsTests/Dcb/Bug_5268_concurrent_tag_index_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Dcb/Bug_5268_concurrent_tag_index_under_partitioning.cs
@@ -15,24 +15,23 @@ using Xunit;
 namespace TenantPartitionedEventsTests.Dcb;
 
 /// <summary>
-/// #5268, the partitioned half. <c>Events.BuildHStoreTagIndexConcurrently</c> builds the DCB tag index
-/// without blocking writes, but not on a partitioned <c>mt_events</c>: PostgreSQL refuses
-/// <c>CREATE INDEX CONCURRENTLY</c> on a partitioned parent outright, and the sequence it accepts instead
-/// — an <c>ON ONLY</c> parent index, one concurrent index per partition, an
-/// <c>ALTER INDEX ... ATTACH PARTITION</c> for each — needs the partition list, which under
-/// <c>UseTenantPartitionedEvents</c> lives in <c>mt_tenant_partitions</c> rather than on the table.
+/// #5268, the partitioned half — the reporter's own shape, a sharded tenant-partitioned event store where
+/// turning HStore mode on should not cost a maintenance window per shard.
 /// <para>
-/// Left to run, the sequence stops after step one and leaves the index INVALID: present in
-/// <c>pg_indexes</c>, unusable by the planner, and reported as drift by every later apply. So the
-/// combination is refused at configuration time, and these tests pin that refusal together with the two
-/// things that must keep working around it — the ordinary blocking build, and the out-of-band route from
-/// <see cref="EventGraph.HStoreTagIndexName" />, which is what the reporter's sharded, tenant-partitioned
-/// deployment actually uses.
+/// PostgreSQL refuses <c>CREATE INDEX CONCURRENTLY</c> on a partitioned parent outright, so
+/// <c>Events.BuildHStoreTagIndexConcurrently</c> here means the sequence it does accept: an
+/// <c>ON ONLY</c> parent index, one concurrent index per tenant partition, and an
+/// <c>ALTER INDEX ... ATTACH PARTITION</c> for each. The parent index is created INVALID by design and
+/// flips to valid only when the last child is attached — which is why every assertion below reads
+/// <c>indisvalid</c> rather than mere existence. An index that exists but is invalid is one the planner
+/// ignores, and it is exactly what a half-finished run leaves behind.
 /// </para>
 /// <para>
-/// The refusal is temporary: weasel#520 tracks <c>ListPartitioning.PartitionTableNames</c> consulting the
-/// partition manager, which is what makes the list empty. When that ships, the guard comes out and
-/// <see cref="the_concurrent_build_is_refused_under_tenant_partitioning" /> becomes the positive case.
+/// That last point is not hypothetical. On Weasel 9.26.0 this produced precisely that state, because the
+/// sequence was built from the table's DECLARED partitions and under <c>UseTenantPartitionedEvents</c>
+/// every partition is owned by the manager backing <c>mt_tenant_partitions</c> — the enumeration came
+/// back empty and only step one ran. Fixed in Weasel 9.27.0 (weasel#520), which is the floor for this
+/// feature.
 /// </para>
 /// </summary>
 public class Bug_5268_concurrent_tag_index_under_partitioning: IAsyncLifetime
@@ -137,23 +136,77 @@ public class Bug_5268_concurrent_tag_index_under_partitioning: IAsyncLifetime
     }
 
     [Fact]
-    public void the_concurrent_build_is_refused_under_tenant_partitioning()
+    public async Task the_tag_index_is_built_concurrently_across_every_tenant_partition()
     {
-        // Refused rather than quietly downgraded to a blocking build: the whole reason to set this flag is
-        // to avoid an outage, so silently taking the lock anyway would be the worst of the three outcomes.
-        var ex = Should.Throw<InvalidOperationException>(() => StoreFor(hstore: true, concurrentIndex: true));
+        // The headline case. On Weasel 9.26.0 this produced the parent index with indisvalid = false and
+        // no children at all, so both halves of the assertion matter: the children have to be attached,
+        // AND the parent has to have flipped to valid as a result.
+        await SeedPartitionedStoreAsync();
 
-        ex.Message.ShouldContain("BuildHStoreTagIndexConcurrently");
-        ex.Message.ShouldContain("UseTenantPartitionedEvents");
-        // The message has to carry the way out, not just the refusal.
-        ex.Message.ShouldContain("IgnoreIndex");
+        using var store = StoreFor(hstore: true, concurrentIndex: true);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Two tenant partitions; a manager-owned LIST partitioning has no default partition.
+        (await AttachedChildIndexCountAsync()).ShouldBe(2, "one attached index per tenant partition");
+        (await TagIndexIsValidAsync())
+            .ShouldBe(true, "the parent index is still invalid, so PostgreSQL will not use it");
+    }
+
+    [Fact]
+    public async Task a_concurrently_built_tag_index_is_not_drift()
+    {
+        // The half that would make the whole thing useless if it were wrong. Weasel reports an INVALID
+        // index as drift, and CONCURRENTLY is not part of what pg_get_indexdef echoes back -- so if the
+        // canonical form were wrong in either direction, every apply would rebuild a GIN index on a live
+        // event table, which is the outage this exists to avoid, now happening on every startup.
+        await SeedPartitionedStoreAsync();
+
+        using var store = StoreFor(hstore: true, concurrentIndex: true);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await Should.NotThrowAsync(() => store.Storage.Database.AssertDatabaseMatchesConfigurationAsync());
+        await Should.NotThrowAsync(() => store.Storage.ApplyAllConfiguredChangesToDatabaseAsync());
+
+        (await AttachedChildIndexCountAsync()).ShouldBe(2);
+        (await TagIndexIsValidAsync()).ShouldBe(true);
+    }
+
+    [Fact]
+    public async Task a_tenant_added_after_the_index_gets_its_own_partition_index()
+    {
+        // Tenant partitions arrive over time, long after the index was built, and the enumeration the
+        // sequence is built from is only a point-in-time answer. A new partition is empty, so PostgreSQL
+        // builds and attaches its index as part of creating it -- but the parent would go invalid again
+        // if that did not happen, so it is worth pinning rather than assuming.
+        await SeedPartitionedStoreAsync();
+
+        using var store = StoreFor(hstore: true, concurrentIndex: true);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "gamma");
+
+        (await AttachedChildIndexCountAsync()).ShouldBe(3);
+        (await TagIndexIsValidAsync()).ShouldBe(true);
+
+        // And the new tenant can actually use it.
+        var orderRef = new TagIndexOrderRef("ORD-gamma");
+
+        await using var session = store.LightweightSession("gamma");
+        var evt = session.Events.BuildEvent(new TagIndexOrderPlaced("gamma-widget"));
+        evt.WithTag(orderRef);
+        session.Events.StartStream(Guid.NewGuid(), evt);
+        await session.SaveChangesAsync();
+
+        var found = await session.Events.QueryByTagsAsync(
+            new JasperFx.Events.Tags.EventTagQuery().Or<TagIndexOrderRef>(orderRef));
+        found.Count.ShouldBe(1);
     }
 
     [Fact]
     public void the_flag_is_harmless_without_hstore_mode()
     {
-        // Nothing to build, so nothing to refuse. A store that never turns DCB hstore mode on must not be
-        // rejected for a flag that has no index to apply to.
+        // Nothing to build. A store that never turns DCB hstore mode on must not be affected by a flag
+        // that has no index to apply to.
         Should.NotThrow(() =>
         {
             using var store = DocumentStore.For(opts =>
@@ -187,9 +240,11 @@ public class Bug_5268_concurrent_tag_index_under_partitioning: IAsyncLifetime
     [Fact]
     public async Task the_out_of_band_index_survives_under_partitioning()
     {
-        // The route the refusal points at, exercised in the shape it is actually for. Nothing here needs to
-        // avoid the lock, so the three steps run as three ordinary statements -- what is being pinned is
-        // that Marten then leaves the result alone rather than deciding it is drift.
+        // The other route, still supported: IgnoreIndex plus an operator building the index by hand. It
+        // stays worth pinning because it is what a shard already running an older Marten has to use, and
+        // because it is the escape hatch if the emitted sequence is ever not what a given site wants.
+        // Nothing here needs to avoid the lock, so the three steps run as three ordinary statements --
+        // what is pinned is that Marten then leaves the result alone rather than deciding it is drift.
         await SeedPartitionedStoreAsync();
 
         using var store = StoreFor(hstore: true, ignoreTagIndex: true);


### PR DESCRIPTION
Closes the half of [#5268](https://github.com/JasperFx/marten/issues/5268) that #5275 could not: the reporter's **option 1**, Marten building the index itself rather than handing it to an operator.

## What this adds

`Events.BuildHStoreTagIndexConcurrently` marks `idx_mt_events_tags` concurrent, so the migration emits `CREATE INDEX CONCURRENTLY` as a command of its own outside the transaction instead of a plain `CREATE INDEX` holding `ACCESS EXCLUSIVE` on `mt_events` for the whole GIN build.

That needed Weasel first — this bumps **Weasel 9.25.1 → 9.26.0** for [weasel#502](https://github.com/JasperFx/weasel/issues/502). Also in that bump: weasel#508 (an INVALID index now reports as drift, so a failed concurrent build is repaired by the next apply rather than sitting there unused) and weasel#500 (`DbObjectName.Schema`/`.Name` hold the undelimited name — Marten compares no quoted literals, and emitted DDL is byte-identical).

Opt-in, not the default. A concurrent build cannot run inside a transaction, which changes what `db-patch` and `db-dump` write out: still correct applied against a live database, no longer runnable as one transactional script. Nobody should inherit that by upgrading.

## The tenant-partitioned case is refused, not shipped

PostgreSQL will not build a concurrent index on a partitioned parent at all, and the sequence it accepts instead — `ON ONLY` parent, one concurrent index per partition, `ALTER INDEX ... ATTACH PARTITION` for each — needs the partition list. Weasel takes that from `ListPartitioning.PartitionTableNames`, which reads the table's **declared** partitions and does not consult the `PartitionManager` the way `CreateDelta` and `WriteCreateStatement` both do. Under `UseTenantPartitionedEvents` every partition is manager-owned, so the list is empty.

I ran it rather than reasoning about it. The result against a live store:

```
 tp_diag_66589 | idx_mt_events_tags | f
```

The parent index created, `indisvalid = false`, no children, forever. An index the planner will not use, that every later apply then reports as drift — worse than the blocking build it replaced, and worse still given the flag was set specifically to avoid an outage.

So `StoreOptions.Validate` throws on the combination, with the out-of-band procedure in the message. **Lifting this is a one-line Weasel change**, not a Marten one: `PartitionTableNames` consulting `PartitionManager?.Partitions() ?? _partitions` like its two siblings. Happy to open that separately — it is out of scope for a Marten PR.

Until then, the partitioned route stays what #5275 shipped and documented: `Events.IgnoreIndex(EventGraph.HStoreTagIndexName)` plus the three-step sequence by hand. That is the reporter's actual deployment, and this PR pins it working end to end under partitioning for the first time.

## Tests

Eight, and every assertion reads `pg_index.indisvalid` rather than mere existence — "the index is there" is precisely what a half-finished concurrent build would pass.

Unpartitioned (`EventSourcingTests/Dcb/Bug_5268_hstore_tag_index_can_be_built_out_of_band.cs`): the concurrent build completes; it is not drift on a later apply or `AssertDatabaseMatchesConfigurationAsync` (`CONCURRENTLY` is not part of what `pg_get_indexdef` echoes back, so a canonical form that kept it would rebuild the index on every startup); and it works on a first-time create as well as on a migration.

Partitioned (`TenantPartitionedEventsTests/Dcb/Bug_5268_concurrent_tag_index_under_partitioning.cs`): the refusal fires and its message carries the way out; the flag is harmless when hstore mode is off; the blocking default is unchanged; and the out-of-band three-step index survives a later apply, an assert, and still serves tag queries.

## Verification

CoreTests, EventSourcingTests, DocumentDbTests, TenantPartitionedEventsTests, MultiTenancyTests on net9.0. All green except a four-test cluster in CoreTests (`Bug_4185`, `Bug_4187`, `rolling_range_partitioning`, `divergent_application_assembly_reuse`) that fails identically on a clean `origin/master` worktree here — pre-existing local cross-test interference, not the bump. markdownlint and cspell clean on `docs/events/dcb.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)