### PR TITLE
Type and count the MatchesJsonPath parameters (#5289 follow-up)

### DIFF
--- a/src/LinqTests/Acceptance/matches_sql_queries.cs
+++ b/src/LinqTests/Acceptance/matches_sql_queries.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Marten.Exceptions;
 using Marten.Linq.MatchesSql;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
@@ -63,6 +64,78 @@ public class matches_sql_queries: IntegrationContext
                 .Select(x => x.UserName)
                 .ToListAsync())
             .ShouldHaveTheSameElementsAs("baz", "foo");
+    }
+
+    /// <summary>
+    /// #5289 follow-up. The overload takes <c>params object[]</c>, so a caller may reasonably pass
+    /// anything; the fix that made it usable at all only covered strings, because
+    /// <c>AppendWithParameters</c> seeds each placeholder with the provider's STRING parameter type and
+    /// assigning <c>.Value</c> alone leaves it there. A number therefore still failed with the same
+    /// exception the fix was for.
+    /// </summary>
+    [Fact]
+    public async Task query_using_matches_json_path_with_a_non_string_parameter()
+    {
+        var user1 = new User { UserName = "foo", Age = 30 };
+        var user2 = new User { UserName = "bar", Age = 60 };
+
+        using var session = theStore.LightweightSession();
+        session.Store(user1, user2);
+        await session.SaveChangesAsync();
+
+        // The value bound on its own, into a JSONPath variable rather than into the path text -- the
+        // shape a caller-supplied filter value has to take if it is not to be concatenated in.
+        (await session.Query<User>()
+                .Where(x => x.MatchesJsonPath(
+                    "jsonb_path_exists(d.data, '$ ? (@.Age <= $v)', jsonb_build_object('v', ^))", 30))
+                .Select(x => x.UserName)
+                .ToListAsync())
+            .ShouldHaveTheSameElementsAs("foo");
+    }
+
+    /// <summary>
+    /// #5289 follow-up. <c>CommandParameter</c> maps null onto <c>DBNull.Value</c>, which is why
+    /// <c>MatchesSql</c> accepts a null argument. Assigning the raw value overwrote the
+    /// <c>DBNull.Value</c> that <c>AppendWithParameters</c> had already put there, and Npgsql refuses a
+    /// CLR null outright.
+    /// </summary>
+    [Fact]
+    public async Task query_using_matches_json_path_with_a_null_parameter()
+    {
+        using var session = theStore.LightweightSession();
+        session.Store(new User { UserName = "foo" });
+        await session.SaveChangesAsync();
+
+        // NULL::jsonpath matches nothing rather than throwing, which is the point: a null filter value
+        // should return no rows, not take the query down.
+        (await session.Query<User>()
+                .Where(x => x.MatchesJsonPath("d.data @? ^::jsonpath", new object[] { null }))
+                .ToListAsync())
+            .ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// #5289 follow-up. '^' is the placeholder character for this overload and is also a regex anchor,
+    /// so it turns up inside JSONPath literals by accident — <c>like_regex "^ba"</c> is one stray
+    /// placeholder. That used to surface as an IndexOutOfRangeException thrown from inside the LINQ
+    /// provider, and in the opposite direction (more values than placeholders) as silence, with the
+    /// surplus values never reaching the query at all.
+    /// </summary>
+    [Fact]
+    public async Task mismatched_json_path_placeholder_count_is_reported()
+    {
+        using var session = theStore.LightweightSession();
+
+        var tooFew = await Should.ThrowAsync<BadLinqExpressionException>(() => session.Query<User>()
+            .Where(x => x.MatchesJsonPath("d.data @? '$ ? (@.UserName like_regex \"^ba\")'"))
+            .ToListAsync());
+
+        tooFew.Message.ShouldContain("0 parameter(s)");
+        tooFew.Message.ShouldContain("1 '^' placeholder(s)");
+
+        await Should.ThrowAsync<BadLinqExpressionException>(() => session.Query<User>()
+            .Where(x => x.MatchesJsonPath("d.data @? ^::jsonpath", "$ ? (@.UserName == \"baz\")", "spare"))
+            .ToListAsync());
     }
 
     [Fact]

--- a/src/Marten/Linq/MatchesSql/MatchesSqlParser.cs
+++ b/src/Marten/Linq/MatchesSql/MatchesSqlParser.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JasperFx.Core.Reflection;
+using Marten.Exceptions;
 using Marten.Linq.Members;
 using Marten.Linq.Parsing;
 using Weasel.Postgresql;
@@ -68,9 +69,7 @@ public class MatchesJsonPathParser: IMethodCallParser
     public ISqlFragment Parse(IQueryableMemberCollection memberCollection, IReadOnlyStoreOptions options,
         MethodCallExpression expression)
     {
-        // The raw values, not CommandParameter wrappers. LiteralSqlWithJsonPath assigns each element
-        // straight to NpgsqlParameter.Value, so wrapping here made Npgsql try to write a
-        // CommandParameter into a text parameter and throw.
+        // Raw values, matching MatchesSqlParser. LiteralSqlWithJsonPath accepts either shape.
         var arguments = expression.Arguments[2].Value().As<object[]>();
 
         return new LiteralSqlWithJsonPath(expression.Arguments[1].Value().As<string>(), arguments);
@@ -91,9 +90,37 @@ internal class LiteralSqlWithJsonPath : ISqlFragment
     public void Apply(ICommandBuilder builder)
     {
         var parameters = builder.AppendWithParameters(_sql, '^');
+
+        if (parameters.Length != _parameters.Length)
+        {
+            // #5289 follow-up. Otherwise this is an IndexOutOfRangeException from inside the LINQ
+            // provider, or -- worse, when there are more values than placeholders -- silence, with
+            // the surplus values simply never reaching the query. The '^' is easy to get wrong
+            // because it is also a regex anchor, so it appears inside JSONPath literals by accident.
+            throw new BadLinqExpressionException(
+                $"MatchesJsonPath was given {_parameters.Length} parameter(s) but the SQL has {parameters.Length} '^' placeholder(s). "
+                + "Note that '^' is the placeholder character for this overload, so a '^' inside a JSONPath literal "
+                + "(a like_regex anchor, for instance) counts as one. SQL: " + _sql);
+        }
+
         for (var i = 0; i < parameters.Length; i++)
         {
-            parameters[i].Value = _parameters[i];
+            // #5289 follow-up: mirrors CustomizableWhereFragment.Apply, which is what MatchesSql uses.
+            // AppendWithParameters seeds every placeholder with DBNull.Value and the provider's STRING
+            // parameter type, because at that point it has no idea what is going into it. Assigning
+            // only .Value leaves NpgsqlDbType at Text, so any non-string argument threw
+            // "Writing values of 'System.Int32' is not supported for parameters having NpgsqlDbType
+            // 'Text'" -- the same failure #5289 set out to fix -- and a null argument overwrote the
+            // seeded DBNull with a CLR null, which Npgsql rejects outright.
+            //
+            // The unwrap keeps a caller-built CommandParameter working, so both shapes are accepted
+            // and this does not depend on what MatchesJsonPathParser.Parse happens to hand over.
+            var commandParameter = _parameters[i] as CommandParameter ?? new CommandParameter(_parameters[i]);
+            parameters[i].Value = commandParameter.Value;
+            if (commandParameter.DbType.HasValue)
+            {
+                parameters[i].NpgsqlDbType = commandParameter.DbType.Value;
+            }
         }
     }
 }


### PR DESCRIPTION
Follow-up to [#5289](https://github.com/JasperFx/marten/pull/5289) (merged as `632773b87`). That PR diagnosed the parameterised `MatchesJsonPath` overload correctly but fixed it at the wrong end, so the overload is still unusable for anything but a string.

## What is still broken on master

`AppendWithParameters` seeds every placeholder with `DBNull.Value` and the provider's **string** parameter type — at that point it has no idea what will go into the slot. `LiteralSqlWithJsonPath.Apply` assigns only `.Value`, so `NpgsqlDbType` stays `Text`:

```csharp
.Where(x => x.MatchesJsonPath(
    "jsonb_path_exists(d.data, '$ ? (@.Age <= $v)', jsonb_build_object('v', ^))", 30))
```

```
System.InvalidCastException : Writing values of 'System.Int32' is not supported for
parameters having NpgsqlDbType 'Text'.
```

That is the same exception #5289 set out to remove, and the numeric-filter case (`?filter[price][lte]=500`) its description gives as the motivation.

A null argument is worse than doing nothing — the assignment overwrites the `DBNull.Value` that was already seeded:

```
System.InvalidOperationException : Parameter '' cannot be null, DBNull.Value should be used instead.
```

`MatchesSql` has neither problem, because `CustomizableWhereFragment.Apply` unwraps-or-wraps into a `CommandParameter` and applies its `DbType` over the placeholder type. This does the same three lines. Since it unwraps as well as wraps it accepts either shape, so it no longer depends on what the parser happens to hand over — the parser change from #5289 stays, but is now belt-and-braces rather than load-bearing.

## Also: count the placeholders

`^` was chosen for this overload because `?` collides with the `@?` JSONPath operator. But `^` is a regex anchor, so it lands inside JSONPath literals by accident — `like_regex "^ba"` is one stray placeholder — and that surfaced as an `IndexOutOfRangeException` thrown from inside the LINQ provider, with no indication of what was wrong. In the other direction there was no error at all: surplus values were silently dropped and the query ran without them.

Both now throw `BadLinqExpressionException` naming both counts and the reason `^` is easy to get wrong.

## Tests

Three, in `matches_sql_queries`, each run against the merged behaviour first to confirm it fails there: a number bound into a JSONPath variable, a null that should return no rows rather than take the query down, and both directions of the count mismatch. The two tests #5289 added keep passing. Full LinqTests green on net9.0.

## Not addressed

There is still no way to *use* a `^` inside a JSONPath literal. `MatchesSql` solves this with an overload taking the placeholder character; the same could be added here, but that is new public API rather than a fix, so it wants its own decision rather than riding along in a follow-up.

Separately, on the security question that prompted this review: the values are genuinely bound. The emitted SQL is `... where d.data @? :p0::jsonpath` and an injection payload passed as a parameter never reaches the SQL text. The `sql` argument itself is raw and concatenated verbatim, by design and the same as `MatchesSql` — worth a line in the XML docs, given closing that surface is this overload's whole purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)