### PR TITLE
Bump to JasperFx 2.56.0 (#5294)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -317,16 +317,41 @@
          breaking change to every existing Marten listener, and putting it on ISessionWorkTracker
          would additionally rope in ProjectionUpdateBatch, whose Inserted/Updated/Deleted all throw
          NotSupportedException. See DocumentCommitListenerAdapter/MartenDocumentChangeSet and
-         StoreOptions.AddCommitListener, pinned by DocumentCommitListenerCompliance. -->
-    <PackageVersion Include="JasperFx" Version="2.53.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.53.0" />
+         StoreOptions.AddCommitListener, pinned by DocumentCommitListenerCompliance.
+         JasperFx 2.56.0 (marten#5294): three async-daemon high-water fixes, all reachable on Marten
+         under load, and none of which need a Marten-side change.
+         jasperfx#702 (contributed by the reporter of marten#5267/#5268, from a deployment running
+         2,173 tenants over 512 shard databases): a tenant agent seeded BELOW its own committed
+         position threw, went to ReportCriticalFailureAsync, and Paused — and nothing restarts a
+         paused agent under a node-distributed daemon, so one momentarily missing per-tenant ceiling
+         took a tenant's projection out until the next deployment. The seed is now clamped to the
+         committed position with a warning; nothing is replayed or skipped, because loading only ever
+         starts above LastCommitted.
+         jasperfx#709 is the one to remember, because it is NOT tenancy-specific: HighWaterAgent set
+         IsRunning BEFORE the Detect() it exists to gate, so a second concurrent StartAgentAsync
+         skipped priming and read Tracker.HighWaterMark while it was still 0. A plain catch-up shard
+         self-heals on the next mark; SubscribeFromPresent does not, because it resolves "present" to
+         the mark it is handed and REWRITES the progression row to it. That is the shape behind an
+         unexplained Paused shard after a rollout.
+         jasperfx#710: per-tenant catch-up and rebuild used Activate, which a concurrent
+         reconciliation could drop, and then skipped that tenant's work silently.
+         Also here: EventStoreExplorerCompliance gains usage_describes_the_registered_projections
+         (jasperfx#700), a new requirement on every store running the suite. Marten passes unchanged —
+         DocumentStore.EventStore.cs already calls Options.Projections.Describe(usage, this) — so this
+         is a regression guard rather than a fix. It is the ONLY test the bump adds or removes;
+         verified by diffing the discovered test list against master, not by comparing run totals.
+         Inert for Marten: the Event Model provenance ladder (jasperfx#703/#704) only affects hosts
+         registering an IEventModelDefinitionSource, which Marten does not, and
+         RetryBlock.ShouldRetry/OnTerminalFailure (jasperfx#701) are additive and default to null. -->
+    <PackageVersion Include="JasperFx" Version="2.56.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.56.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.53.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.56.0" />
     <!--
       Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
       the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
@@ -344,11 +369,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.53.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.56.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.53.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.56.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Closes [#5294](https://github.com/JasperFx/marten/issues/5294). One PR, as asked: the version bump and the compliance side together.

Master pinned `2.53.0` (the issue says 2.52.0 — it moved in the meantime), so this spans 2.54, 2.55 and 2.56. All five JasperFx entries move together: `JasperFx`, `JasperFx.Events`, `JasperFx.Events.ComplianceTests`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator`.

## The substantive half — async daemon high water

Three fixes, all reachable on Marten under load, **none of which need a Marten-side change**:

- **jasperfx#702** — a tenant agent seeded below its own committed position threw → `ReportCriticalFailureAsync` → `Paused`, and nothing restarts a paused agent under a node-distributed daemon. One momentarily missing per-tenant ceiling took a tenant's projection out until the next deployment. Now clamped with a warning; nothing replayed or skipped, since loading only ever starts above `LastCommitted`.
- **jasperfx#709** — the one to remember, because it is *not* tenancy-specific. `HighWaterAgent` set `IsRunning` **before** the `Detect()` it exists to gate, so a second concurrent `StartAgentAsync` read `Tracker.HighWaterMark` at 0. A plain catch-up shard self-heals on the next mark; `SubscribeFromPresent` does not, because it resolves "present" to the mark it is handed and **rewrites the progression row** to it. That is the shape behind an unexplained `Paused` shard after a rollout.
- **jasperfx#710** — per-tenant catch-up and rebuild used `Activate`, which a concurrent reconciliation could drop, and then skipped that tenant's work in silence.

## The compliance half

`EventStoreExplorerCompliance` gains `usage_describes_the_registered_projections` (jasperfx#700). **Marten passes unchanged** — `DocumentStore.EventStore.cs` already calls `Options.Projections.Describe(usage, this)` — so it is a regression guard, not a fix request. All 37 suites stay enrolled; 2.54 through 2.56 added no new suite to adopt.

One methodological note, because it nearly went the other way. The `EventSourcingTests` **run total** dropped between the branches I was comparing, which looks exactly like a suite quietly losing tests. It wasn't — the branches differed for unrelated reasons. Diffing the *discovered test list* against master gives the real answer:

```
565a566
> EventSourcingTests.Compliance.event_store_explorer_compliance.usage_describes_the_registered_projections
```

Exactly one test added, none removed. Run totals are not a safe way to check this; the list is.

## Verification

net9.0: **EventSourcingTests** (which carries the compliance enrollments), **DaemonTests** and **TenantPartitionedEventsTests** all green — the last two being where the daemon fixes would show if they regressed anything. CoreTests shows only the same four failures (`Bug_4185`, `Bug_4187`, `rolling_range_partitioning`, `divergent_application_assembly_reuse`) that a clean `origin/master` worktree shows on this machine.

Inert for Marten and not exercised here: the Event Model provenance ladder (jasperfx#703/#704) only affects hosts registering an `IEventModelDefinitionSource`, which Marten does not, and `RetryBlock.ShouldRetry` / `OnTerminalFailure` (jasperfx#701) are additive with null defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)