### PR TITLE
Refresh duplicated columns for the patches that actually move them (#5295)

### DIFF
--- a/src/Marten/Patching/PatchOperation.cs
+++ b/src/Marten/Patching/PatchOperation.cs
@@ -197,10 +197,7 @@ internal class PatchOperation: StatementOperation, NoDataReturnedCall
             return;
         }
 
-        // Get the paths being modified by this patch operation
-        var modifiedPaths = _patchSet
-            .Select(patch => patch.Items["path"].ToString())
-            .ToHashSet(System.StringComparer.Ordinal);
+        var modifiedPaths = collectModifiedPaths();
 
         // Only update duplicated fields where their mapping path is affected by the patch path
         var affectedFields = fields.Where(f => IsFieldAffectedByPatchPath(f, modifiedPaths)).ToList();
@@ -225,10 +222,71 @@ internal class PatchOperation: StatementOperation, NoDataReturnedCall
         writeWhereClause(builder);
     }
 
+    /// <summary>
+    /// Every JSON location this patch set writes to, in the same form <c>PatchExpression.toPath</c> emits.
+    /// </summary>
+    /// <remarks>
+    /// #5295: "path" is not the only place a patch writes. A <c>duplicate</c> carries its destinations in
+    /// "targets", and a <c>rename</c> puts the value at a sibling of "path" named by "to" — a duplicated
+    /// column over either location went stale because neither was ever considered.
+    /// </remarks>
+    private HashSet<string> collectModifiedPaths()
+    {
+        var paths = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var patch in _patchSet)
+        {
+            if (!patch.Items.TryGetValue("path", out var raw) || raw?.ToString() is not { } path) continue;
+
+            paths.Add(path);
+
+            if (patch.Items.TryGetValue("targets", out var targets) && targets is IEnumerable<string> destinations)
+            {
+                foreach (var destination in destinations) paths.Add(destination);
+            }
+
+            if (patch.Items.TryGetValue("to", out var to) && to?.ToString() is { Length: > 0 } newName)
+            {
+                var lastSeparator = path.LastIndexOf('.');
+                paths.Add(lastSeparator < 0 ? newName : string.Concat(path.AsSpan(0, lastSeparator + 1), newName));
+            }
+        }
+
+        return paths;
+    }
+
     private bool IsFieldAffectedByPatchPath(IDuplicatedField field, HashSet<string> modifiedPaths)
     {
-        // get the dot seperated path derived from field Members info
-        var path = string.Join('.', field.Members.Select(x => x.Name.FormatCase(_serializer.Casing)));
-        return modifiedPaths.Any(p => p.StartsWith(path, StringComparison.Ordinal));
+        // #5290/#5295: ToJsonKey, not Name.FormatCase. PatchExpression.toPath resolves serializer member
+        // aliases, so on an aliased member the two disagreed -- the patch wrote "st" and this looked for
+        // "AliasedStatus", found no overlap, and left the duplicated column holding the old value while
+        // the document held the new one.
+        var path = string.Join('.', field.Members.Select(x => x.ToJsonKey(_serializer.Casing)));
+
+        return modifiedPaths.Any(p => pathsOverlap(path, p));
+    }
+
+    /// <summary>
+    /// True when writing <paramref name="patchPath" /> can change the value at <paramref name="fieldPath" />.
+    /// </summary>
+    /// <remarks>
+    /// #5295. Overlap runs in BOTH directions and only on a separator boundary. Patching a parent moves
+    /// everything beneath it, so <c>Set(x =&gt; x.Job, ...)</c> has to refresh a column duplicated from
+    /// <c>Job.Progress</c> — the previous one-way prefix test missed exactly that and left the column
+    /// stale. The boundary check is what stops <c>Status</c> and <c>StatusCode</c> from matching each
+    /// other, which the old test also got wrong, though only ever by doing harmless extra work.
+    /// </remarks>
+    private static bool pathsOverlap(string fieldPath, string patchPath)
+    {
+        if (fieldPath.Length == patchPath.Length)
+        {
+            return string.Equals(fieldPath, patchPath, StringComparison.Ordinal);
+        }
+
+        var (shorter, longer) = fieldPath.Length < patchPath.Length
+            ? (fieldPath, patchPath)
+            : (patchPath, fieldPath);
+
+        return longer.StartsWith(shorter, StringComparison.Ordinal) && longer[shorter.Length] == '.';
     }
 }

--- a/src/PatchingTests/Patching/Bug_5295_patch_updates_duplicated_columns.cs
+++ b/src/PatchingTests/Patching/Bug_5295_patch_updates_duplicated_columns.cs
@@ -1,0 +1,205 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Patching;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace PatchingTests.Patching;
+
+/// <summary>
+/// #5295. A patch that moves a value the schema also keeps in a <c>.Duplicate()</c> column has to refresh
+/// that column, or the document and the index that exists to search it disagree — <c>Load</c> returns the
+/// new value and <c>Query</c> filtered on the same member returns nothing, with no error and nothing in
+/// the row to show why.
+/// <para>
+/// Marten already did this for the straightforward case, so the issue's headline ("patches never update
+/// duplicated columns") is not what the code does: a patch whose path is exactly the duplicated member's
+/// has refreshed the column since #2995. What was broken is which patches counted as affecting a field —
+/// three separate gaps, each verified failing before the fix.
+/// </para>
+/// </summary>
+public class Bug_5295_patch_updates_duplicated_columns: OneOffConfigurationsContext
+{
+    // The schema name defaults to the class name and feeds every table, constraint and index name under
+    // it, so with a name this long a duplicated column's index runs past PostgreSQL's 63-character limit.
+    public Bug_5295_patch_updates_duplicated_columns() => _schemaName = "bug5295";
+
+    // Every test uses the SAME mapping, deliberately. OneOffConfigurationsContext gives the whole class
+    // one schema, so varying the duplicated columns per test leaves the table from the previous test in
+    // place and the next CREATE INDEX collides with 42P07.
+    private void ConfigureStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.UseSystemTextJsonForSerialization();
+
+            opts.Schema.For<Doc>()
+                .DocumentAlias("doc5295")
+                .Duplicate(x => x.Status)
+                .Duplicate(x => x.AliasedStatus)
+                .Duplicate(x => x.Copy)
+                .Duplicate(x => x.StatusCode)
+                .Duplicate(x => x.Job.Progress);
+        });
+    }
+
+    public class Doc
+    {
+        public Guid Id { get; set; }
+
+        public string Status { get; set; } = string.Empty;
+
+        [JsonPropertyName("st")]
+        public string AliasedStatus { get; set; } = string.Empty;
+
+        public JobState Job { get; set; } = new();
+
+        public string Copy { get; set; } = string.Empty;
+
+        // Deliberately a prefix-neighbour of Status: the old matching test was a bare StartsWith with no
+        // separator boundary, so these two overlapped each other.
+        public string StatusCode { get; set; } = string.Empty;
+    }
+
+    public class JobState
+    {
+        public int Progress { get; set; }
+    }
+
+    private async Task<Guid> SeedAsync(Action<Doc> configure)
+    {
+        var doc = new Doc { Id = Guid.NewGuid() };
+        configure(doc);
+
+        await using var session = theStore.LightweightSession();
+        session.Store(doc);
+        await session.SaveChangesAsync();
+
+        return doc.Id;
+    }
+
+    [Fact]
+    public async Task the_straightforward_case_already_worked()
+    {
+        // The issue's headline repro. Pinned as the baseline the three gaps below are measured against,
+        // and because a fix to the matching rule could easily break it.
+        ConfigureStore();
+        var id = await SeedAsync(d => d.Status = "open");
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Patch<Doc>(id).Set(x => x.Status, "done");
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            (await session.LoadAsync<Doc>(id))!.Status.ShouldBe("done");
+            (await session.Query<Doc>().Where(x => x.Status == "done").ToListAsync()).Count.ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public async Task an_aliased_member_is_matched_by_its_serialized_name()
+    {
+        // Gap 1, and a regression #5292 introduced. That PR made PatchExpression.toPath resolve serializer
+        // aliases, so the patch now correctly writes "st" -- but the affected-field test still computed
+        // "AliasedStatus" from the raw member name, found no overlap, and skipped the column refresh.
+        // Before #5292 the two agreed by both being wrong: the patch missed the aliased node as well, so
+        // document and column stayed consistent with each other while both ignored the patch.
+        ConfigureStore();
+        var id = await SeedAsync(d => d.AliasedStatus = "open");
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Patch<Doc>(id).Set(x => x.AliasedStatus, "done");
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            (await session.LoadAsync<Doc>(id))!.AliasedStatus.ShouldBe("done");
+            (await session.Query<Doc>().Where(x => x.AliasedStatus == "done").ToListAsync()).Count.ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public async Task patching_a_parent_refreshes_a_deeper_duplicated_column()
+    {
+        // Gap 2. The match was a one-way prefix test -- "does a patch path start with the field path" --
+        // so it saw a patch on Job.Progress affecting a column duplicated from Job, but not a patch on
+        // Job affecting a column duplicated from Job.Progress. Replacing the parent moves everything
+        // underneath it, so that is the direction that actually loses data from the index.
+        ConfigureStore();
+        var id = await SeedAsync(d => d.Job = new JobState { Progress = 1 });
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Patch<Doc>(id).Set(x => x.Job, new JobState { Progress = 42 });
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            (await session.LoadAsync<Doc>(id))!.Job.Progress.ShouldBe(42);
+            (await session.Query<Doc>().Where(x => x.Job.Progress == 42).ToListAsync()).Count.ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public async Task the_destination_of_a_duplicate_operation_is_refreshed()
+    {
+        // Gap 3. "path" is not the only place a patch writes: the patching API's own Duplicate copies a
+        // value to other locations, carried in "targets", and only "path" was ever collected. (Rename is
+        // the same shape, writing to a sibling named by "to".)
+        ConfigureStore();
+        var id = await SeedAsync(d =>
+        {
+            d.Status = "open";
+            d.Copy = "stale";
+        });
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Patch<Doc>(id).Duplicate(x => x.Status, x => x.Copy);
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            (await session.LoadAsync<Doc>(id))!.Copy.ShouldBe("open");
+            (await session.Query<Doc>().Where(x => x.Copy == "open").ToListAsync()).Count.ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public async Task a_prefix_neighbour_is_not_confused_for_the_duplicated_member()
+    {
+        // Status and StatusCode share a prefix. Under the old bare StartsWith they matched each other,
+        // which only ever cost a redundant column refresh -- but the boundary check that fixes gap 2 has
+        // to keep both columns correct rather than trading one bug for another.
+        ConfigureStore();
+        var id = await SeedAsync(d =>
+        {
+            d.Status = "open";
+            d.StatusCode = "A1";
+        });
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Patch<Doc>(id).Set(x => x.StatusCode, "B2");
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            (await session.Query<Doc>().Where(x => x.StatusCode == "B2").ToListAsync()).Count.ShouldBe(1);
+            (await session.Query<Doc>().Where(x => x.Status == "open").ToListAsync()).Count.ShouldBe(1);
+        }
+    }
+}


### PR DESCRIPTION
Fixes [#5295](https://github.com/JasperFx/marten/issues/5295).

First, a correction to the issue's premise, because it changes what the fix is. **Marten does not "never" update duplicated columns.** `PatchOperation.applyUpdates` has emitted a second `UPDATE` for affected duplicated columns since #2995, and the headline repro — `Duplicate(x => x.Status)` plus `Patch.Set(x => x.Status, "done")` — works on master today. There is a test in this PR pinning that, because it is the thing a change to the matching rule could most easily break.

What was wrong is **which patches counted as affecting a field**. Three gaps, each verified failing before the fix:

**1. An aliased member never matched — and that one is a regression from earlier today.** `IsFieldAffectedByPatchPath` built the field's path from raw member names with a casing transform. [#5292](https://github.com/JasperFx/marten/pull/5292) made `PatchExpression.toPath` resolve serializer aliases, so the patch now correctly writes `st` while this still looked for `AliasedStatus`, found no overlap, and skipped the refresh. Before #5292 the two agreed *by both being wrong* — the patch missed the aliased node too, so document and column stayed consistent with each other while both ignored the patch. This is exactly the blast-radius widening the issue predicted, though by a different mechanism than it guessed. Now uses `ToJsonKey`, the same resolution `toPath` and `QueryableMember` use.

**2. The overlap test only ran one way.** A patch on `Job.Progress` refreshed a column duplicated from `Job`, but a patch on `Job` did **not** refresh one duplicated from `Job.Progress`. Replacing a parent moves everything underneath it, so that is the direction that actually loses data from the index. Overlap now runs in both directions and only on a separator boundary — which also stops `Status` and `StatusCode` matching each other, something the bare `StartsWith` got wrong, though only ever by doing harmless extra work.

**3. `path` is not the only place a patch writes.** The patching API's own `Duplicate` copies a value to other locations, carried in `targets`, and `Rename` writes to a sibling named by `to`. Neither was collected, so a duplicated column over either destination kept its old value.

## On the issue's three options

This is option 1, and it turned out to be mostly already built — the machinery to derive the column from the patched `data` in SQL is `IDuplicatedField.UpdateSqlFragment()`, which is the same fragment used to backfill a column when one is first added to an existing table. So no throw (option 2) and no docs-only retreat (option 3) was needed for these cases.

Worth being explicit about what still is *not* covered, since the issue asked for a general answer: this refreshes a duplicated column whenever a patch writes at, above, or below its member. It does not attempt anything for a duplicated column whose value is not derivable from the JSONB by `UpdateSqlFragment` — there is no such case in the current `DuplicatedField`, but that is the boundary if one is ever added.

## Tests

Five, in `src/PatchingTests/Patching/Bug_5295_patch_updates_duplicated_columns.cs`. The three gaps fail against master and pass with the fix; the two guards (the straightforward case, and the prefix neighbour) pass both ways by design. Full PatchingTests and DocumentDbTests green on net9.0.

One test-harness note in the file itself: all five tests share one mapping deliberately. `OneOffConfigurationsContext` gives the class a single schema, so varying the duplicated columns per test leaves the previous test's table in place and the next `CREATE INDEX` collides with `42P07`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)