### PR TITLE
Capture the DCB tag version ahead of the events read (#5300)

### DIFF
--- a/src/EventSourcingTests/Dcb/dcb_staggered_concurrent_append_tests.cs
+++ b/src/EventSourcingTests/Dcb/dcb_staggered_concurrent_append_tests.cs
@@ -1,0 +1,117 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Dcb;
+
+// Concurrent appends guarded by the same DCB tag boundary must serialize: when several
+// writers race the same boundary, only one may commit. This pins that invariant under
+// staggered (non-lockstep) concurrency, exercised with many racers over many rounds.
+// Note: #4591's test only covers the lockstep case (racers synchronized).
+[Collection("OneOffs")]
+public class dcb_staggered_concurrent_append_tests : OneOffConfigurationsContext
+{
+    private const int Racers = 24;
+    private const int Rounds = 200;
+
+    public dcb_staggered_concurrent_append_tests()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.AddEventType<Enrolled>();
+            opts.Events.AddEventType<ProgressRecorded>();
+
+            opts.Events.RegisterTagType<EnrolleeId>("enrollee").ForAggregate<SubscriptionState>();
+            opts.Events.RegisterTagType<ProgramId>("program").ForAggregate<SubscriptionState>();
+        });
+    }
+
+    [Fact]
+    public async Task first_appends_to_a_shared_tag_serialize_to_one_winner()
+    {
+        long appended = 0;
+        for (var round = 0; round < Rounds; round++)
+        {
+            var programId = new ProgramId(Guid.NewGuid());
+            await RaceToEnrollAsync(programId);
+
+            appended = Math.Max(appended, await EnrollmentCountAsync(programId));
+        }
+
+        appended.ShouldBe(1);
+    }
+
+    // Same race, but the tag already has a version row (advanced by an unrelated
+    // ProgressRecorded), so this exercises the UPDATE-WHERE-version path, not the
+    // first-time INSERT.
+    [Fact]
+    public async Task appends_at_an_existing_version_serialize_to_one_winner()
+    {
+        long appended = 0;
+
+        for (var round = 0; round < Rounds; round++)
+        {
+            var programId = new ProgramId(Guid.NewGuid());
+            await SeedProgressAsync(programId);
+            await RaceToEnrollAsync(programId);
+
+            appended = Math.Max(appended, await EnrollmentCountAsync(programId));
+        }
+
+        appended.ShouldBe(1);
+    }
+
+    private Task RaceToEnrollAsync(ProgramId programId)
+        => Task.WhenAll(Enumerable.Range(0, Racers).Select(_ => TryEnrollAsync(programId)));
+
+    // Invariant: at most one enrollment per program. A racer that fetched after another
+    // committed sees the enrollment and backs off.
+    private async Task TryEnrollAsync(ProgramId programId)
+    {
+        await using var session = theStore.LightweightSession();
+        var boundary = await session.Events.FetchForWritingByTags<SubscriptionState>(
+            new EventTagQuery().Or<ProgramId>(programId));
+
+        if (boundary.Aggregate is { EnrollmentCount: > 0 })
+        {
+            return;
+        }
+
+        var enrolled = session.Events.BuildEvent(new Enrolled("Student"));
+        enrolled.WithTag(new EnrolleeId(Guid.NewGuid()), programId);
+        boundary.AppendOne(enrolled);
+
+        try
+        {
+            await session.SaveChangesAsync();
+        }
+        catch (DcbConcurrencyException)
+        {
+        }
+    }
+
+    private async Task SeedProgressAsync(ProgramId programId)
+    {
+        await using var session = theStore.LightweightSession();
+        var boundary = await session.Events.FetchForWritingByTags<SubscriptionState>(
+            new EventTagQuery().Or<ProgramId>(programId));
+        var progress = session.Events.BuildEvent(new ProgressRecorded("kickoff"));
+        progress.WithTag(new EnrolleeId(Guid.NewGuid()), programId);
+        boundary.AppendOne(progress);
+        await session.SaveChangesAsync();
+    }
+
+    private async Task<long> EnrollmentCountAsync(ProgramId programId)
+    {
+        await using var session = theStore.LightweightSession();
+        var enrolled = await session.Events.QueryByTagsAsync(
+            new EventTagQuery().Or<Enrolled, ProgramId>(programId));
+        return enrolled.Count;
+    }
+}

--- a/src/EventSourcingTests/Dcb/dcb_staggered_concurrent_append_tests.cs
+++ b/src/EventSourcingTests/Dcb/dcb_staggered_concurrent_append_tests.cs
@@ -14,6 +14,20 @@ namespace EventSourcingTests.Dcb;
 // writers race the same boundary, only one may commit. This pins that invariant under
 // staggered (non-lockstep) concurrency, exercised with many racers over many rounds.
 // Note: #4591's test only covers the lockstep case (racers synchronized).
+//
+// #5300: what makes the staggered case different is that FetchForWritingByTags reads the
+// events and the mt_dcb_tag_version row in two SEPARATE statements, and at READ COMMITTED
+// each statement takes its own snapshot -- so a commit landing between them is visible to
+// one read and not the other. Pre-fix the version was captured SECOND, which paired a fresh
+// version with a stale aggregate and let the save's `where version = $captured` match a check
+// the caller never actually made. The window is the whole duration of the events query, which
+// is why a handful of concurrent requests is enough to hit it. #4591's barrier syncs every
+// racer AFTER the fetch, so all of them capture the same version and the ordering bug cannot
+// show up there.
+//
+// The fix captures the version FIRST. If anything commits mid-fetch the captured version is
+// stale-low and the assertion fails -- a spurious conflict the caller retries, never a lost
+// one. Do not "tidy" the two statements back into the other order.
 [Collection("OneOffs")]
 public class dcb_staggered_concurrent_append_tests : OneOffConfigurationsContext
 {

--- a/src/Marten/Events/Dcb/FetchForWritingByTagsHandler.cs
+++ b/src/Marten/Events/Dcb/FetchForWritingByTagsHandler.cs
@@ -43,6 +43,20 @@ internal class FetchForWritingByTagsHandler<T>: IQueryHandler<IEventBoundary<T>>
         var schema = _store.Events.DatabaseSchemaName;
         var isHStore = _store.Events.DcbStorageMode == DcbStorageMode.HStore;
 
+        // #5300: the version capture goes FIRST, ahead of the events SELECT.
+        // The two are separate statements, and at READ COMMITTED each statement
+        // takes its own snapshot -- so a save that commits while one of them is
+        // running is visible to the other but not to it. Capturing after the
+        // events read pairs a FRESH version with a STALE aggregate, and the
+        // save's `where version = $captured` then matches: the conflict is
+        // missed and both appends commit. Capturing first can only pair a STALE
+        // version with a fresh aggregate, which fails the assertion -- a
+        // spurious conflict the caller retries, never a lost one. Same ordering
+        // (and same reason) as FetchAsyncPlan.FetchForWriting, which reads the
+        // stream version ahead of the events.
+        AppendVersionCapture(builder, (IMartenSession)session);
+        builder.StartNewCommand();
+
         builder.Append("select ");
         for (var f = 0; f < selectFields.Length; f++)
         {
@@ -128,13 +142,6 @@ internal class FetchForWritingByTagsHandler<T>: IQueryHandler<IEventBoundary<T>>
         }
 
         builder.Append(" order by e.seq_id");
-
-        // #4591: append the DCB tag-version capture step as a second statement
-        // in the same command. The events SELECT above is unchanged; this just
-        // SELECTs the current version for each (tag_table, tag_value) in the
-        // query so the captured version flows into DcbTagVersionAssertion's
-        // INSERT … ON CONFLICT DO UPDATE WHERE at SaveChangesAsync time.
-        AppendVersionCapture(builder, (IMartenSession)session);
     }
 
     private void AppendVersionCapture(ICommandBuilder builder, IMartenSession session)
@@ -165,10 +172,12 @@ internal class FetchForWritingByTagsHandler<T>: IQueryHandler<IEventBoundary<T>>
 
         var tenantId = session.TenantId;
 
-        // Use StartNewCommand (not `; <sql>`) so Npgsql sends a separate
-        // batched command. Multiple `;`-separated statements in a single
-        // prepared statement raise Postgres SQLSTATE 42601.
-        builder.StartNewCommand();
+        // No StartNewCommand here -- this is the handler's FIRST statement, and the
+        // batched-query path (CommandExtensions.BuildCommand) already opens a command
+        // per handler. A second call back to back would push an empty statement into
+        // the batch and shift every NextResultAsync in HandleAsync by one. The
+        // boundary between this statement and the events SELECT is opened by the
+        // caller instead.
 
         // Plain SELECT — no INSERT here. The fetch query shares the session
         // connection, and any INSERT-OR-IGNORE here would hold the row lock
@@ -222,6 +231,14 @@ internal class FetchForWritingByTagsHandler<T>: IQueryHandler<IEventBoundary<T>>
         var docSession = (DocumentSessionBase)session;
         var storage = (EventDocumentStorage)docSession.EventStorage();
 
+        // #4591/#5300: FIRST result set is the per-tag captured versions for the side-table
+        // assertion. Always present because AppendVersionCapture always runs (any DCB tag
+        // query necessarily references at least one tag). It has to be read before the
+        // events -- see the ordering note in ConfigureCommand.
+        var capturedByKey = await readCapturedVersions(reader, token).ConfigureAwait(false);
+
+        await reader.NextResultAsync(token).ConfigureAwait(false);
+
         var events = new List<IEvent>();
         while (await reader.ReadAsync(token).ConfigureAwait(false))
         {
@@ -231,13 +248,7 @@ internal class FetchForWritingByTagsHandler<T>: IQueryHandler<IEventBoundary<T>>
 
         var lastSeenSequence = events.Count > 0 ? events.Max(e => e.Sequence) : 0;
 
-        // #4591: second result set from ConfigureCommand — per-tag captured
-        // versions for the side-table assertion. Always present because
-        // AppendVersionUpsertAndCapture always runs (any DCB tag query
-        // necessarily references at least one tag).
-        await reader.NextResultAsync(token).ConfigureAwait(false);
-
-        var capturedVersions = await readCapturedVersions(reader, lastSeenSequence, token).ConfigureAwait(false);
+        var capturedVersions = buildEntries(capturedByKey, lastSeenSequence);
 
         T? aggregate = default;
         if (events.Count > 0)
@@ -263,8 +274,8 @@ internal class FetchForWritingByTagsHandler<T>: IQueryHandler<IEventBoundary<T>>
         return new EventBoundary<T>(docSession, _store.Events, aggregate, events, lastSeenSequence);
     }
 
-    private async Task<IReadOnlyList<DcbTagVersionEntry>> readCapturedVersions(
-        DbDataReader reader, long lastSeenSequence, CancellationToken token)
+    private static async Task<Dictionary<(string, string), long>> readCapturedVersions(
+        DbDataReader reader, CancellationToken token)
     {
         // SELECT returns only the rows that exist. A missing row means no prior
         // save has touched this tag boundary yet — captured version = 0, and the
@@ -279,6 +290,12 @@ internal class FetchForWritingByTagsHandler<T>: IQueryHandler<IEventBoundary<T>>
             byKey[(tagTable, tagValue)] = version;
         }
 
+        return byKey;
+    }
+
+    private IReadOnlyList<DcbTagVersionEntry> buildEntries(
+        Dictionary<(string, string), long> byKey, long lastSeenSequence)
+    {
         var targets = _versionTargets!;
         var entries = new DcbTagVersionEntry[targets.Count];
         for (var i = 0; i < targets.Count; i++)


### PR DESCRIPTION
Fixes the DCB double-append reported in #5300, and carries @Noblix's reproduction from that PR as the first commit (unchanged, with authorship preserved).

## The bug

`FetchForWritingByTags` emits the events `SELECT` over `mt_events` and the version `SELECT` over `mt_dcb_tag_version` as **two statements in one batch**. They share a round trip but not a snapshot — at READ COMMITTED Postgres takes a fresh snapshot at the start of *each* statement, even inside the batch's implicit transaction.

The version was captured **second**, so a save committing while the events query ran was invisible to the events read and visible to the version read:

| | racer A | racer B |
|---|---|---|
| T0 | events SELECT starts → sees nothing | |
| T1 | | commits: event + `mt_dcb_tag_version` 0 → 1 |
| T2 | version SELECT → reads **1** (fresh) | |
| T3 | `boundary.Aggregate` is null (stale) → appends | |
| T4 | save: `... where version = 1` → **matches** → commits | |

A committed an append whose decision was made against events it had never seen. Two writers past an invariant that admits one.

The race window is the **whole duration of the events query**, not the gap between the two statements, which is why the reporter hit it with 16 concurrent requests.

#4591's regression test cannot catch this — it barriers every racer *after* the fetch, so all of them capture the same version and the ordering is never exercised.

## The fix

Two statements at READ COMMITTED can never be made to share a snapshot, but the pairing only has to fail safe:

- version **after** events → fresh version + stale aggregate → **conflict missed**
- version **before** events → stale version + fresh aggregate → **spurious conflict**, caller retries

Capturing first makes `captured_version <= version_at_events_snapshot` an invariant, so a fetch that read stale events can only pair a stale-low version with them and fail the assertion. This is the ordering [`FetchAsyncPlan.FetchForWriting`](https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Fetching/FetchAsyncPlan.ExpectedVersion.cs) already uses for streams — version, then document, then events — for the same reason. The DCB handler was the odd one out.

One implementation detail: the version capture no longer calls `StartNewCommand` itself. It is now the handler's first statement, and `CommandExtensions.BuildCommand` already opens a command per handler on the batched-query path — a second call back to back would push an empty statement into the batch and shift every `NextResultAsync` by one.

## Behaviour change

A caller can now get a `DcbConcurrencyException` after reading data that was in fact current, when a commit lands between the two reads. That window is a PK lookup on `mt_dcb_tag_version` — microseconds, against the multi-ms events query — and a spurious conflict is ordinary optimistic-concurrency behaviour. The trade is a retry in place of silent corruption.

## Verification

- Both tests from #5300 fail on `master` (`appended` = 2) and pass here; 4 consecutive clean runs.
- Full `EventSourcingTests.Dcb` namespace: 139 passed, 0 failed (2 pre-existing skips, unrelated hstore projection issue). Covers the #4591, #5276 and #5280 regressions and the batched `IBatchedQuery` DCB path.
- `TenantPartitionedEventsTests.Dcb`: 12/12.

Polecat and Fisher get follow-up issues to run the same staggered race against their own DCB implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)