### PR TITLE
Invoke transaction participants when the session is in an ambient transaction

### DIFF
--- a/src/CoreTests/Sessions/transaction_participant_invocation.cs
+++ b/src/CoreTests/Sessions/transaction_participant_invocation.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using Marten;
+using Marten.Services;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests.Sessions;
+
+/// <summary>
+/// Every connection lifetime is handed the session's transaction participants when its batch pages
+/// execute. A participant exists to flush work belonging to another system, EF Core being the only
+/// production implementation, into the same transaction Marten is about to commit. A lifetime that
+/// accepts participants and does not invoke them therefore drops that work with no error.
+/// </summary>
+public class transaction_participant_invocation: BugIntegrationContext
+{
+    [Fact]
+    public async Task participant_is_invoked_on_an_ordinary_session()
+    {
+        StoreOptions(opts => opts.RegisterDocumentType<Target>());
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var participant = new RecordingParticipant();
+
+        await using var session = theStore.LightweightSession();
+        ((ITransactionParticipantRegistrar)session).AddTransactionParticipant(participant);
+        session.Store(Target.Random());
+        await session.SaveChangesAsync();
+
+        // The control. If this ever fails, the test below is proving nothing, because it would be
+        // asserting a behaviour that does not exist on any lifetime.
+        participant.Invocations.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task participant_is_invoked_when_enlisted_in_an_ambient_transaction()
+    {
+        StoreOptions(opts => opts.RegisterDocumentType<Target>());
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var participant = new RecordingParticipant();
+
+        using var scope = new TransactionScope(
+            TransactionScopeOption.Required,
+            new TransactionOptions(),
+            TransactionScopeAsyncFlowOption.Enabled);
+
+        await using (var session = theStore.LightweightSession(SessionOptions.ForCurrentTransaction()))
+        {
+            // AmbientTransactionLifetime, per SessionOptions.buildConnectionLifetime: DotNetTransaction
+            // is set and is tested before the Connection branch.
+            session.Connection.ShouldNotBeNull();
+
+            ((ITransactionParticipantRegistrar)session).AddTransactionParticipant(participant);
+            session.Store(Target.Random());
+            await session.SaveChangesAsync();
+        }
+
+        scope.Complete();
+
+        participant.Invocations.ShouldBe(1);
+    }
+
+    internal class RecordingParticipant: ITransactionParticipant
+    {
+        public int Invocations { get; private set; }
+
+        public List<bool> TransactionWasNull { get; } = new();
+
+        public Task BeforeCommitAsync(NpgsqlConnection connection, NpgsqlTransaction transaction,
+            CancellationToken token)
+        {
+            Invocations++;
+
+            // Recorded rather than asserted. Under an ambient System.Transactions scope the
+            // connection is enlisted and there is no NpgsqlTransaction to hand over, which is the
+            // design question this test exposes rather than answers.
+            TransactionWasNull.Add(transaction == null);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Marten.EntityFrameworkCore/DbContextTransactionParticipant.cs
+++ b/src/Marten.EntityFrameworkCore/DbContextTransactionParticipant.cs
@@ -49,8 +49,12 @@ internal class DbContextTransactionParticipant<TDbContext>: ITransactionParticip
     public TDbContext DbContext { get; }
 
     public async Task BeforeCommitAsync(NpgsqlConnection connection,
-        NpgsqlTransaction transaction, CancellationToken token)
+        NpgsqlTransaction? transaction, CancellationToken token)
     {
+        // A null transaction means the session is in an ambient TransactionScope and the connection
+        // carries the enlistment. Assigning null to DbCommand.Transaction is correct there, and
+        // UseTransactionAsync(null) is required rather than merely tolerated: EF Core throws if it
+        // is handed a transaction while already operating inside a TransactionScope.
         // Set search_path on Marten's real connection so EF Core targets the right schema
         if (!string.IsNullOrEmpty(_schemaName))
         {

--- a/src/Marten/ITransactionParticipant.cs
+++ b/src/Marten/ITransactionParticipant.cs
@@ -17,6 +17,11 @@ public interface ITransactionParticipant
     /// transaction is committed. Implementations should use the provided
     /// connection and transaction to execute any pending work.
     /// </summary>
-    Task BeforeCommitAsync(NpgsqlConnection connection, NpgsqlTransaction transaction,
+    /// <param name="transaction">
+    /// Null when the session is enlisted in an ambient <c>System.Transactions</c> scope, where the
+    /// connection is enlisted and no <c>NpgsqlTransaction</c> exists. Work must still be executed
+    /// on <paramref name="connection"/>, which carries the enlistment.
+    /// </param>
+    Task BeforeCommitAsync(NpgsqlConnection connection, NpgsqlTransaction? transaction,
         CancellationToken token);
 }

--- a/src/Marten/Internal/Sessions/AmbientTransactionLifetime.cs
+++ b/src/Marten/Internal/Sessions/AmbientTransactionLifetime.cs
@@ -312,5 +312,20 @@ internal class AmbientTransactionLifetime: ConnectionLifetimeBase, IAlwaysConnec
             throw new AggregateException(exceptions);
         }
 
+        // The other three lifetimes invoke participants immediately before they commit. This one
+        // never commits: the ambient TransactionScope owns that, and completes when the caller
+        // completes the scope. So the last safe point is here, after the pages have executed and
+        // after the failure paths above have thrown.
+        //
+        // The transaction argument is null by necessity rather than by omission. The connection is
+        // enlisted in the ambient transaction, so no NpgsqlTransaction exists to hand over, and EF
+        // Core throws if given one while it is operating inside a TransactionScope.
+        if (participants is { Count: > 0 })
+        {
+            foreach (var participant in participants)
+            {
+                await participant.BeforeCommitAsync(_connection!, null, token).ConfigureAwait(false);
+            }
+        }
     }
 }


### PR DESCRIPTION
`AmbientTransactionLifetime.ExecuteBatchPagesAsync` accepts a participants list and never reads it. `BeforeCommitAsync` appears zero times in that file, and it does not delegate to an inner lifetime either.

The asymmetry is three against one:

| Lifetime | invokes `BeforeCommitAsync` |
|---|---|
| `TransactionalConnection` | yes |
| `ExternalTransaction` | yes |
| `AutoClosingLifetime` | yes |
| `AmbientTransactionLifetime` | **no, and does not delegate** |

(`EventTracingConnectionLifetime` looks like a fourth by grep but is a decorator passing `participants` through correctly.)

So a session enlisted in a `TransactionScope` is the one place a registered participant is silently skipped. For the EF Core participant that means the `DbContext` is never handed Marten's connection, and its writes go nowhere the Marten transaction can see.

## Where the call goes

After the pages execute and after the existing failure paths throw. This lifetime never commits: the ambient scope owns that and completes when the caller completes the scope, so this is the last safe point.

## The transaction argument is null there

`ITransactionParticipant.BeforeCommitAsync` now takes `NpgsqlTransaction?`. That is by necessity rather than convenience: the connection is enlisted in the ambient transaction, so no `NpgsqlTransaction` exists to hand over, and EF Core throws if given one while already operating inside a `TransactionScope`. `UseTransactionAsync(null)` is the required call there rather than a tolerated one, which is now written into the EF Core participant.

The signature change is a nullable annotation, so it is metadata rather than a binary break, but it is a public interface and worth naming.

## Tests

`transaction_participant_invocation`, two cases, and the pair is the point:

- `participant_is_invoked_on_an_ordinary_session` **passes on master**. Without it, the other test could be failing because participants are broken generally rather than in this one lifetime.
- `participant_is_invoked_when_enlisted_in_an_ambient_transaction` **fails on master**, passes with the change.

Measured in that order on `b6f6f81`: 1 passed, 1 failed before; 2 passed after. `CoreTests` Sessions suite 26 passed.

## Not addressed

The end-to-end consequence for an inline EF-Core-backed projection under a `TransactionScope` is argued rather than demonstrated here. This proves the participant is not invoked, which is the mechanism; I did not build the projection scenario on top of it.