### PR TITLE
Apply OrderBy, Where and Count to the join itself after GroupJoin + SelectMany

### DIFF
--- a/src/LinqTests/Operators/group_join_operator.cs
+++ b/src/LinqTests/Operators/group_join_operator.cs
@@ -679,4 +679,107 @@ public class group_join_operator: OneOffConfigurationsContext
     }
 
     #endregion
+
+    #region Ordering and filtering after the join (#5302)
+
+    [Fact]
+    public async Task OrderBy_after_the_join_is_applied()
+    {
+        await SetupData();
+
+        var amounts = await _session.Query<JoinCustomer>()
+            .GroupJoin(_session.Query<JoinOrder>(), c => c.Id, o => o.CustomerId, (c, orders) => new { c, orders })
+            .SelectMany(x => x.orders, (x, o) => o)
+            .OrderByDescending(o => o.Amount)
+            .Select(o => o.Amount)
+            .ToListAsync();
+
+        amounts.ShouldHaveTheSameElementsAs(300m, 200m, 100m);
+    }
+
+    [Fact]
+    public async Task OrderBy_and_paging_after_the_join_return_the_asked_for_page()
+    {
+        await SetupData();
+
+        // Skip/Take were already transferred to the join select, so an unapplied OrderBy did not
+        // produce an unordered list -- it produced an arbitrary page.
+        var amounts = await _session.Query<JoinCustomer>()
+            .GroupJoin(_session.Query<JoinOrder>(), c => c.Id, o => o.CustomerId, (c, orders) => new { c, orders })
+            .SelectMany(x => x.orders, (x, o) => o)
+            .OrderByDescending(o => o.Amount)
+            .Skip(1)
+            .Take(1)
+            .Select(o => o.Amount)
+            .ToListAsync();
+
+        amounts.ShouldHaveTheSameElementsAs(200m);
+    }
+
+    [Fact]
+    public async Task OrderBy_after_the_join_can_order_by_the_outer_side()
+    {
+        await SetupData();
+
+        var names = await _session.Query<JoinCustomer>()
+            .GroupJoin(_session.Query<JoinOrder>(), c => c.Id, o => o.CustomerId, (c, orders) => new { c, orders })
+            .SelectMany(x => x.orders, (x, o) => new { x.c.Name, o.Amount })
+            .OrderByDescending(z => z.Name)
+            .ThenBy(z => z.Amount)
+            .Select(z => z.Name)
+            .ToListAsync();
+
+        names.ShouldHaveTheSameElementsAs("Bob", "Alice", "Alice");
+    }
+
+    [Fact]
+    public async Task Where_after_the_join_is_applied_when_the_projection_is_the_inner_side()
+    {
+        await SetupData();
+
+        // (x, o) => o binds nothing to index, which used to make the Where() disappear.
+        var amounts = await _session.Query<JoinCustomer>()
+            .GroupJoin(_session.Query<JoinOrder>(), c => c.Id, o => o.CustomerId, (c, orders) => new { c, orders })
+            .SelectMany(x => x.orders, (x, o) => o)
+            .Where(o => o.Amount > 150m)
+            .OrderBy(o => o.Amount)
+            .Select(o => o.Amount)
+            .ToListAsync();
+
+        amounts.ShouldHaveTheSameElementsAs(200m, 300m);
+    }
+
+    [Fact]
+    public async Task Count_after_the_join_respects_a_post_join_Where()
+    {
+        await SetupData();
+
+        var count = await _session.Query<JoinCustomer>()
+            .GroupJoin(_session.Query<JoinOrder>(), c => c.Id, o => o.CustomerId, (c, orders) => new { c, orders })
+            .SelectMany(x => x.orders, (x, o) => o)
+            .Where(o => o.Amount > 150m)
+            .CountAsync();
+
+        count.ShouldBe(2);
+    }
+
+
+    [Fact]
+    public async Task Count_after_the_join_counts_the_join_and_not_the_outer_side()
+    {
+        await SetupData();
+
+        // Diana has no orders, so the outer side has four customers and the join has three rows.
+        // The existing Count coverage cannot see this: with three of each, both answers are 3.
+        _session.Store(new JoinCustomer { Id = Guid.NewGuid(), Name = "Diana", City = "Seattle" });
+        await _session.SaveChangesAsync();
+
+        var count = await _session.Query<JoinCustomer>()
+            .GroupJoin(_session.Query<JoinOrder>(), c => c.Id, o => o.CustomerId, (c, orders) => new { c, orders })
+            .SelectMany(x => x.orders, (x, o) => o)
+            .CountAsync();
+
+        count.ShouldBe(3);
+    }
+    #endregion
 }

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -320,6 +320,9 @@ public partial class CollectionUsage
         return statement;
     }
 
+    private static Ordering CopyOrdering(Ordering source, LambdaExpression rewritten) =>
+        new(rewritten, source.Direction) { CasingRule = source.CasingRule, IsTransformed = source.IsTransformed };
+
     public Statement CompileGroupJoin(IStorageSession session,
         SelectorStatement outerStatement, QueryStatistics? statistics)
     {
@@ -572,6 +575,77 @@ public partial class CollectionUsage
             }
         }
 
+        // Post-SelectMany OrderBy(): render it on the join select, not inside a CTE. A join is free to
+        // discard the order of its inputs, and Limit/Offset are already transferred above -- so leaving
+        // the ordering out does not produce an unordered list, it produces an arbitrary page.
+        var postSmOrderings = new List<Ordering>();
+        for (var sweep = Inner; sweep != null; sweep = sweep.Inner)
+        {
+            postSmOrderings.AddRange(sweep.OrderingExpressions);
+        }
+
+        foreach (var ordering in postSmOrderings)
+        {
+            if (!string.IsNullOrEmpty(ordering.Literal))
+            {
+                joinStatement.Ordering.Expressions.Add(ordering.Literal!);
+                continue;
+            }
+
+            if (!expander.CanExpand)
+            {
+                throw new BadLinqExpressionException(
+                    "Marten cannot translate an OrderBy() applied after GroupJoin(...).SelectMany(...) for this "
+                    + "projection. Order the outer Query<T>() before the GroupJoin instead.");
+            }
+
+            var body = ordering.Expression;
+            while (body is UnaryExpression { NodeType: ExpressionType.Quote or ExpressionType.Convert } unary)
+            {
+                body = unary.Operand;
+            }
+
+            if (body is LambdaExpression orderingLambda)
+            {
+                body = orderingLambda.Body;
+            }
+
+            var expandedOrdering = expander.Expand(body);
+            var orderingSide = PostSelectManyFilterSideAnalyzer.Analyze(
+                expandedOrdering, groupJoin.FlattenedResultSelector.Parameters);
+
+            string sql;
+            if (orderingSide == PostSelectManyFilterSideAnalyzer.Side.InnerOnly)
+            {
+                var innerParam = Expression.Parameter(groupJoin.InnerElementType, "child");
+                var rewritten = new ParameterReplacingVisitor(
+                    groupJoin.FlattenedResultSelector.Parameters[1], innerParam).Visit(expandedOrdering);
+
+                sql = CopyOrdering(ordering, Expression.Lambda(rewritten, innerParam))
+                    .BuildExpression(innerCollection)
+                    .Replace("d.", innerCteAlias + ".");
+            }
+            else if (orderingSide == PostSelectManyFilterSideAnalyzer.Side.OuterOnly)
+            {
+                var outerParam = Expression.Parameter(ElementType, "outer");
+                var rewritten = new GroupJoinOuterNavigationStripper(
+                    groupJoin.FlattenedResultSelector.Parameters[0],
+                    groupJoin.ResultSelector, outerParam).Visit(expandedOrdering);
+
+                sql = CopyOrdering(ordering, Expression.Lambda(rewritten, outerParam))
+                    .BuildExpression(outerCollection)
+                    .Replace("d.", outerCteAlias + ".");
+            }
+            else
+            {
+                throw new BadLinqExpressionException(
+                    "Marten cannot translate this post-SelectMany OrderBy() -- it touches both the outer and "
+                    + "inner sides of the GroupJoin (or neither). Order by a member of one side.");
+            }
+
+            joinStatement.Ordering.Expressions.Add(sql);
+        }
+
         // Transfer Distinct() from the SelectMany usage chain. JoinSelectClause implements
         // IScalarSelectClause, so ProcessSingleValueModeIfAny renders DISTINCT(<projection>) for
         // a materialized Distinct() and wraps it in a count(*) CTE for Distinct().Count().
@@ -601,6 +675,28 @@ public partial class CollectionUsage
             joinStatement.AddToEnd(scalarStatement);
 
             ProcessSingleValueModeIfAny(scalarStatement, session, null, statistics);
+
+            return joinStatement;
+        }
+
+        // Count()/LongCount() must count the join, not the outer side. ProcessSingleValueModeIfAny
+        // builds its count(*) over SelectClause.FromObject, and JoinSelectClause reports the *outer*
+        // CTE there -- so counting without wrapping silently drops the join itself, along with every
+        // filter on the inner side. Distinct().Count() is left alone: ProcessSingleValueModeIfAny
+        // already builds its own count(*) CTE over the DISTINCT projection.
+        if ((SingleValueMode is Marten.Linq.Parsing.SingleValueMode.Count
+                or Marten.Linq.Parsing.SingleValueMode.LongCount)
+            && !joinStatement.IsDistinct)
+        {
+            joinStatement.ConvertToCommonTableExpression(session);
+
+            var countStatement = new SelectorStatement
+            {
+                SelectClause = new NewScalarStringSelectClause("d.data", joinStatement.ExportName)
+            };
+            joinStatement.AddToEnd(countStatement);
+
+            ProcessSingleValueModeIfAny(countStatement, session, null, statistics);
 
             return joinStatement;
         }

--- a/src/Marten/Linq/Parsing/JoinSelectParser.cs
+++ b/src/Marten/Linq/Parsing/JoinSelectParser.cs
@@ -447,14 +447,26 @@ internal sealed class AnonProjectionExpander: ExpressionVisitor
     private readonly Dictionary<string, Expression> _memberToSource = new(StringComparer.Ordinal);
     private readonly Type _projectionType;
 
+    // Set for (x, c) => c, where the projection *is* one of the join's sides. There is nothing to
+    // index then, so without this CanExpand is false and every post-SelectMany Where()/OrderBy() is
+    // silently dropped rather than routed to a side.
+    private readonly ParameterExpression? _identitySource;
+
     public AnonProjectionExpander(LambdaExpression flattenedResultSelector)
     {
         _projectionType = flattenedResultSelector.ReturnType;
-        ExtractBindings(flattenedResultSelector.Body);
+        if (flattenedResultSelector.Body is ParameterExpression identity)
+        {
+            _identitySource = identity;
+        }
+        else
+        {
+            ExtractBindings(flattenedResultSelector.Body);
+        }
     }
 
-    /// <summary>True if the result selector body was a NewExpression / MemberInit we could index.</summary>
-    public bool CanExpand => _memberToSource.Count > 0;
+    /// <summary>True if the result selector body was a NewExpression / MemberInit we could index, or a bare side.</summary>
+    public bool CanExpand => _memberToSource.Count > 0 || _identitySource != null;
 
     /// <summary>Rewrites <paramref name="body"/>, replacing every <c>z.X</c> (where z is the projection type) with the bound source expression.</summary>
     public Expression Expand(Expression body) => Visit(body);
@@ -492,6 +504,14 @@ internal sealed class AnonProjectionExpander: ExpressionVisitor
                 _memberToSource[binding.Member.Name] = binding.Expression;
             }
         }
+    }
+
+    protected override Expression VisitParameter(ParameterExpression node)
+    {
+        // z (or z.X) where the projection is a bare side: z is that side. Matched by type, since the
+        // post-SelectMany lambda has its own parameter instance. Returning the join's own parameter
+        // keeps the side analyzer -- which compares by reference -- able to place the expression.
+        return _identitySource != null && node.Type == _projectionType ? _identitySource : base.VisitParameter(node);
     }
 
     protected override Expression VisitMember(MemberExpression node)


### PR DESCRIPTION
## The problem

Three operators applied after `GroupJoin(...).SelectMany(...)` are dropped or misdirected. None of
them throw, so the query returns a wrong answer instead of failing.

```csharp
var page = await session.Query<Customer>()
    .GroupJoin(session.Query<Order>(), c => c.Id, o => o.CustomerId, (c, orders) => new { c, orders })
    .SelectMany(x => x.orders, (x, o) => o)
    .Where(o => o.Amount > 150m)
    .OrderByDescending(o => o.Amount)
    .Skip(1).Take(1)
    .ToListAsync();
```

Before this change that renders:

```sql
WITH cte1 as (select d.data, d.id from mt_doc_customer as d)
   , cte2 as (select d.data, d.id from mt_doc_order as d)
select to_jsonb(cte2.data) as data from cte1 INNER JOIN cte2 ON cte1.id = cte2.id
LIMIT 1 OFFSET 1;
```

No `WHERE`, no `ORDER BY` — but the `LIMIT`/`OFFSET` are there. A paginated query therefore does not
return an unordered list, it returns an arbitrary page, and page 2 can repeat or skip rows.

Three separate causes:

1. **`OrderBy` was never transferred.** `CompileGroupJoin` transfers `Limit` and `Offset` from the
   post-`SelectMany` usage onto the join statement, but not `OrderingExpressions`. The comment above
   that block says "Apply downstream operators (Where, OrderBy, ...)".
2. **`Where` is discarded for `(x, c) => c`.** The #4677 routing is guarded by
   `AnonProjectionExpander.CanExpand`, which is `_memberToSource.Count > 0`. An identity projection is
   a `ParameterExpression`, not a `NewExpression`, so nothing is indexed, `CanExpand` is false and the
   filters are silently skipped.
3. **`Count()`/`LongCount()` count the outer table.** `ProcessSingleValueModeIfAny` builds `count(*)`
   over `SelectClause.FromObject`, and `JoinSelectClause.FromObject` is the *outer* CTE alias, so the
   join and every inner-side filter drop out:
   `select count(*) as number from cte1 as d;`

## The change

- Post-`SelectMany` orderings are rendered **on the join select**, not pushed into a CTE — a join is
  free to discard the order of its inputs, so ordering a CTE would not be the same thing. Each
  ordering is routed to the side it belongs to using `PostSelectManyFilterSideAnalyzer`, the same one
  the `Where` path already uses. An ordering that straddles both sides now raises
  `BadLinqExpressionException` instead of disappearing.
- `AnonProjectionExpander` recognises the identity projection, so `Where`/`OrderBy` over `(x, c) => c`
  resolve to that side.
- `Count`/`LongCount` wrap the join in a CTE and count over it, the way the scalar aggregates already do.
  `Distinct().Count()` is untouched — it already builds its own `count(*)` CTE.

## Tests

Six added to `group_join_operator`. The `Count` one needs a fourth customer with no orders: the
existing fixture has three customers and three join rows, so the outer count and the join count are
both 3 and the defect is invisible. Full `LinqTests` suite green (1 454) on net10.0.

## Not covered

`Any()` after the join goes through the same `FromObject` path and may have the same problem — I did
not measure it, so I left it alone rather than guess. Ordering applied to the *outer* query before
`GroupJoin` still lands inside the outer CTE; it happens to come out ordered on PostgreSQL today, but
that is not guaranteed across a join either.
