### PR TITLE
Make HotCold lock denial observable, and restart stranded Stopped agents (8.x)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>8.37.4</Version>
+        <Version>8.38.0</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/src/DaemonTests/Coordination/OwnershipTrackerTests.cs
+++ b/src/DaemonTests/Coordination/OwnershipTrackerTests.cs
@@ -1,0 +1,166 @@
+using System;
+using JasperFx.Core;
+using Marten.Events.Daemon.Coordination;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.Coordination;
+
+public class OwnershipTrackerTests
+{
+    private static readonly TimeSpan Threshold = 2.Minutes();
+    private static readonly TimeSpan Repeat = 5.Minutes();
+
+    private readonly AdjustableTimeProvider theTime = new();
+    private readonly OwnershipTracker theTracker;
+
+    public OwnershipTrackerTests()
+    {
+        theTracker = new OwnershipTracker(theTime);
+    }
+
+    private OwnershipReport record(int owned, int denied, int total, TimeSpan? threshold = null)
+    {
+        return theTracker.Record(owned, denied, total, threshold ?? Threshold, Repeat);
+    }
+
+    [Fact]
+    public void reports_the_tally_as_changed_on_the_very_first_cycle()
+    {
+        record(3, 0, 3).TallyChanged.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void is_quiet_while_the_tally_is_unchanged()
+    {
+        record(3, 0, 3);
+
+        record(3, 0, 3).TallyChanged.ShouldBeFalse();
+        record(3, 0, 3).TallyChanged.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void reports_a_change_when_databases_are_lost()
+    {
+        record(3, 0, 3);
+
+        record(1, 2, 3).TallyChanged.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void reports_a_change_when_only_the_denied_count_moves()
+    {
+        // Same number owned, but the rest of the cluster's shape changed underneath us --
+        // worth a line, because it means sets appeared or disappeared.
+        record(1, 1, 2);
+
+        record(1, 2, 3).TallyChanged.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void does_not_warn_before_the_threshold_has_elapsed()
+    {
+        record(0, 33, 33).ShouldWarn.ShouldBeFalse();
+
+        theTime.Advance(119.Seconds());
+
+        record(0, 33, 33).ShouldWarn.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void warns_once_the_threshold_has_elapsed()
+    {
+        record(0, 33, 33);
+
+        theTime.Advance(2.Minutes()).Advance(1.Seconds());
+
+        var report = record(0, 33, 33);
+        report.ShouldWarn.ShouldBeTrue();
+        report.OwnedNothingFor.ShouldBeGreaterThanOrEqualTo(2.Minutes());
+    }
+
+    [Fact]
+    public void throttles_the_warning_to_the_repeat_time()
+    {
+        record(0, 33, 33);
+        theTime.Advance(3.Minutes());
+        record(0, 33, 33).ShouldWarn.ShouldBeTrue();
+
+        theTime.Advance(4.Minutes());
+        record(0, 33, 33).ShouldWarn.ShouldBeFalse();
+
+        theTime.Advance(2.Minutes());
+        record(0, 33, 33).ShouldWarn.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void never_warns_when_the_threshold_is_disabled()
+    {
+        // Calling Record directly -- the helper's null means "use the default threshold"
+        theTracker.Record(0, 33, 33, null, Repeat);
+
+        theTime.Advance(2.Hours());
+
+        theTracker.Record(0, 33, 33, null, Repeat).ShouldWarn.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void does_not_warn_when_there_is_simply_nothing_to_own()
+    {
+        // A store with no asynchronous projections at all owns zero sets forever, and that is
+        // not a node that has been locked out of its work.
+        record(0, 0, 0);
+
+        theTime.Advance(2.Hours());
+
+        record(0, 0, 0).ShouldWarn.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void recovering_ownership_resets_the_clock_and_the_throttle()
+    {
+        record(0, 33, 33);
+        theTime.Advance(3.Minutes());
+        record(0, 33, 33).ShouldWarn.ShouldBeTrue();
+
+        // The zombie sessions time out and this node takes the databases over
+        theTime.Advance(1.Minutes());
+        record(33, 0, 33).ShouldWarn.ShouldBeFalse();
+
+        // ...and then loses them again. The threshold has to be served afresh rather than
+        // firing immediately off the previous outage's clock.
+        theTime.Advance(1.Minutes());
+        record(0, 33, 33).ShouldWarn.ShouldBeFalse();
+
+        theTime.Advance(3.Minutes());
+        record(0, 33, 33).ShouldWarn.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void partial_ownership_is_not_a_warning()
+    {
+        // Owning even one set means the coordinator is alive and acquiring. This is the
+        // 19:48 point of the incident, where the replacement node had taken 1 of 33.
+        record(1, 32, 33);
+
+        theTime.Advance(2.Hours());
+
+        record(1, 32, 33).ShouldWarn.ShouldBeFalse();
+    }
+
+    internal class AdjustableTimeProvider: TimeProvider
+    {
+        private DateTimeOffset _now = new(2026, 8, 28, 19, 33, 0, TimeSpan.Zero);
+
+        public AdjustableTimeProvider Advance(TimeSpan span)
+        {
+            _now = _now.Add(span);
+            return this;
+        }
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            return _now;
+        }
+    }
+}

--- a/src/Marten/Events/Daemon/Coordination/OwnershipTracker.cs
+++ b/src/Marten/Events/Daemon/Coordination/OwnershipTracker.cs
@@ -1,0 +1,73 @@
+using System;
+
+namespace Marten.Events.Daemon.Coordination;
+
+/// <summary>
+///     The decision produced by <see cref="OwnershipTracker" /> for a single polling cycle.
+/// </summary>
+internal readonly record struct OwnershipReport(bool TallyChanged, bool ShouldWarn, TimeSpan OwnedNothingFor);
+
+/// <summary>
+///     Tracks how many projection sets this node actually owns from one leadership polling cycle to the
+///     next, and decides when that is worth logging.
+/// </summary>
+/// <remarks>
+///     Split out of <see cref="ProjectionCoordinator" /> purely so the threshold and throttling rules can be
+///     unit tested without standing up a DocumentStore. It holds no dependencies beyond a TimeProvider and
+///     is only ever touched from the coordinator's single polling loop, so it is deliberately not thread safe.
+/// </remarks>
+internal class OwnershipTracker
+{
+    private readonly TimeProvider _timeProvider;
+
+    private int? _lastOwned;
+    private int? _lastDenied;
+    private DateTimeOffset? _ownsNothingSince;
+    private DateTimeOffset? _lastWarning;
+
+    public OwnershipTracker(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    /// <param name="owned">Projection sets whose leadership lock this node holds.</param>
+    /// <param name="denied">Projection sets whose lock is held by some other node.</param>
+    /// <param name="total">All projection sets this node knows about.</param>
+    /// <param name="warningThreshold">
+    ///     How long this node may own nothing before warning, or null to never warn.
+    /// </param>
+    /// <param name="repeatTime">How often to repeat that warning while the condition persists.</param>
+    public OwnershipReport Record(int owned, int denied, int total, TimeSpan? warningThreshold, TimeSpan repeatTime)
+    {
+        var now = _timeProvider.GetUtcNow();
+
+        var tallyChanged = _lastOwned != owned || _lastDenied != denied;
+        _lastOwned = owned;
+        _lastDenied = denied;
+
+        // Owning nothing is only meaningful when there is something to own. A store with no async
+        // projections at all is not a node that has been locked out of its work.
+        if (owned > 0 || total == 0)
+        {
+            _ownsNothingSince = null;
+            _lastWarning = null;
+            return new OwnershipReport(tallyChanged, false, TimeSpan.Zero);
+        }
+
+        _ownsNothingSince ??= now;
+        var ownedNothingFor = now.Subtract(_ownsNothingSince.Value);
+
+        if (warningThreshold == null || ownedNothingFor < warningThreshold.Value)
+        {
+            return new OwnershipReport(tallyChanged, false, ownedNothingFor);
+        }
+
+        if (_lastWarning != null && now.Subtract(_lastWarning.Value) < repeatTime)
+        {
+            return new OwnershipReport(tallyChanged, false, ownedNothingFor);
+        }
+
+        _lastWarning = now;
+        return new OwnershipReport(tallyChanged, true, ownedNothingFor);
+    }
+}

--- a/src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs
+++ b/src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs
@@ -34,6 +34,9 @@ public class ProjectionCoordinator: IProjectionCoordinator
     private ImHashMap<string, IProjectionDaemon> _daemons = ImHashMap<string, IProjectionDaemon>.Empty;
     private Task? _runner;
 
+    // Ownership tallies for recordOwnership(). Only ever touched from the single executeAsync loop.
+    private readonly OwnershipTracker _ownership;
+
     public ProjectionCoordinator(IDocumentStore documentStore, ILogger<ProjectionCoordinator> logger)
     {
         var store = (DocumentStore)documentStore;
@@ -60,6 +63,7 @@ public class ProjectionCoordinator: IProjectionCoordinator
         _logger = logger;
         _resilience = store.Options.ResiliencePipeline;
         _timeProvider = _options.Events.TimeProvider;
+        _ownership = new OwnershipTracker(_timeProvider);
         Store = store;
     }
 
@@ -199,6 +203,9 @@ public class ProjectionCoordinator: IProjectionCoordinator
                 var sets = await Distributor
                     .BuildDistributionAsync().ConfigureAwait(false);
 
+                var owned = 0;
+                var denied = 0;
+
                 foreach (var set in sets)
                 {
                     // Is it already running here?
@@ -208,6 +215,7 @@ public class ProjectionCoordinator: IProjectionCoordinator
 
                         // check if it's still running
                         await startAgentsIfNecessaryAsync(set, daemon, stoppingToken).ConfigureAwait(false);
+                        owned++;
                         continue;
                     }
 
@@ -219,6 +227,7 @@ public class ProjectionCoordinator: IProjectionCoordinator
 
                             // check if it's still running
                             await startAgentsIfNecessaryAsync(set, daemon, stoppingToken).ConfigureAwait(false);
+                            owned++;
                         }
                         else
                         {
@@ -226,15 +235,19 @@ public class ProjectionCoordinator: IProjectionCoordinator
                             var daemon = resolveDaemon(set);
 
                             await stopAgentsIfNecessaryAsync(set, daemon).ConfigureAwait(false);
+                            denied++;
                         }
                     }
                     catch (Exception e)
                     {
                         _logger.LogError(e, "Error trying to attain a lock for set {Name} and lock id {LockId}. Will retry later", set.Names.Select(x => x.Identity).Join(", "), set.LockId);
+                        denied++;
                         await Task.Delay(_options.Projections.LeadershipPollingTime.Milliseconds(), stoppingToken)
                             .ConfigureAwait(false);
                     }
                 }
+
+                recordOwnership(owned, denied, sets.Count);
             }
             catch (Exception e)
             {
@@ -276,6 +289,43 @@ public class ProjectionCoordinator: IProjectionCoordinator
     }
 
 
+    /// <summary>
+    ///     Log this node's share of the projection sets, so that "this node is running nothing" is visible
+    ///     in telemetry rather than having to be inferred from the absence of other log lines.
+    /// </summary>
+    /// <remarks>
+    ///     The lock-denied branch of the polling loop above was completely silent: no log, no metric, no
+    ///     health signal. Only a thrown exception produced any output. That made a node which had been
+    ///     denied every database's lock indistinguishable from a healthy node on an idle system, and hid a
+    ///     ~35 minute projection outage after an ungraceful node kill left session-scoped advisory locks
+    ///     alive server-side until Postgres's TCP layer timed the dead peer out.
+    ///
+    ///     Steady state is quiet: the Information line is only written when the tally actually changes.
+    ///     The warning is the part that cannot be made both loud and quiet at once -- a node can observe
+    ///     "I own nothing" but never "nobody owns this", so on a real multi-node HotCold cluster the
+    ///     standbys will warn on their repeat cadence. That is why the threshold is configurable and can
+    ///     be switched off outright.
+    /// </remarks>
+    private void recordOwnership(int owned, int denied, int total)
+    {
+        var report = _ownership.Record(owned, denied, total,
+            _options.Projections.NoOwnedProjectionSetsWarningThreshold,
+            _options.Projections.NoOwnedProjectionSetsRepeatTime);
+
+        if (report.TallyChanged)
+        {
+            _logger.LogInformation(
+                "ProjectionCoordinator owns {Owned} of {Total} projection sets ({Denied} held by another node)",
+                owned, total, denied);
+        }
+
+        if (!report.ShouldWarn) return;
+
+        _logger.LogWarning(
+            "ProjectionCoordinator has owned none of the {Total} known projection sets for {Elapsed}, so no asynchronous projections or subscriptions are running on this node. Every leadership lock is held elsewhere -- if no other node is running them, the likely cause is a previous node that was killed without releasing its session-scoped advisory locks, which Postgres will hold until it detects the dead client. This is expected on a standby node in a multi-node HotCold cluster; set StoreOptions.Projections.NoOwnedProjectionSetsWarningThreshold to null to silence it",
+            total, report.OwnedNothingFor);
+    }
+
     private async Task startAgentsIfNecessaryAsync(IProjectionSet set,
         IProjectionDaemon daemon, CancellationToken stoppingToken)
     {
@@ -290,6 +340,24 @@ public class ProjectionCoordinator: IProjectionCoordinator
                      _timeProvider.GetUtcNow().Subtract(agent.PausedTime.Value) >
                      _options.Projections.HealthCheckPollingTime)
             {
+                await tryStartAgent(stoppingToken, daemon, name, set).ConfigureAwait(false);
+            }
+            else if (agent.Status == AgentStatus.Stopped)
+            {
+                // A stranded agent. SubscriptionAgent.ReportCriticalFailureAsync sets its own Status and
+                // disposes itself, but never calls back into the daemon's StopAgentAsync -- so the corpse
+                // stays in the daemon's agent map. A ProgressionProgressOutOfOrderException lands it here
+                // with Status == Stopped and PausedTime == null, which matched neither branch above: the
+                // shard was dead, this node still held the set's lock, and nothing ever restarted it or
+                // released the lock. Paused agents self-heal through the branch above; Stopped ones did not.
+                //
+                // Restarting is safe and idempotent. Daemon.StartAgentAsync builds a *fresh* agent for the
+                // shard and AddOrUpdates it over the dead entry, and its own guard only declines when the
+                // existing agent is still Running.
+                _logger.LogWarning(
+                    "Restarting stranded projection agent {ShardName} on database {Database}: the agent is in a Stopped state while this node still holds the leadership lock",
+                    name.Identity, set.Database.Identifier);
+
                 await tryStartAgent(stoppingToken, daemon, name, set).ConfigureAwait(false);
             }
         }

--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -56,6 +56,30 @@ public class ProjectionOptions: ProjectionGraph<IProjection, IDocumentOperations
         set => _options.Events.UseIdentityMapForAggregates = value;
     }
 
+    /// <summary>
+    ///     In HotCold mode, how long this node may own zero projection sets before the
+    ///     ProjectionCoordinator logs a warning that it is running no asynchronous projections at all.
+    ///     Default is 2 minutes. Set to null to disable the warning entirely.
+    /// </summary>
+    /// <remarks>
+    ///     A node that has been denied every database's leadership lock is indistinguishable, in the logs,
+    ///     from a healthy node on an idle system -- the lock-denied branch of the coordinator's polling loop
+    ///     is otherwise completely silent. That silence hid a ~35 minute outage in which an ungracefully
+    ///     killed node's session-scoped advisory locks stayed alive server-side until Postgres's TCP layer
+    ///     gave up, leaving every replacement node with nothing to run.
+    ///
+    ///     On a genuinely multi-node HotCold cluster the standby nodes legitimately own nothing, and will
+    ///     emit this warning on the <see cref="NoOwnedProjectionSetsRepeatTime" /> cadence. That is the
+    ///     intended tradeoff: no single node can observe "nobody owns this database", only "I own nothing".
+    /// </remarks>
+    public TimeSpan? NoOwnedProjectionSetsWarningThreshold { get; set; } = 2.Minutes();
+
+    /// <summary>
+    ///     How often to repeat the warning described by <see cref="NoOwnedProjectionSetsWarningThreshold" />
+    ///     while this node continues to own zero projection sets. Default is 5 minutes.
+    /// </summary>
+    public TimeSpan NoOwnedProjectionSetsRepeatTime { get; set; } = 5.Minutes();
+
     protected override void onAddProjection(object projection)
     {
         if (projection is IAggregateProjection { Lifecycle: ProjectionLifecycle.Live } aggregateProjection)


### PR DESCRIPTION
Two independent daemon-coordination fixes for the 8.x line, prompted by a customer incident report. Bumps the branch to **8.38.0** (minor rather than patch — two additive public properties on `ProjectionOptions`).

## The incident

A daemon host was killed ungracefully by the hosting platform. Because there was no clean process exit, `StopAsync` → `ReleaseAllLocks()` never ran, and the node's advisory-lock sessions stayed alive **server-side** until Postgres's TCP layer noticed the dead peer — 20 to 33 minutes. Throughout that window every replacement instance was denied every database's leadership lock and ran **zero** projection agents, while every process involved looked healthy. Restarting the application could not fix it; each new instance faced the same orphaned locks.

Nothing in the logs said so. That is the part this PR addresses.

## 1. Lock denial is no longer silent

The lock-denied branch of `ProjectionCoordinator.executeAsync` produced no log, no metric and no health signal — only a thrown *exception* logged anything. A node that had been denied every lock was indistinguishable from a healthy node on an idle system, and the only observable symptom was the *absence* of `Started HighWaterAgent` lines.

The coordinator now tallies owned vs. denied projection sets each polling cycle and:

- logs at **Information** when that tally changes, so steady state stays quiet but `owns 0 of 33` is impossible to miss;
- logs at **Warning** once this node has owned nothing for longer than `StoreOptions.Projections.NoOwnedProjectionSetsWarningThreshold` (default 2 minutes, repeating every 5, `null` disables).

No single node can observe "nobody owns this database", only "I own nothing" — so standby nodes in a genuine multi-node HotCold cluster will emit this warning on the repeat cadence. That tradeoff is deliberate and is spelled out both in the warning text and in the option's XML docs.

## 2. Stranded `Stopped` agents now restart

Found while reading the coordination code; independent of the incident above.

`SubscriptionAgent.ReportCriticalFailureAsync` sets its own `Status` and disposes itself, but never calls back into the daemon's `StopAgentAsync` — so the dead agent stays in the daemon's agent map. On a `ProgressionProgressOutOfOrderException` it lands there with `Status == Stopped` and `PausedTime == null`, which matched **neither** restart branch in `startAgentsIfNecessaryAsync`:

```csharp
if (agent == null)                                     // restart
else if (agent is { Status: Paused, PausedTime: not null } && ...)  // restart
// else: nothing at all
```

The shard stayed dead, this node went on holding the set's leadership lock, and nothing ever restarted it or released the lock. Paused agents already self-healed; Stopped ones did not.

Restarting is safe and idempotent: `StartAgentAsync` builds a *fresh* agent for the shard and `AddOrUpdate`s it over the dead entry, and its own guard only declines when the existing agent is still `Running`.

## Testing

The threshold and throttling rules are extracted into `OwnershipTracker` so they can be unit tested without standing up a `DocumentStore` — 11 tests, including the case where the node owns 1 of 33 sets and correctly does *not* warn.

- `CoreTests`: 335 passed, 0 failed, 1 skipped
- `DaemonTests`: no new failures. `Composites.Bug_4329_fan_out_and_cache_limit` fails deterministically on a clean detached worktree at `origin/8.0` (`9e03eef68`) with none of this branch's code present, and `Bug_catching_up_apply_errors` flakes under full-suite ordering on both sides.

⚠️ **The `Stopped` restart branch has no automated coverage** — forcing a `ProgressionProgressOutOfOrderException` into a live daemon was more scaffolding than this change warranted. It mirrors the existing Paused branch and the restart is idempotent, but it is untested and should be reviewed as such.

## Not included

Their report also asks for a databases-owned/denied **metric** alongside the logging. Adding a `Meter` is more surface than belongs in a same-night patch; the logging alone satisfies "make lock denial loud". Easy to add as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)