### PR TITLE
marten#5305: regression guard for #4085, and the JasperFx bump it requires

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -342,19 +342,35 @@
          verified by diffing the discovered test list against master, not by comparing run totals.
          Inert for Marten: the Event Model provenance ladder (jasperfx#703/#704) only affects hosts
          registering an IEventModelDefinitionSource, which Marten does not, and
-         RetryBlock.ShouldRetry/OnTerminalFailure (jasperfx#701) are additive and default to null. -->
-    <PackageVersion Include="JasperFx" Version="2.56.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.56.0" />
+         RetryBlock.ShouldRetry/OnTerminalFailure (jasperfx#701) are additive and default to null.
+
+         2.57-2.59 (marten#5305): the bump this branch actually needs. jasperfx#721 fixed
+         TenantedEventSlicer.SliceAsync(EventRange) to honour ForceSingleTenancy. It was respected
+         only by the IReadOnlyList<IEvent> overload, and the async daemon reaches only the EventRange
+         one. Marten has set that flag in SingleStreamProjection.BuildSlicer since the marten#4085
+         fix, so until 2.58.0 the flag was being set on precisely the path that could not read it.
+         Bug_4085_async_projection_with_mixed_tenant_ids fails on anything earlier; that was verified
+         by pinning back to 2.57.2 and watching it go red, not by reading release notes.
+
+         Also arriving, both inert for Marten: jasperfx#723 moves ForceSingleTenancy resolution into
+         JasperFxSingleStreamProjectionBase behind IEventTenancySource on the session, which Marten's
+         own BuildSlicer override already computes identically (Polecat and Fisher, whose subclasses
+         are empty class bodies, are the stores that needed it); and two opt-in compliance suites
+         (jasperfx#724, #725) that add no tests until a store enrolls them. Marten enrolls neither;
+         see jasperfx#727 for why #724 in particular is being reconsidered. -->
+    <PackageVersion Include="JasperFx" Version="2.59.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.59.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.56.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.59.0" />
     <!--
-      Deliberately AHEAD of the rest of the JasperFx line, which stays at 2.41.0 until Marten adopts
-      the strong-typed identity compliance suite that landed in 2.42.0. This package is analyzer-only,
+      No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
+      whole family moves together, and this note is kept for the history below. This package is
+      analyzer-only,
       declares no dependencies, and Marten bundles its dll into Marten.nupkg (see
       _BundleEventsSourceGeneratorAnalyzer in Marten.csproj, marten#4557), so its version is
       independent of the runtime family's.
@@ -369,11 +385,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.56.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.59.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.56.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.59.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/Bugs/Bug_4085_async_projection_with_mixed_tenant_ids.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4085_async_projection_with_mixed_tenant_ids.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Events;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using NpgsqlTypes;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+// Regression guard for https://github.com/JasperFx/marten/issues/4085 (originally
+// JasperFx/wolverine#2053).
+//
+// On a SINGLE-TENANTED store, events on one stream can end up with disagreeing tenant_id
+// values -- the reporter had `DEFAULT` and `Marten` on the same stream, written by
+// Wolverine stamping appends inconsistently between IStartStream and plain
+// IEnumerable<object> returns. The async daemon then grouped that stream per tenant and
+// folded it into several partial aggregates, so an Apply saw a document with every
+// property at its default, as though Create had never run.
+//
+// Only the async daemon was affected. Live and inline aggregation fold the same events
+// correctly, which is exactly why this went unnoticed for as long as it did, and why this
+// test drives the daemon rather than asserting on a live aggregate.
+//
+// The fix has two halves that only work together:
+//
+//   * Marten's SingleStreamProjection.BuildSlicer sets ForceSingleTenancy on the slicer
+//     when EventGraph.TenancyStyle is Single. That has been here since the original fix.
+//   * TenantedEventSlicer honours that flag on BOTH of its overloads. It did not:
+//     SliceAsync(IReadOnlyList<IEvent>) respected it while SliceAsync(EventRange) ignored
+//     it -- and the async daemon reaches only the EventRange one. So the flag was being
+//     set on precisely the path that could not read it, and honoured on the path that
+//     never needed it. Fixed upstream in JasperFx/jasperfx#721, shipped in JasperFx
+//     2.58.0; this test fails on anything earlier.
+//
+// The rows are seeded by updating tenant_id directly rather than by reproducing the
+// Wolverine append path. That is deliberate: the bug is "given rows in this state, the
+// daemon must fold them as one aggregate", and how they reached that state is not
+// Marten's concern and is fragile to reproduce. The reporter's own workaround was the
+// mirror image of this UPDATE.
+public class Bug_4085_async_projection_with_mixed_tenant_ids: BugIntegrationContext
+{
+    public record TallyIncremented(int Amount);
+
+    // Additive on purpose. A stream folded once and a stream folded in two pieces differ
+    // in these numbers; a last-write-wins aggregate would hide the split.
+    public class MixedTenancyTally
+    {
+        public Guid Id { get; set; }
+        public int Total { get; set; }
+        public int EventCount { get; set; }
+
+        public void Apply(TallyIncremented e)
+        {
+            Total += e.Amount;
+            EventCount++;
+        }
+    }
+
+    [Fact]
+    public async Task async_projection_folds_one_stream_despite_disagreeing_tenant_ids()
+    {
+        StoreOptions(_ =>
+        {
+            // No conjoined tenancy: the store stays single-tenanted, which is the whole
+            // precondition. Any tenant id on an event is incidental rather than meaningful.
+            _.Projections.Snapshot<MixedTenancyTally>(SnapshotLifecycle.Async);
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<MixedTenancyTally>(streamId,
+            new TallyIncremented(1), new TallyIncremented(2), new TallyIncremented(4));
+        await theSession.SaveChangesAsync();
+
+        await dirtyTheTenantIdsOnAllButTheFirstEvent(streamId);
+
+        using var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(30.Seconds());
+
+        await using var query = theStore.QuerySession();
+        var tally = await query.Query<MixedTenancyTally>().FirstOrDefaultAsync(x => x.Id == streamId);
+
+        tally.ShouldNotBeNull();
+
+        // Before the fix the daemon sliced this stream into two tenant groups, and the
+        // document reflected only whichever group was applied last -- so both numbers came
+        // up short rather than wrong in some exotic way.
+        tally.EventCount.ShouldBe(3);
+        tally.Total.ShouldBe(7);
+    }
+
+    /// <summary>
+    /// Reproduce the reported table state: one stream whose events do not agree on tenant_id.
+    /// </summary>
+    private async Task dirtyTheTenantIdsOnAllButTheFirstEvent(Guid streamId)
+    {
+        await using var conn = theStore.Storage.Database.CreateConnection();
+        await conn.OpenAsync();
+
+        var updated = await conn
+            .CreateCommand(
+                $"update {theStore.Events.DatabaseSchemaName}.mt_events set tenant_id = 'Marten' where stream_id = :stream and version > 1")
+            .With("stream", streamId, NpgsqlDbType.Uuid)
+            .ExecuteNonQueryAsync();
+
+        // Guard the precondition. If a future change normalises tenant_id on write or read,
+        // this test would still pass -- for a reason that has nothing to do with slicing --
+        // and would quietly stop guarding #4085. Polecat and Fisher both turned out to
+        // normalise here, which is why the shared compliance suite could not cover this and
+        // it lives in Marten's own tests instead (JasperFx/jasperfx#727).
+        updated.ShouldBe(2);
+    }
+}


### PR DESCRIPTION
Closes #5305.

## The gap this closes

[#4085](https://github.com/JasperFx/marten/issues/4085) (originally wolverine#2053) was closed as fixed. It had **no regression test** — `2053` appeared exactly once in the whole source tree, in a comment on `SingleStreamProjection.BuildSlicer`.

Worse, the fix was structurally incomplete, and nothing here could have told us. Marten has set `ForceSingleTenancy` since the original fix. But `TenantedEventSlicer` honoured that flag on only **one of its two overloads**: `SliceAsync(IReadOnlyList<IEvent>)` respected it while `SliceAsync(EventRange)` ignored it — and the async daemon reaches only the `EventRange` one.

So the flag was being set on precisely the path that could not read it, and honoured on the path that never needed it. Which lines up exactly with what #4085 reported:

> Only async projections during rebuild/catchup are affected
>
> Live aggregation works correctly (not affected)

Fixed upstream in JasperFx/jasperfx#721, shipped in JasperFx **2.58.0**. That is why this PR bumps the pin rather than adding a test alone — the test cannot pass on 2.56.0.

## The test

`Bug_4085_async_projection_with_mixed_tenant_ids`, and it is a **proven** guard rather than an assumed one:

| JasperFx pin | Result |
|---|---|
| 2.57.2 (pre-fix) | **fails** — `Shouldly.ShouldAssertException : tally.EventCount` |
| 2.59.0 | **passes** |

Verified by pinning back and watching it go red, then forward again — not by reading release notes.

Two deliberate choices worth reviewing:

**It seeds the reported table state with an `UPDATE` on `tenant_id`** rather than reproducing the Wolverine append path. The bug is "given rows in this state, the daemon must fold them as one aggregate"; how they reached that state is not Marten's concern and is fragile to reproduce. The reporter's own workaround was the mirror image of this UPDATE.

**It asserts the UPDATE touched exactly two rows.** If a future change normalises `tenant_id` on write or read, the test would otherwise still pass — for a reason with nothing to do with slicing — and quietly stop guarding #4085.

**The aggregate is additive on purpose.** A stream folded once and a stream folded in two pieces differ in these numbers; a last-write-wins aggregate would hide the split.

## Why this test lives in Marten rather than the shared compliance suite

I first wrote this as a shared suite (JasperFx/jasperfx#724) and it does not work. Polecat and Fisher both **normalise `tenant_id` on write**, so neither can construct the precondition through the shared surface — the fact skips on both, asserting nothing. Marten appears to be the only store that can hold these rows, which is the wrong shape for a compliance suite. Written up in JasperFx/jasperfx#727; this PR is the coverage landing where the condition is actually reachable.

## The `IsGlobalWithinConjoinedTenancy` question — deliberately NOT answered here

#5305 also asks whether `isSingleTenanted` should be `TenancyStyle == Single || IsGlobalWithinConjoinedTenancy`, since `FetchAsyncPlan.cs:45` treats a global aggregate as single-tenanted while `BuildSlicer` does not.

What I established:

- `AddGlobalProjection` sets `IsGlobalWithinConjoinedTenancy = true` **and** `Schema.For<TDoc>().SingleTenanted()`, so the document is single-tenanted while events stay conjoined.
- Stream ids are globally unique under conjoined tenancy — `StartStream` with the same id from a second tenant throws `ExistingStreamIdCollisionException` — so one stream cannot be *created* across tenants.

What I could **not** establish: my probe's events all landed with `*DEFAULT*` tenant_id, so it never actually exercised mixed tenancy. I am not turning a misconfigured probe into a conclusion. The question is still open and wants someone with deeper knowledge of Marten's tenancy intent, or its own issue.

## Test results

`EventSourcingTests` on net9.0: **1991 passed, 4 failed** of 2002. All four investigated against a `master` baseline worktree at its own 2.56.0 pin:

| Failure | Verdict |
|---|---|
| `testing_projections.test_async_aggregation` | **pre-existing** — fails identically on master |
| `testing_projections.test_async_aggregation_with_wait_for` | **pre-existing** |
| `testing_projections.test_async_aggregation_with_wait_for_and_fake_time_provider` | **pre-existing** |
| `Bug_5268...the_concurrent_index_works_under_archived_stream_partitioning` | **environmental** — passes on this branch against a clean database; the failure only appears after repeated full-suite runs against a reused one |

None are caused by this change. A clean-database full run is in flight to confirm the count; I will update here if it says otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)