### PR TITLE
Extended progression: stop gating the table shape on configuration, restore the default, and answer the slicing question (#5307, #5308, #5309, #5310)

### DIFF
--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -686,17 +686,24 @@ past the event type's introduction.
 A shard that recovers clears its failure columns on the next successful start, so a supervisor built on
 them does not keep alerting on a failure that was fixed an hour ago.
 
-**Default: off**. The columns are useful for
-any stuck-shard diagnosis -- not just CritterWatch -- and the write-side cost is
-negligible because they're already-computed daemon-internal values. When enabled,
-the next `ApplyAllConfiguredChangesToDatabaseAsync()` adds the columns to an existing
-database; they're nullable so no backfill is required.
+**Default: on.** The columns are useful for any stuck-shard diagnosis -- not just CritterWatch --
+and the write-side cost is negligible, because they carry already-computed daemon-internal values.
 
-Opt in (e.g. for CritterWatch monitoring or your own shard health tooling)
-by setting the toggle to true explicitly:
+The columns themselves are created for **every** store regardless of this setting, and the next
+`ApplyAllConfiguredChangesToDatabaseAsync()` adds them to an existing database. They are nullable,
+so no backfill is required, and a store that leaves tracking off simply never writes them.
+
+That the shape does not depend on the setting is deliberate. It used to, and two `DocumentStore`s
+pointed at the same `DatabaseSchemaName` that disagreed about the flag then stripped each other's
+columns on every schema application -- last writer wins, with no warning on either side. Two
+processes over one schema is an ordinary arrangement (a service beside a seeder, a reporting job or
+a migration tool), so the table shape is now the same for all of them
+(see [marten#5309](https://github.com/JasperFx/marten/issues/5309)).
+
+To turn the tracking off, set the toggle explicitly:
 
 ```cs
-opts.Events.EnableExtendedProgressionTracking = true;
+opts.Events.EnableExtendedProgressionTracking = false;
 ```
 
 Marten registers a storage-agnostic
@@ -720,11 +727,12 @@ public class EnableExtendedProgression: IConfigureMarten
 }
 ```
 
-The adapter's value is applied at store build and does **not** overwrite a direct
-`opts.Events.EnableExtendedProgressionTracking = true`, so the two opt-in paths
-compose. (Note that `opts.Events` -- Marten's `EventGraph` -- does not itself
-implement `IEventStoreInstrumentation`; use the `EnableExtendedProgressionTracking`
-property shown above.)
+The adapter's value is applied at store build only if something actually set it, so it does **not**
+overwrite a direct `opts.Events.EnableExtendedProgressionTracking = ...` of either polarity and the
+two paths compose. Setting `ExtendedProgressionEnabled = false` on the adapter is a real opt-out, not
+merely the absence of an opt-in. (Note that `opts.Events` -- Marten's `EventGraph` -- does not itself
+implement `IEventStoreInstrumentation`; use the `EnableExtendedProgressionTracking` property shown
+above.)
 
 ### What extended progression actually costs
 

--- a/src/CoreTests/Events/EventGraph_IEventStoreInstrumentation.cs
+++ b/src/CoreTests/Events/EventGraph_IEventStoreInstrumentation.cs
@@ -14,14 +14,67 @@ namespace CoreTests.Events;
 public class EventGraph_IEventStoreInstrumentation
 {
 
-    // #4687: default flipped from false → true (Critter Stack 1.0 timing). The six
-    // monitoring columns are written from existing daemon runtime state so the cost is
-    // negligible, and they're useful for any stuck-shard diagnosis -- not just CritterWatch.
-    // Opt-out remains via either name.
+    // #4687: default flipped from false → true (Critter Stack 1.0 timing). The monitoring
+    // columns are written from existing daemon runtime state so the cost is negligible, and
+    // they're useful for any stuck-shard diagnosis -- not just CritterWatch.
+    //
+    // #5310: this guard is the whole reason that flip regressed unnoticed. 824e3b783 added the
+    // `= true` and renamed this test to default_is_enabled; 769a6fd5e reverted both the next day
+    // while moving the property onto the SetEventStoreInstrumentation adapters, leaving this
+    // comment arguing for a default the test underneath it pinned as false. Both shipped in
+    // V9.30.0. If this is ever flipped back, flip the comment with it.
     [Fact]
-    public void default_is_disabled()
+    public void default_is_enabled()
     {
-        new StoreOptions().EventGraph.EnableExtendedProgressionTracking.ShouldBeFalse();
+        new StoreOptions().EventGraph.EnableExtendedProgressionTracking.ShouldBeTrue();
+    }
+
+    // #5310: the scope of the regression was wider than "a bare DocumentStore.For(...) gets false"
+    // -- no path defaulted to true, AddMarten included. Pin the DI path separately, since it runs
+    // the adapters and the bare StoreOptions constructor does not.
+    [Fact]
+    public void add_marten_alone_is_enabled()
+    {
+        var collection = new ServiceCollection();
+        collection.AddMarten(ConnectionSource.ConnectionString);
+
+        using var provider = collection.BuildServiceProvider();
+        provider.GetRequiredService<IDocumentStore>()
+            .Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+    }
+
+    // #5310: with a true default, an opt-out has to actually opt out. #4981's guard was
+    // `if (ExtendedProgressionEnabled)`, which cannot fire for false -- correct while the default
+    // was false, silently inert the moment it is true. The adapter now distinguishes unset from
+    // explicitly-false, so this is the case that would regress if it ever goes back to a plain bool.
+    [Fact]
+    public void explicit_opt_out_on_the_di_singleton_is_honored()
+    {
+        var collection = new ServiceCollection();
+        collection.AddMarten(ConnectionSource.ConnectionString);
+
+        using var provider = collection.BuildServiceProvider();
+        provider.GetRequiredService<IEventStoreInstrumentation>().ExtendedProgressionEnabled = false;
+
+        provider.GetRequiredService<IDocumentStore>()
+            .Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+    }
+
+    // #5310: and the direct opt-out has to survive the adapter too -- the mirror of
+    // direct_toggle_inside_add_marten_survives_store_build, which only covered opting IN.
+    [Fact]
+    public void direct_opt_out_inside_add_marten_survives_store_build()
+    {
+        var collection = new ServiceCollection();
+        collection.AddMarten(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Events.EnableExtendedProgressionTracking = false;
+        });
+
+        using var provider = collection.BuildServiceProvider();
+        provider.GetRequiredService<IDocumentStore>()
+            .Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
     }
 
     [Fact]
@@ -59,25 +112,27 @@ public class EventGraph_IEventStoreInstrumentation
         store.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
     }
 
-    // #4981: the adapter must apply, not clobber -- a direct opt-in and the DI-singleton opt-in
-    // (what CritterWatch uses) compose rather than fighting.
+    // #4981: the adapter must apply, not clobber. Under the #5310 true default the interesting
+    // direction is the opposite one from the original test -- an untouched DI singleton must leave
+    // a direct opt-OUT alone, which is exactly what an unconditional assignment would break.
     [Fact]
-    public void direct_toggle_and_di_singleton_toggle_compose()
+    public void untouched_di_singleton_does_not_clobber_a_direct_toggle()
     {
         var collection = new ServiceCollection();
         collection.AddMarten(opts =>
         {
             opts.Connection(ConnectionSource.ConnectionString);
-            opts.Events.EnableExtendedProgressionTracking = true;
+            opts.Events.EnableExtendedProgressionTracking = false;
         });
 
         using var provider = collection.BuildServiceProvider();
 
-        // DI singleton left at its default (false) -- the direct toggle must still win.
-        provider.GetRequiredService<IEventStoreInstrumentation>().ExtendedProgressionEnabled.ShouldBeFalse();
+        // Never assigned, so the adapter has nothing to apply and the direct toggle stands. The
+        // getter reports the EventGraph default it would leave in place rather than default(bool).
+        provider.GetRequiredService<IEventStoreInstrumentation>().ExtendedProgressionEnabled.ShouldBeTrue();
 
         var store = provider.GetRequiredService<IDocumentStore>();
-        store.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+        store.Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
     }
 
     [Fact]

--- a/src/CoreTests/Events/extended_progression_gate.cs
+++ b/src/CoreTests/Events/extended_progression_gate.cs
@@ -7,16 +7,33 @@ using Xunit;
 namespace CoreTests.Events;
 
 // #750 regression guard. The async daemon's ExtendedProgressionWriter observer gates on
-// IEventStore.ExtendedProgressionEnabled, whose interface default is false. Marten's DocumentStore
-// must reflect the store opt-in here or the observer silently never fires and the extended
-// progression columns (heartbeat / agent_status / pause_reason / running_on_node) stay NULL --
-// exactly the "a feature that was built and never connected" failure #750 reported.
+// IEventStore.ExtendedProgressionEnabled. Marten's DocumentStore must reflect the store setting here
+// or the observer silently never fires and the extended progression columns (heartbeat /
+// agent_status / pause_reason / running_on_node) stay NULL -- exactly the "a feature that was built
+// and never connected" failure #750 reported. Since #5310 the store default is true, so the failure
+// #750 describes now lives on the opt-OUT side: a store that turns tracking off must be reported as
+// off, or the observer fires for a deployment that asked it not to.
 public class extended_progression_gate
 {
+    // #5310: the default is true again. What #750 is actually about is that this property must TRACK
+    // the store option rather than being hardcoded, so the guard is that both polarities are reported
+    // faithfully -- not that either one of them is the default.
     [Fact]
-    public void event_store_reports_extended_progression_disabled_by_default()
+    public void event_store_reports_extended_progression_enabled_by_default()
     {
         using var store = DocumentStore.For(ConnectionSource.ConnectionString);
+        ((IEventStore)store).ExtendedProgressionEnabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void event_store_reflects_the_extended_progression_opt_out()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Events.EnableExtendedProgressionTracking = false;
+        });
+
         ((IEventStore)store).ExtendedProgressionEnabled.ShouldBeFalse();
     }
 

--- a/src/CoreTests/jasper_fx_mechanics.cs
+++ b/src/CoreTests/jasper_fx_mechanics.cs
@@ -408,8 +408,11 @@ public class jasper_fx_mechanics
     [Fact]
     public async Task advanced_tracking_off_leaves_extended_progression_tracking_at_default()
     {
-        // Sanity: when EnableAdvancedTracking is not set (default false), we do NOT
-        // flip EnableExtendedProgressionTracking on. Per-store opt-in is preserved.
+        // Sanity: when EnableAdvancedTracking is not set (default false), ReadJasperFxOptions does
+        // not touch EnableExtendedProgressionTracking at all -- the stores keep whatever the Marten
+        // default is. #5310 restored that default to true, so "at default" now means true; the point
+        // of the test is that JasperFxOptions is not the thing deciding it, which is why the
+        // assertions read the same for every store below.
         using var host = await Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
             {
@@ -429,10 +432,10 @@ public class jasper_fx_mechanics
             }).StartAsync();
 
         var main = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
-        main.Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+        main.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
 
         var first = host.Services.GetRequiredService<IFirstStore>().As<DocumentStore>();
-        first.Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+        first.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
     }
 
     [Fact]

--- a/src/DaemonTests/Bugs/Bug_5309_progression_columns_survive_a_store_with_tracking_off.cs
+++ b/src/DaemonTests/Bugs/Bug_5309_progression_columns_survive_a_store_with_tracking_off.cs
@@ -1,0 +1,201 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using Marten;
+using Marten.Testing;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace DaemonTests.Bugs;
+
+/// <summary>
+/// #5309 — two <see cref="DocumentStore" />s over one <c>DatabaseSchemaName</c> that disagreed about
+/// <c>EnableExtendedProgressionTracking</c> used to undo each other's schema. The flag-off store did not
+/// merely decline to add the extended columns to <c>mt_event_progression</c>: its expected table
+/// genuinely lacked them, the delta resolved them as extras, and Weasel emitted
+/// <c>alter table … drop column</c> for each one. Whichever store applied schema last decided the
+/// table's shape, and they kept stripping each other for as long as both ran.
+///
+/// <para>
+/// Nothing warned either side. The flag-off store had no reason to log anything, and the flag-on store
+/// then failed every progression read with <c>column "heartbeat" does not exist</c>. Found downstream as
+/// CritterWatch#1183, where a sample's publisher and its host shared three schemas and the console went
+/// silently dark — the poller catches per-database — rather than noisily broken.
+/// </para>
+///
+/// <para>
+/// The blast radius was bounded, and measured rather than assumed: the columns dropped IN PLACE, so the
+/// progression rows kept their <c>last_seq_id</c>. It cost monitoring data, not projection positions —
+/// projections did not rewind. <c>last_seq_id_survives_the_strip</c> below pins that, because if the fix
+/// ever regresses it is the difference between an annoyance and a data-loss incident.
+/// </para>
+///
+/// <para>
+/// The fix is that the shape of this table no longer depends on configuration at all: every column is
+/// created for every store, and the flag gates only whether the daemon reads and writes them. The same
+/// applies to <c>UseOptimizedProjectionRebuilds</c> and its three columns, which had the identical defect
+/// for the identical reason and is covered here too.
+/// </para>
+/// </summary>
+public record ProgressionProbe5309(int Number);
+
+public class Bug_5309_progression_columns_survive_a_store_with_tracking_off: OneOffConfigurationsContext
+{
+    private static readonly string[] ExtendedColumns =
+    [
+        "heartbeat", "agent_status", "pause_reason", "running_on_node", "warning_behind_threshold",
+        "critical_behind_threshold", "failure_category", "failure_event_sequence", "failure_event_type",
+        "failure_event_tenant_id"
+    ];
+
+    private static readonly string[] RebuildColumns = ["mode", "rebuild_threshold", "assigned_node"];
+
+    [Fact]
+    public async Task a_store_with_tracking_off_does_not_strip_the_extended_columns()
+    {
+        var schema = await trackedStoreCreatesTheTableAsync();
+
+        // The precondition. Without it the assertion below passes vacuously if the flag-on store never
+        // wrote the columns in the first place -- which is the exact trap that made #4085's shared-suite
+        // coverage useless on two stores.
+        var before = await progressionColumnsAsync(schema);
+        foreach (var column in ExtendedColumns) before.ShouldContain(column);
+
+        await applySchemaFromAStoreWithTrackingOffAsync(schema);
+
+        var after = await progressionColumnsAsync(schema);
+        foreach (var column in ExtendedColumns)
+        {
+            after.ShouldContain(column,
+                $"'{column}' was dropped by a store with EnableExtendedProgressionTracking off");
+        }
+    }
+
+    /// <summary>
+    /// The same defect, the same table, a different flag. <c>UseOptimizedProjectionRebuilds</c> gated
+    /// three columns the identical way, so two stores disagreeing about IT stripped those three. Fixed by
+    /// the same change and pinned here so it is not gated again on the grounds that only the extended
+    /// block was reported.
+    /// </summary>
+    [Fact]
+    public async Task a_store_with_optimized_rebuilds_off_does_not_strip_the_rebuild_columns()
+    {
+        var schema = await trackedStoreCreatesTheTableAsync();
+
+        var before = await progressionColumnsAsync(schema);
+        foreach (var column in RebuildColumns) before.ShouldContain(column);
+
+        await applySchemaFromAStoreWithTrackingOffAsync(schema);
+
+        var after = await progressionColumnsAsync(schema);
+        foreach (var column in RebuildColumns)
+        {
+            after.ShouldContain(column,
+                $"'{column}' was dropped by a store with UseOptimizedProjectionRebuilds off");
+        }
+    }
+
+    /// <summary>
+    /// The severity claim in the issue, pinned rather than asserted. The columns dropped in place, so the
+    /// progression rows kept their positions and projections did not rewind. If a future change ever makes
+    /// the strip recreate the table instead, this is the test that turns a monitoring bug into the
+    /// data-loss report it would then be.
+    /// </summary>
+    [Fact]
+    public async Task last_seq_id_survives_the_strip()
+    {
+        var schema = await trackedStoreCreatesTheTableAsync();
+
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
+            await conn.CreateCommand(
+                    $"insert into {schema}.mt_event_progression (name, last_seq_id, last_updated) "
+                    + "values ('Probe5309:All', 4242, now())")
+                .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        await applySchemaFromAStoreWithTrackingOffAsync(schema);
+
+        await using var check = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await check.OpenAsync(TestContext.Current.CancellationToken);
+        var seq = await check
+            .CreateCommand($"select last_seq_id from {schema}.mt_event_progression where name = 'Probe5309:All'")
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken);
+
+        seq.ShouldBe(4242L);
+    }
+
+    /// <summary>
+    /// And the sharper edge: a host that asserts its schema at boot rather than applying it. Under
+    /// AutoCreate.None a stripped table does not migrate on the next start, it refuses to run.
+    /// </summary>
+    [Fact]
+    public async Task the_tracked_store_still_matches_its_configuration_afterwards()
+    {
+        var schema = await trackedStoreCreatesTheTableAsync();
+        await applySchemaFromAStoreWithTrackingOffAsync(schema);
+
+        await theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync();
+    }
+
+    private async Task<string> trackedStoreCreatesTheTableAsync()
+    {
+        StoreOptions(x =>
+        {
+            x.Events.EnableExtendedProgressionTracking = true;
+            x.Events.UseOptimizedProjectionRebuilds = true;
+
+            // Registering an event type is what puts the event store's tables into the schema migration
+            // at all. Without it mt_event_progression is never compared, every delta comes back None, and
+            // every assertion in this class is vacuous.
+            x.Events.AddEventType(typeof(ProgressionProbe5309));
+        });
+
+        await theStore.EnsureStorageExistsAsync(typeof(IEvent));
+        return theStore.Events.DatabaseSchemaName;
+    }
+
+    /// <summary>
+    /// The second process: a seeder, a reporting job or a migration tool beside the main service. It
+    /// points at the same schema, does not opt into either flag, and applies schema — which is all it
+    /// takes.
+    /// </summary>
+    private static async Task applySchemaFromAStoreWithTrackingOffAsync(string schema)
+    {
+        await using var bare = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = schema;
+            opts.Events.EnableExtendedProgressionTracking = false;
+            opts.Events.UseOptimizedProjectionRebuilds = false;
+            opts.Events.AddEventType(typeof(ProgressionProbe5309));
+        });
+
+        await bare.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    private static async Task<List<string>> progressionColumnsAsync(string schema)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+
+        await using var reader = await conn
+            .CreateCommand(
+                "select column_name from information_schema.columns where table_schema = :schema and table_name = 'mt_event_progression'")
+            .With("schema", schema, NpgsqlTypes.NpgsqlDbType.Varchar)
+            .ExecuteReaderAsync(TestContext.Current.CancellationToken);
+
+        var names = new List<string>();
+        while (await reader.ReadAsync(TestContext.Current.CancellationToken))
+        {
+            names.Add(reader.GetString(0));
+        }
+
+        return names;
+    }
+}

--- a/src/EventSourcingTests/Bugs/Bug_5307_global_aggregate_slicing_under_conjoined_tenancy.cs
+++ b/src/EventSourcingTests/Bugs/Bug_5307_global_aggregate_slicing_under_conjoined_tenancy.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using NpgsqlTypes;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+// #5307, split out of #5305. Two places decide whether a stream should be treated as
+// single-tenanted, and they disagree:
+//
+//   * FetchAsyncPlan counts a GLOBAL AGGREGATE as single-tenanted
+//     (`TenancyStyle == Single || GlobalAggregates.Contains(typeof(TDoc))`).
+//   * SingleStreamProjection.BuildSlicer looks only at `TenancyStyle == Single`.
+//
+// So on a conjoined store a global aggregate is FETCHED as global but its events are SLICED per
+// tenant. AddGlobalProjection deliberately creates that mismatch -- the document is made
+// single-tenanted while the events stay conjoined -- and the projection's own validation permits it
+// via the !IsGlobalWithinConjoinedTenancy guard. Until JasperFx 2.58.0 the difference could not have
+// mattered, because TenantedEventSlicer honoured ForceSingleTenancy on only one of its two overloads
+// and the async daemon reaches the other (jasperfx#721). #5306 bumped to 2.59.0, which makes the flag
+// live and the asymmetry observable for the first time.
+//
+// ANSWER: the asymmetry is harmless, because the hazard it would cause is prevented one layer
+// earlier. GlobalEventAppenderDecorator forces every stream belonging to a global aggregate onto the
+// default tenant AT WRITE TIME, so a global aggregate's stream cannot carry disagreeing tenant_ids in
+// the first place and per-tenant slicing has nothing to split. These tests pin that, rather than the
+// slicer's behaviour, because that is where the guarantee actually lives -- and they probe both of the
+// appender's two matching rules, since a gap in either one would reopen the question.
+public class Bug_5307_global_aggregate_slicing_under_conjoined_tenancy: OneOffConfigurationsContext
+{
+    public record TallyIncremented(int Amount);
+
+    // Deliberately NOT applied by GlobalTally. GlobalEventAppenderDecorator.Matches has two rules --
+    // the stream's AggregateType is a global aggregate, or one of the appended events is an event type
+    // the global projection includes. An event satisfying neither is the one shape that could still
+    // reach storage under a non-default tenant, so it needs its own case.
+    public record UnrelatedNoise(string What);
+
+    // Additive on purpose, exactly as in Bug_4085: a stream folded once and a stream folded in pieces
+    // differ in these numbers, where a last-write-wins aggregate would hide the split.
+    public class GlobalTally
+    {
+        public Guid Id { get; set; }
+        public int Total { get; set; }
+        public int EventCount { get; set; }
+
+        public void Apply(TallyIncremented e)
+        {
+            Total += e.Amount;
+            EventCount++;
+        }
+    }
+
+    private void ConfigureGlobalProjectionStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AddEventType<UnrelatedNoise>();
+
+            // What creates the mismatch under test: TDoc joins EventGraph.GlobalAggregates,
+            // IsGlobalWithinConjoinedTenancy is set, and the DOCUMENT is overridden to single-tenanted
+            // while the EVENTS stay conjoined.
+            opts.Projections.AddGlobalProjection(new SingleStreamProjection<GlobalTally, Guid>(),
+                ProjectionLifecycle.Async);
+        });
+    }
+
+    /// <summary>
+    /// The mechanism, pinned directly. A cross-tenant append to a global aggregate's stream is accepted
+    /// -- and lands on the default tenant anyway.
+    /// </summary>
+    [Fact]
+    public async Task a_global_aggregates_stream_is_normalised_to_the_default_tenant_on_write()
+    {
+        ConfigureGlobalProjectionStore();
+
+        var streamId = Guid.NewGuid();
+
+        // Assert the session really does carry a non-default tenant, so that the DEFAULT below is
+        // Marten normalising rather than the test never having configured tenancy at all. Not
+        // establishing this is how the original probe on #5305 produced a result that proved nothing.
+        await using (var blue = theStore.LightweightSession("blue"))
+        {
+            blue.TenantId.ShouldBe("blue");
+
+            blue.Events.StartStream<GlobalTally>(streamId, new TallyIncremented(1));
+            await blue.SaveChangesAsync();
+        }
+
+        // A cross-tenant append to an already-existing stream. EventGraph.Append stamps the
+        // StreamAction with the SESSION's tenant, so absent the global-appender decorator this is all
+        // it would take to get disagreeing tenant_ids onto one stream.
+        await using (var red = theStore.LightweightSession("red"))
+        {
+            red.Events.Append(streamId, new TallyIncremented(2), new TallyIncremented(4));
+            await red.SaveChangesAsync();
+        }
+
+        // Matched by BOTH of the decorator's rules here: the first append by AggregateType, the second
+        // by TallyIncremented being an event type the global projection includes.
+        var tenantIds = await tenantIdsOnStreamAsync(streamId);
+        tenantIds.ShouldBe([StorageConstants.DefaultTenantId]);
+    }
+
+    /// <summary>
+    /// And the consequence: with the whole stream on one tenant, per-tenant slicing has nothing to
+    /// split and the daemon folds it once. This is the assertion #5305 wanted and could not make.
+    /// </summary>
+    [Fact]
+    public async Task the_async_daemon_folds_a_global_aggregate_once_under_conjoined_tenancy()
+    {
+        ConfigureGlobalProjectionStore();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var blue = theStore.LightweightSession("blue"))
+        {
+            blue.Events.StartStream<GlobalTally>(streamId, new TallyIncremented(1));
+            await blue.SaveChangesAsync();
+        }
+
+        await using (var red = theStore.LightweightSession("red"))
+        {
+            red.Events.Append(streamId, new TallyIncremented(2), new TallyIncremented(4));
+            await red.SaveChangesAsync();
+        }
+
+        using var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(30.Seconds());
+
+        await using var query = theStore.QuerySession();
+        var tally = await query.LoadAsync<GlobalTally>(streamId);
+
+        tally.ShouldNotBeNull();
+
+        // Sliced per tenant, the document would reflect only the group applied last -- so both numbers
+        // would come up short rather than wrong in some exotic way.
+        tally.EventCount.ShouldBe(3);
+        tally.Total.ShouldBe(7);
+    }
+
+    /// <summary>
+    /// The remaining shape, and the one that decides whether "harmless" is the whole answer. An event
+    /// that is neither appended under a stream declared for the global aggregate nor one of the
+    /// projection's own event types satisfies neither of GlobalEventAppenderDecorator.Matches's rules.
+    /// This test asserts its own precondition -- that the tenant ids really do disagree -- and only then
+    /// asks whether the daemon still folds the aggregate correctly.
+    /// </summary>
+    [Fact]
+    public async Task an_unrelated_event_type_does_not_corrupt_the_global_aggregate()
+    {
+        ConfigureGlobalProjectionStore();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var blue = theStore.LightweightSession("blue"))
+        {
+            blue.Events.StartStream<GlobalTally>(streamId, new TallyIncremented(1), new TallyIncremented(2),
+                new TallyIncremented(4));
+            await blue.SaveChangesAsync();
+        }
+
+        await using (var red = theStore.LightweightSession("red"))
+        {
+            red.Events.Append(streamId, new UnrelatedNoise("not part of the tally"));
+            await red.SaveChangesAsync();
+        }
+
+        // THE PRECONDITION. Without it this passes vacuously if the decorator turns out to catch this
+        // shape too, making it a duplicate of the first test rather than a probe of the gap. Skipping
+        // this check is exactly the trap that made #4085's shared-suite coverage useless on two stores
+        // (jasperfx#727).
+        var tenantIds = await tenantIdsOnStreamAsync(streamId);
+        tenantIds.Count.ShouldBe(2);
+        tenantIds.ShouldContain(StorageConstants.DefaultTenantId);
+        tenantIds.ShouldContain("red");
+
+        using var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(30.Seconds());
+
+        await using var query = theStore.QuerySession();
+        var tally = await query.LoadAsync<GlobalTally>(streamId);
+
+        tally.ShouldNotBeNull();
+
+        // The three tally events all sit on the default tenant, so a per-tenant split leaves them in one
+        // group regardless; the 'red' group holds only the event the projection ignores. If that group
+        // can still overwrite the document, these come up short.
+        tally.EventCount.ShouldBe(3);
+        tally.Total.ShouldBe(7);
+    }
+
+    /// <summary>
+    /// The distinct tenant_id values actually persisted for one stream, read from the table rather than
+    /// inferred from what the test asked for -- because what the test asked for is precisely the thing
+    /// in question.
+    /// </summary>
+    private async Task<List<string>> tenantIdsOnStreamAsync(Guid streamId)
+    {
+        await using var conn = theStore.Storage.Database.CreateConnection();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+
+        await using var reader = await conn
+            .CreateCommand(
+                $"select distinct tenant_id from {theStore.Events.DatabaseSchemaName}.mt_events where stream_id = :stream order by 1")
+            .With("stream", streamId, NpgsqlDbType.Uuid)
+            .ExecuteReaderAsync(TestContext.Current.CancellationToken);
+
+        var ids = new List<string>();
+        while (await reader.ReadAsync(TestContext.Current.CancellationToken))
+        {
+            ids.Add(reader.GetString(0));
+        }
+
+        return ids;
+    }
+}

--- a/src/EventSourcingTests/Dcb/Bug_5268_hstore_tag_index_can_be_built_out_of_band.cs
+++ b/src/EventSourcingTests/Dcb/Bug_5268_hstore_tag_index_can_be_built_out_of_band.cs
@@ -37,6 +37,25 @@ public class Bug_5268_hstore_tag_index_can_be_built_out_of_band: OneOffConfigura
     {
         return StoreOptions(opts =>
         {
+            // #5308: CREATE INDEX CONCURRENTLY cannot finish until every transaction that was open when
+            // it started has finished, and that wait is cluster-wide -- transactions in completely
+            // unrelated schemas count. A full single-process EventSourcingTests run keeps sessions open
+            // across hundreds of schemas, so whichever method here happens to start while enough of them
+            // are in flight waits behind them and blows Npgsql's 30s default. The symptom is a command
+            // timeout rather than an assertion, on a different method each run, while the class passes
+            // 8 of 8 in isolation -- which reads as a regression in whatever change you are validating.
+            //
+            // CI never tripped this, because it shards the suite per area and no job concentrates that
+            // much concurrent load on one instance. But a test whose success depends on how much
+            // unrelated work happens to be in flight is fragile regardless of whether CI currently
+            // trips it, and validating a dependency bump by running everything at once and comparing
+            // failure counts is a reasonable thing to want to do. This removes the dependency instead of
+            // leaving it to be rediscovered.
+            //
+            // A longer timeout, not [Trait("Isolated")]: the contention is other transactions on the
+            // same DATABASE, so moving this class to its own process does not remove it.
+            opts.CommandTimeout = 300;
+
             opts.Events.AddEventType<StudentEnrolled>();
             opts.Events.UseArchivedStreamPartitioning = archivedPartitioning;
 

--- a/src/Marten/Events/Aggregation/SingleStreamProjection.cs
+++ b/src/Marten/Events/Aggregation/SingleStreamProjection.cs
@@ -50,7 +50,28 @@ public class SingleStreamProjection<TDoc, TId>:
     {
         // This will address https://github.com/JasperFx/wolverine/issues/2053
         var isSingleTenanted = session.As<QuerySession>().Options.EventGraph.TenancyStyle == TenancyStyle.Single;
-        return new TenantedEventSlicer<TDoc, TId>(new ByStream<TDoc, TId>()){ForceSingleTenancy = isSingleTenanted};
+
+        // #5307: a global aggregate counts too, so that this agrees with FetchAsyncPlan, which has
+        // always read `TenancyStyle == Single || GlobalAggregates.Contains(typeof(TDoc))`. Under
+        // AddGlobalProjection the document is single-tenanted while the events stay conjoined, so
+        // slicing per tenant would be slicing a stream that the fetch path treats as one.
+        //
+        // This is alignment, not a fix: no reachable corruption depended on it, and the reason is
+        // structural rather than lucky. GlobalEventAppenderDecorator forces a global aggregate's
+        // stream onto the default tenant at WRITE time, matching either on the stream's AggregateType
+        // or on the event type being one the global projection includes -- which is exactly the set of
+        // events this projection could ever apply. So every event that could reach an Apply is already
+        // on one tenant by the time the slicer sees it, and the per-tenant split had nothing to split.
+        // An event type the projection does NOT include can still land under another tenant, but it
+        // lands in a group the projection ignores. Both shapes are pinned in
+        // Bug_5307_global_aggregate_slicing_under_conjoined_tenancy.
+        //
+        // Setting it anyway means the two sites cannot drift into disagreeing again, and that the next
+        // reader does not have to reconstruct the argument above to decide whether they are safe.
+        return new TenantedEventSlicer<TDoc, TId>(new ByStream<TDoc, TId>())
+        {
+            ForceSingleTenancy = isSingleTenanted || IsGlobalWithinConjoinedTenancy
+        };
     }
 
     public static void Register<TConcrete>(IServiceCollection services, ProjectionLifecycle lifecycle,

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -282,15 +282,27 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     public bool EnableEventSkippingInProjectionsOrSubscriptions { get; set; }
 
     /// <summary>
-    /// When enabled, adds heartbeat, agent_status, pause_reason, running_on_node, and
-    /// warning/critical-behind-threshold columns to the event progression table for
-    /// CritterWatch monitoring.
+    /// When enabled, the daemon writes heartbeat, agent_status, pause_reason, running_on_node and the
+    /// failure_* columns of the event progression table, and progression reads hydrate them, for
+    /// CritterWatch monitoring. Defaults to <c>true</c>.
     /// </summary>
+    /// <remarks>
+    /// #4687 flipped this default from false to true; the values are written from daemon runtime state
+    /// that already exists, so the cost is negligible and the columns are useful for any stuck-shard
+    /// diagnosis, not just CritterWatch. #5310: that flip landed in 824e3b783 and was lost the next day
+    /// in 769a6fd5e, which moved the property onto the SetEventStoreInstrumentation adapters and did not
+    /// carry the initializer over -- taking the regression guard with it, which is why nothing caught it.
+    /// <para>
+    /// This no longer decides the SHAPE of mt_event_progression. Since #5309 the columns are always
+    /// created, because a table shape that depends on configuration means two stores over one schema can
+    /// disagree about it and strip each other's columns. This flag now gates only reads and writes.
+    /// </para>
+    /// </remarks>
     public bool EnableExtendedProgressionTracking
     {
         get;
         set;
-    }
+    } = true;
 
     /// <summary>
     /// Optional best-effort observer invoked after each successful <c>SaveChangesAsync</c> with the

--- a/src/Marten/Events/Schema/EventProgressionTable.cs
+++ b/src/Marten/Events/Schema/EventProgressionTable.cs
@@ -37,51 +37,66 @@ internal class EventProgressionTable: Table
         // single-PK shape. See Marten.Events.Daemon.HighWater.HighWaterShardIdentity
         // for the canonical producer (#4681).
 
-        if (eventGraph.UseOptimizedProjectionRebuilds)
-        {
-            AddColumn<string>("mode").DefaultValueByString(ShardMode.none.ToString());
-            AddColumn<int>("rebuild_threshold").DefaultValueByExpression("0");
-            AddColumn<int>("assigned_node").DefaultValueByExpression("0");
-        }
+        // #5309: the optional blocks below are DELIBERATELY not gated on the options that decide
+        // whether Marten reads and writes them. The shape of this table is the same for every store
+        // regardless of EnableExtendedProgressionTracking and UseOptimizedProjectionRebuilds; only
+        // the daemon's use of the columns is conditional.
+        //
+        // Gating the DDL made two DocumentStores over one DatabaseSchemaName undo each other. The
+        // store with the flag off does not merely decline to add the columns -- its expected table
+        // genuinely lacks them, the delta resolves them as extras, and Weasel emits `alter table ...
+        // drop column` for each. Whichever store applies schema last decides the shape, and they keep
+        // stripping each other for as long as both run. Nothing warns either side: the flag-off store
+        // logs no reason to, and the flag-on store then fails every progression read with `column
+        // "heartbeat" does not exist`. Two processes over one schema -- a service beside a seeder, a
+        // reporting job or a migration tool -- is ordinary, and neither of them is doing anything
+        // wrong. Found downstream as CritterWatch#1183, where the console went silently dark rather
+        // than noisily broken because the poller catches per-database.
+        //
+        // The columns cost nothing to carry: every one of them is nullable or defaulted, and a store
+        // that does not use them never writes them. That is the same trade #5173 already made below
+        // for warning/critical_behind_threshold, generalised -- the cost of a conditional column is
+        // never the column, it is the schema CHANGE, and a shape that depends on configuration means
+        // some pair of stores will disagree about it.
+        AddColumn<string>("mode").DefaultValueByString(ShardMode.none.ToString());
+        AddColumn<int>("rebuild_threshold").DefaultValueByExpression("0");
+        AddColumn<int>("assigned_node").DefaultValueByExpression("0");
 
-        if (eventGraph.EnableExtendedProgressionTracking)
-        {
-            AddColumn("heartbeat", "timestamp with time zone").AllowNulls();
-            AddColumn("agent_status", "varchar(20)").AllowNulls();
-            AddColumn("pause_reason", "text").AllowNulls();
-            AddColumn("running_on_node", "integer").AllowNulls();
+        AddColumn("heartbeat", "timestamp with time zone").AllowNulls();
+        AddColumn("agent_status", "varchar(20)").AllowNulls();
+        AddColumn("pause_reason", "text").AllowNulls();
+        AddColumn("running_on_node", "integer").AllowNulls();
 
-            // #5173: warning_behind_threshold / critical_behind_threshold are DELIBERATELY still
-            // created, and are the one part of the extended block that is neither written nor read.
-            // Nothing in any repo ever owned the value, so #5184 removed them outright -- from the
-            // DDL, the SELECT, and the ShardStateSelector ordinals. The read-side half of that stands;
-            // only the DDL is restored here.
-            //
-            // Restored because the cost of removing them is not the two columns, it is the schema
-            // CHANGE. Dropping a column from an existing deployment means `alter table ... drop
-            // column` on the next apply, and in PostgreSQL that needs ACCESS EXCLUSIVE on a small,
-            // hot table that every running daemon writes. The operation itself is O(1) metadata, but
-            // the lock queues behind in-flight progression writes and blocks every reader and writer
-            // behind it while it waits. Two always-NULL columns are cheaper than asking every
-            // deployment to take that lock, so an upgrade stays a no-op on this table.
-            //
-            // They are not selected and not hydrated -- see ProjectionProgressStatement and
-            // ShardStateSelector, whose ordinals now skip them. If they are ever removed for real,
-            // it has to be a documented migration step, not a silent auto-apply.
-            AddColumn("warning_behind_threshold", "bigint").AllowNulls();
-            AddColumn("critical_behind_threshold", "bigint").AllowNulls();
+        // #5173: warning_behind_threshold / critical_behind_threshold are DELIBERATELY still
+        // created, and are the one part of the extended block that is neither written nor read.
+        // Nothing in any repo ever owned the value, so #5184 removed them outright -- from the
+        // DDL, the SELECT, and the ShardStateSelector ordinals. The read-side half of that stands;
+        // only the DDL is restored here.
+        //
+        // Restored because the cost of removing them is not the two columns, it is the schema
+        // CHANGE. Dropping a column from an existing deployment means `alter table ... drop
+        // column` on the next apply, and in PostgreSQL that needs ACCESS EXCLUSIVE on a small,
+        // hot table that every running daemon writes. The operation itself is O(1) metadata, but
+        // the lock queues behind in-flight progression writes and blocks every reader and writer
+        // behind it while it waits. Two always-NULL columns are cheaper than asking every
+        // deployment to take that lock, so an upgrade stays a no-op on this table.
+        //
+        // They are not selected and not hydrated -- see ProjectionProgressStatement and
+        // ShardStateSelector, whose ordinals now skip them. If they are ever removed for real,
+        // it has to be a documented migration step, not a silent auto-apply.
+        AddColumn("warning_behind_threshold", "bigint").AllowNulls();
+        AddColumn("critical_behind_threshold", "bigint").AllowNulls();
 
-            // #5048 / jasperfx#565: the classified reason this shard is paused or stopped, so a consumer
-            // polling the database (CritterWatch when the publishing node is DOWN, which is exactly when
-            // it matters) sees the same reason an in-process ShardState observer does. The reason *text*
-            // needs no new column -- ShardFailure.Detail is precisely what pause_reason has always
-            // carried. failure_category stores the enum NAME, never the ordinal, so reordering
-            // ShardFailureCategory can never silently re-label persisted rows.
-            AddColumn("failure_category", "varchar(50)").AllowNulls();
-            AddColumn("failure_event_sequence", "bigint").AllowNulls();
-            AddColumn("failure_event_type", "varchar(500)").AllowNulls();
-            AddColumn("failure_event_tenant_id", "varchar(500)").AllowNulls();
-        }
+        // #5048 / jasperfx#565: the classified reason this shard is paused or stopped, so a consumer
+        // polling the database (CritterWatch when the publishing node is DOWN, which is exactly when
+        // it matters) sees the same reason an in-process ShardState observer does. The reason *text*
+        // needs no new column -- ShardFailure.Detail is precisely what pause_reason has always
+        // carried. failure_category stores the enum NAME, never the ordinal, so reordering
+        // ShardFailureCategory can never silently re-label persisted rows.
+        AddColumn("failure_category", "varchar(50)").AllowNulls();
+        AddColumn("failure_event_sequence", "bigint").AllowNulls();
+        AddColumn("failure_event_type", "varchar(500)").AllowNulls();
+        AddColumn("failure_event_tenant_id", "varchar(500)").AllowNulls();
 
         PrimaryKeyName = "pk_mt_event_progression";
     }

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -1143,13 +1143,19 @@ internal class SetEventStoreInstrumentation: IConfigureMarten, IEventStoreInstru
 {
     public void Configure(IServiceProvider services, StoreOptions options)
     {
-        // #4981: only apply the adapter's values, never overwrite. This adapter is always
-        // registered by AddMarten, so an unconditional assignment clobbered a direct
+        // #4981: only apply the adapter's value, never overwrite. This adapter is always registered
+        // by AddMarten, so an unconditional assignment clobbered a direct
         // `opts.Events.EnableExtendedProgressionTracking = true` (and any directly-set
         // AppendObserver) back to the adapter defaults at store build.
-        if (ExtendedProgressionEnabled)
+        //
+        // #5310: "was it assigned" and "is it true" have to be different questions. #4981's guard was
+        // `if (ExtendedProgressionEnabled)`, which was a correct opt-out only while the EventGraph
+        // default was false -- once the default is true, that guard cannot fire for
+        // `ExtendedProgressionEnabled = false` and the opt-out silently stops working. Keying off the
+        // backing field instead means unset still never clobbers, while an explicit false is applied.
+        if (_extendedProgressionEnabled.HasValue)
         {
-            options.EventGraph.EnableExtendedProgressionTracking = true;
+            options.EventGraph.EnableExtendedProgressionTracking = _extendedProgressionEnabled.Value;
         }
 
         if (AppendObserver != null)
@@ -1158,7 +1164,16 @@ internal class SetEventStoreInstrumentation: IConfigureMarten, IEventStoreInstru
         }
     }
 
-    public bool ExtendedProgressionEnabled { get; set; }
+    private bool? _extendedProgressionEnabled;
+
+    public bool ExtendedProgressionEnabled
+    {
+        // Unset reads as the EventGraph default this adapter would leave in place, so reading the
+        // property before the store is built does not misreport what the store will get.
+        get => _extendedProgressionEnabled ?? true;
+        set => _extendedProgressionEnabled = value;
+    }
+
     public Action<IReadOnlyList<IEvent>>? AppendObserver { get; set; }
 }
 
@@ -1166,10 +1181,11 @@ internal class SetEventStoreInstrumentation<T>: IConfigureMarten<T>, IEventStore
 {
     public void Configure(IServiceProvider services, StoreOptions options)
     {
-        // #4981: see SetEventStoreInstrumentation.Configure — apply, do not clobber.
-        if (ExtendedProgressionEnabled)
+        // #4981 / #5310: see SetEventStoreInstrumentation.Configure — apply an explicit value of
+        // either polarity, never clobber an unset one.
+        if (_extendedProgressionEnabled.HasValue)
         {
-            options.EventGraph.EnableExtendedProgressionTracking = true;
+            options.EventGraph.EnableExtendedProgressionTracking = _extendedProgressionEnabled.Value;
         }
 
         if (AppendObserver != null)
@@ -1178,6 +1194,13 @@ internal class SetEventStoreInstrumentation<T>: IConfigureMarten<T>, IEventStore
         }
     }
 
-    public bool ExtendedProgressionEnabled { get; set; }
+    private bool? _extendedProgressionEnabled;
+
+    public bool ExtendedProgressionEnabled
+    {
+        get => _extendedProgressionEnabled ?? true;
+        set => _extendedProgressionEnabled = value;
+    }
+
     public Action<IReadOnlyList<IEvent>>? AppendObserver { get; set; }
 }


### PR DESCRIPTION
Four issues, all reachable from the same corner of the event store. Each commit stands alone.

## #5309 — a store with tracking off DROPS the extended columns another store added

Two `DocumentStore`s over one `DatabaseSchemaName` that disagreed about `EnableExtendedProgressionTracking` undid each other's schema. The flag-off store did not merely decline to add the extended columns: its expected table genuinely lacked them, the delta resolved them as extras, and Weasel emitted `alter table … drop column` for each. Whichever store applied schema last decided the shape, and they kept stripping each other for as long as both ran — silently on both sides, since the flag-off store had no reason to log anything and the flag-on store then failed every progression read with `column "heartbeat" does not exist`.

**The shape of `mt_event_progression` no longer depends on configuration at all.** Every column is created for every store; the flag gates only whether the daemon reads and writes them. That is the trade #5173 already made for `warning_behind_threshold`/`critical_behind_threshold`, generalised — the cost of a conditional column is never the column, it is the schema *change*, and a shape that depends on configuration means some pair of stores will disagree about it.

`UseOptimizedProjectionRebuilds` gated three more columns the identical way and had the identical defect. Fixed and covered here rather than left for the next report.

Severity was bounded and measured rather than assumed: columns dropped **in place**, so progression rows kept their `last_seq_id` and projections did not rewind. One of the four tests pins that, so a future change that turns this into a rewind is a loud failure.

## #5310 — the default regressed the day after it landed, along with its regression guard

`824e3b783` added `= true` for #4687 and renamed the guard to `default_is_enabled`. `769a6fd5e` removed both the next day while moving the property onto the `SetEventStoreInstrumentation` adapters — leaving a comment arguing for the new default sitting directly on top of a test pinning the old one. Both shipped in V9.30.0.

Restoring it needed the opt-out fixed first. #4981 made the adapters apply-only via `if (ExtendedProgressionEnabled)`, which is a correct opt-out **only while the default is false**; once it is true that guard cannot fire for an explicit `false`, so `instrumentation.ExtendedProgressionEnabled = false` would stop working silently. The adapters now distinguish *unset* from *explicitly false*, so unset still never clobbers a direct toggle of either polarity.

## #5308 — `Bug_5268` fails under full-suite load

`CREATE INDEX CONCURRENTLY` cannot finish until every transaction open when it started has finished, and that wait is cluster-wide — transactions in unrelated schemas count. A full single-process `EventSourcingTests` run concentrates enough of them to blow Npgsql's 30s default, on a different method each run.

CI never tripped this (it shards per area, and 30/30 jobs passed on #5306), so nothing is broken there. It is still worth removing: a test whose success depends on how much unrelated work happens to be in flight punishes a reasonable workflow — validating a dependency bump by running everything at once and comparing failure counts — with a failure that looks exactly like a regression in whatever you are validating. That is how it was found.

A longer command timeout rather than `[Trait("Isolated", "true")]`: the contention is other transactions on the same **database**, so moving the class to its own process does not remove it.

## #5307 — should `BuildSlicer` treat a global aggregate as single-tenanted?

**It does not matter, and the reason is structural rather than lucky.** `GlobalEventAppenderDecorator` forces a global aggregate's stream onto the default tenant at *write* time, matching either on the stream's `AggregateType` or on the appended event type being one the global projection includes — which is exactly the set of events the projection could ever apply. So every event that can reach an `Apply` is already on one tenant before the slicer sees it.

That also explains the probe on #5305 that "proved nothing": the `*DEFAULT*` it saw was Marten normalising, not a misconfigured store.

The one shape escaping both matching rules is an event type the projection does not include. It does reach storage under the appending session's tenant — the third test asserts that precondition rather than assuming it — but it lands in a slice group the projection ignores.

`BuildSlicer` now sets `ForceSingleTenancy` for a global aggregate too. **That is alignment, not a fix**: the tests pass with or without it. It is worth doing so the two sites cannot drift back into disagreeing, and the argument above is written down at the call site so the next reader does not have to reconstruct it.

## Verification

The new `Bug_5309` tests were checked as real guards, not assumed ones: with the production change reverted, three of the four go red with the table stripped to `["name", "last_seq_id", "last_updated"]`.

For #5308, matching the evidence standard the issue set for the failure — before: failed 2 of 2 full single-process runs at JasperFx 2.59.0; after: 2 of 2 clean, 2002 tests, 0 failures on the same machine and JasperFx.

Every suite run locally on net9.0, against a `master` baseline taken in a separate worktree:

| Suite | master baseline | this branch |
|---|---|---|
| CoreTests | 588, 4 failed | 592, 2 failed (both in master's set) |
| DaemonTests | 315, 0 failed | 319, 0 failed |
| EventSourcingTests | — | 2005, 0 failed |
| MultiTenancyTests | — | 165, 0 failed |
| LinqTests `group_join_operator` | — | 27, 0 failed |

The four failures on master (`Bug_4185`, `Bug_4187`, `rolling_range_partitioning`, `divergent_application_assembly_reuse_warning`) are pre-existing and order-dependent; two of them did not fire on the branch run.

markdownlint and cspell are clean on the changed doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDX5UV1He5if9vVo8Bdi7g