### PR TITLE
Bump to JasperFx 2.60.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -357,16 +357,35 @@
          own BuildSlicer override already computes identically (Polecat and Fisher, whose subclasses
          are empty class bodies, are the stores that needed it); and two opt-in compliance suites
          (jasperfx#724, #725) that add no tests until a store enrolls them. Marten enrolls neither;
-         see jasperfx#727 for why #724 in particular is being reconsidered. -->
-    <PackageVersion Include="JasperFx" Version="2.59.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.59.0" />
+         see jasperfx#727 for why #724 in particular is being reconsidered.
+
+         JasperFx 2.60.0: jasperfx#730, an identity-less [BoundaryAggregate] folded by
+         Evolve(IEvent) got no evolver AND no diagnostic, while its Apply/Create sibling in the same
+         compilation generated fine. AnalyzeSelfAggregatingEvolve bailed with a bare `return null`
+         when it could not infer an identity, and control then fell to the Apply/Create path, which
+         returned at its "no conventional methods" guard, so the [BoundaryAggregate] opt-in below
+         that guard was never reached. Marten users saw it far from the cause, as
+         FetchForWritingByTags<T> throwing "No source-generated dispatcher found" at fetch time,
+         naming neither the type nor the reason. The Evolve path now takes the same TId-defaults-to-
+         string fallback, matching the SingleStreamProjection<T, string> the DCB aggregator builds.
+         Adds JFXEVT007, an error for a [BoundaryAggregate] carrying nothing to fold events with:
+         silence is right for a bare no-Id aggregate, wrong for an explicit opt-in that generates
+         nothing.
+
+         Also arriving and inert for Marten's own code: jasperfx#728, a `projection-run` CLI command
+         that replays one projection over a stream slice or DCB tag match and prints per-event
+         before/after state, writing nothing. It is picked up by JasperFx.CommandLine discovery, so
+         every Marten host referencing JasperFx.Events gains the command on this bump with no Marten
+         change, which is worth knowing about when it shows up in the CLI help output. -->
+    <PackageVersion Include="JasperFx" Version="2.60.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.60.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.59.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.60.0" />
     <!--
       No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
       whole family moves together, and this note is kept for the history below. This package is
@@ -385,11 +404,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.59.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.60.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.59.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.60.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
All five JasperFx packages move together, as they have since the 2.59.0 bump (#5305): `JasperFx`, `JasperFx.Events`, `JasperFx.Events.ComplianceTests`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator`.

## What's in it

**[jasperfx#730](https://github.com/JasperFx/jasperfx/pull/731) — the one Marten users hit directly.** An identity-less `[BoundaryAggregate]` folded by `Evolve(IEvent)` got no evolver *and* no diagnostic, while its `Apply`/`Create` sibling in the same compilation generated fine. `AnalyzeSelfAggregatingEvolve` bailed with a bare `return null` when it could not infer an identity, and control then fell through to the `Apply`/`Create` path, which returned at its "no conventional methods" guard — an `Evolve`-only type has none — so the `[BoundaryAggregate]` opt-in below that guard was never reached.

The consequence surfaced far from the cause and late: `FetchForWritingByTags<T>` throwing **"No source-generated dispatcher found"** at fetch time, naming neither the type nor the reason. The `Evolve` path now takes the same TId-defaults-to-`string` fallback as `Apply`/`Create`, matching the `SingleStreamProjection<T, string>` the DCB aggregator builds.

It also adds **`JFXEVT007`**, an error for a `[BoundaryAggregate]` carrying nothing to fold events with. Silence is right for a bare no-Id aggregate — far more likely a forgotten `Id` than an intentional boundary aggregate — and wrong for an explicit opt-in that generates nothing.

**[jasperfx#728](https://github.com/JasperFx/jasperfx/pull/729) — a `projection-run` CLI command.** Replays one projection over a stream slice or a DCB tag match and prints per-event before/after state, writing nothing and never touching the projection's stored state. Marten needs no change for it: `JasperFx.CommandLine` discovery means every host referencing `JasperFx.Events` picks it up on this bump. Flagging it because it will appear in `help` output, which is better known in advance than discovered.

## Verification

Held to the standard #5294 established: **a compliance bump is not judged by run totals**, because shared tests can be added or dropped without the totals moving in a way that shows it. The `--list-tests` output for `EventSourcingTests` is byte-identical across the bump — **1963 tests before and after**, no additions, no drops. Consistent with the two upstream commits, neither of which touches a compliance suite.

Suites on net9.0, each compared against a 2.59.0 baseline built in a separate worktree:

| Suite | 2.60.0 | 2.59.0 baseline |
|---|---|---|
| Marten.SourceGenerator.Tests | 19, 0 failed | — |
| EventSourcingTests | 2005, 0 failed | — |
| DaemonTests | 319, 0 failed | — |
| CoreTests | 592, **4 failed** | 592, **4 failed — same names** |

The four `CoreTests` failures (`Bug_4185`, `Bug_4187`, `rolling_range_partitioning`, `divergent_application_assembly_reuse_warning`) are pre-existing and order-dependent. The 2.59.0 baseline run reproduces all four exactly, so **the bump introduces nothing**.

The source-generator suite is called out separately because it is the one that would catch a regression in `JFXEVT007` or the `Evolve` analysis path, and it needs no database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDX5UV1He5if9vVo8Bdi7g