### PR TITLE
Apply table alias to the data column in `where`

### DIFF
--- a/src/CoreTests/Util/StringExtensionsTests.cs
+++ b/src/CoreTests/Util/StringExtensionsTests.cs
@@ -1,0 +1,68 @@
+using Marten.Util;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests.Util;
+
+public class StringExtensionsTests
+{
+    [Theory]
+    [InlineData("data", "d.data")]
+    [InlineData("(data ->> 'Title')", "(d.data ->> 'Title')")]
+    [InlineData("((data ->> 'Title') || ' ' || (data ->> 'LastName'))",
+        "((d.data ->> 'Title') || ' ' || (d.data ->> 'LastName'))")]
+    [InlineData("data #>> '{Inner,Name}'", "d.data #>> '{Inner,Name}'")]
+    public void qualifies_the_data_column(string sql, string expected)
+    {
+        sql.ApplyTableAliasToDataColumn("d").ShouldBe(expected);
+    }
+
+    // https://github.com/JasperFx/marten/issues/5314 — a naive Replace("data", "d.data") rewrote the
+    // JSON key as readily as the column, so a member whose serialized name contains "data" searched
+    // a key that does not exist.
+    [Theory]
+    [InlineData("(data ->> 'data')", "(d.data ->> 'data')")]
+    [InlineData("(data ->> 'metadata')", "(d.data ->> 'metadata')")]
+    [InlineData("(data ->> 'data_v2')", "(d.data ->> 'data_v2')")]
+    [InlineData("(coalesce(data ->> 'data', '') || ' ' || coalesce(data ->> 'title', ''))",
+        "(coalesce(d.data ->> 'data', '') || ' ' || coalesce(d.data ->> 'title', ''))")]
+    // a doubled quote escapes a quote inside the literal, so the literal does not end early
+    [InlineData("(data ->> 'it''s data')", "(d.data ->> 'it''s data')")]
+    public void leaves_json_keys_alone(string sql, string expected)
+    {
+        sql.ApplyTableAliasToDataColumn("d").ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("(metadata ->> 'Title')")]
+    [InlineData("(data_v2 ->> 'Title')")]
+    public void leaves_other_identifiers_alone(string sql)
+    {
+        sql.ApplyTableAliasToDataColumn("d").ShouldBe(sql);
+    }
+
+    [Fact]
+    public void is_idempotent()
+    {
+        const string sql = "((data ->> 'data') || ' ' || (data ->> 'title'))";
+
+        var once = sql.ApplyTableAliasToDataColumn("d");
+        once.ApplyTableAliasToDataColumn("d").ShouldBe(once);
+    }
+
+    [Fact]
+    public void round_trips_with_RemoveTableAlias()
+    {
+        const string aliased = "((d.data ->> 'data') || ' ' || (d.data ->> 'metadata'))";
+
+        aliased.RemoveTableAlias("d").ApplyTableAliasToDataColumn("d").ShouldBe(aliased);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void handles_empty_input(string sql)
+    {
+        sql.ApplyTableAliasToDataColumn("d").ShouldBe(sql);
+    }
+}

--- a/src/DocumentDbTests/Bugs/Bug_5314_fts_json_key_rewritten.cs
+++ b/src/DocumentDbTests/Bugs/Bug_5314_fts_json_key_rewritten.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace DocumentDbTests.Bugs;
+
+public class Bug_5314_fts_json_key_rewritten: BugIntegrationContext
+{
+    public class FtsDoc
+    {
+        public Guid Id { get; set; }
+        public string Data { get; set; }
+        public string Title { get; set; }
+    }
+
+    public Bug_5314_fts_json_key_rewritten()
+    {
+        // camelCase serialization is what makes this reachable: it turns the Data member into the
+        // JSON key "data", which the old substring rebase rewrote along with the column.
+        StoreOptions(opts =>
+        {
+            opts.UseSystemTextJsonForSerialization(casing: Casing.CamelCase);
+            opts.Schema.For<FtsDoc>().FullTextIndex(x => x.Data, x => x.Title);
+        });
+    }
+
+    [Fact]
+    public void the_json_key_is_not_rebased_onto_the_table_alias()
+    {
+        using var session = theStore.QuerySession();
+
+        var sql = session.Query<FtsDoc>().Where(x => x.PlainTextSearch("hi")).ToCommand().CommandText;
+
+        sql.ShouldContain("d.data ->> 'data'");
+        sql.ShouldNotContain("'d.data'");
+    }
+
+    [Fact]
+    public async Task can_search_on_a_member_whose_serialized_name_contains_data()
+    {
+        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(FtsDoc));
+
+        await using var session = theStore.LightweightSession();
+        session.Store(
+            new FtsDoc { Id = Guid.NewGuid(), Data = "kangaroo", Title = "irrelevant" },
+            new FtsDoc { Id = Guid.NewGuid(), Data = "irrelevant", Title = "kangaroo" });
+        await session.SaveChangesAsync();
+
+        var results = await session.Query<FtsDoc>().Where(x => x.PlainTextSearch("kangaroo")).ToListAsync();
+
+        results.Count.ShouldBe(2);
+    }
+}

--- a/src/Marten/Linq/SqlGeneration/Filters/FullTextWhereFragment.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/FullTextWhereFragment.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Marten.Linq.Parsing.Methods.FullText;
 using Marten.Schema;
+using Marten.Util;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
 using Weasel.Postgresql.Tables.Indexes;
@@ -35,7 +36,7 @@ internal class FullTextWhereFragment: ISqlFragment
 
         _regConfig = regConfig;
 
-        _dataConfig = GetDataConfig(mapping, regConfig).Replace("data", "d.data");
+        _dataConfig = GetDataConfig(mapping, regConfig).ApplyTableAliasToDataColumn("d");
         _searchFunction = searchFunction;
         _searchTerm = searchTerm;
     }

--- a/src/Marten/Util/StringExtensions.cs
+++ b/src/Marten/Util/StringExtensions.cs
@@ -16,6 +16,12 @@ internal static class StringExtensionMethods
 {
     private static readonly ConcurrentDictionary<string, Regex> _removeTableAliasRegexCache = new();
 
+    // Alternation order matters: the single-quoted literal is tried first so its contents are
+    // consumed before the identifier branch can see anything inside it.
+    private static readonly Regex _dataColumnPattern = new(
+        @"'(?:[^']|'')*'|(?<![\w.])data(?![\w])",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     /// <summary>
     /// Process-wide list of optional member-name resolvers. Marten core leaves this empty
     /// and only honors <see cref="JsonPropertyNameAttribute"/> (STJ). The optional
@@ -62,6 +68,22 @@ internal static class StringExtensionMethods
         }
 
         return memberLocator;
+    }
+
+    /// <summary>
+    /// Qualify bare references to the document <c>data</c> column with a table alias — the inverse of
+    /// <see cref="RemoveTableAlias"/>, since index definitions store the un-aliased form. Quoted
+    /// literals are skipped so a JSON key is not rewritten along with the column
+    /// (https://github.com/JasperFx/marten/issues/5314), as are <c>metadata</c> and already-qualified
+    /// occurrences, which makes this idempotent.
+    /// </summary>
+    public static string ApplyTableAliasToDataColumn(this string sql, string tableAlias)
+    {
+        if (string.IsNullOrEmpty(sql) || string.IsNullOrEmpty(tableAlias))
+            return sql;
+
+        return _dataColumnPattern.Replace(sql,
+            match => match.Value[0] == '\'' ? match.Value : $"{tableAlias}.{match.Value}");
     }
 
     /// <summary>


### PR DESCRIPTION
Using a regex apply the alias instead of a simple replace. 

Closes #5314