### PR TITLE
Weasel 9.29.0 + full-text search: weighted indexes and refusing ambiguous index selection (#5298, #5315)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -459,7 +459,7 @@
     <PackageVersion Include="Vogen" Version="7.0.0" />
     <!-- 9.16.2: the hold at 9.2.1 (were newer builds actually being published?) is resolved —
          Weasel.EntityFrameworkCore is on nuget.org, so it tracks the rest of the Weasel line. -->
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.27.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.29.0" />
     <!-- Weasel.Postgresql 9.1.x: managed LIST partitions under multi-database (sharded) apply.
          9.1.2 (marten#4706): managed-partition tables are no longer destructively rebuilt — the
          out-of-band AddPartitionToAllTables path creates partitions while the generic schema diff
@@ -596,9 +596,21 @@
          manager-owned — that enumeration returned the EMPTY sequence, not a short one. Only step 1
          rendered, and the parent index was created permanently INVALID: unusable by the planner, and
          reported as drift by every later apply thanks to weasel#508. All three call sites now resolve
-         through one expectedPartitions() helper, which is why RangePartitioning never had the bug. -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.27.0" />
-    <PackageVersion Include="Weasel.Storage" Version="9.27.0" />
+         through one expectedPartitions() helper, which is why RangePartitioning never had the bug.
+
+         9.29.0 (weasel#541, raised from marten#5298): FullTextIndexDefinition can index an expression
+         that is ALREADY a tsvector, via TsVectorExpression and the ForTsVector factory. That is what
+         makes per-member setweight() weighting expressible at all. PostgreSQL's setweight labels a
+         vector, so weighting concatenates the VECTORS rather than the text, and the old unconditional
+         to_tsvector wrapping turned that into a type error rather than a weighted index. IndexedTsVector
+         is the single property both the DDL and Marten's query-side filter read, so the indexed vector
+         and the searched vector cannot drift apart. Left unset it is byte-identical to before, which
+         matters because a changed index expression makes Weasel drop and recreate the index.
+         Also arriving: 9.28.0 (weasel#538) lets a rebuildable Invalid delta through
+         AssertPatchingIsValid, and weasel#539/#540 are SQLite and foreign-key-cycle fixes with no
+         Marten surface. -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.29.0" />
+    <PackageVersion Include="Weasel.Storage" Version="9.29.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <!-- The whole test suite is on xunit v3. VSTest stays the execution mode, so the
          Nuke targets and the GitHub workflows are unaffected. -->

--- a/src/DocumentDbTests/Indexes/weighted_full_text_index.cs
+++ b/src/DocumentDbTests/Indexes/weighted_full_text_index.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Exceptions;
+using Marten.Schema.Indexing.FullText;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables.Indexes;
+using Xunit;
+
+namespace DocumentDbTests.Indexes;
+
+/// <summary>
+/// #5298, index half. A plain <c>FullTextIndex</c> concatenates its members as TEXT and converts once,
+/// so every match is equally relevant. Weighting cannot be expressed that way: <c>setweight</c> labels a
+/// VECTOR, so each member is converted separately and the vectors are concatenated. That expression is a
+/// tsvector at the top level, which is why it needs Weasel's <c>ForTsVector</c> rather than
+/// <c>DocumentConfig</c> (weasel#541, shipped in 9.29.0).
+/// </summary>
+[Collection("OneOffs")]
+public class weighted_full_text_index: OneOffConfigurationsContext
+{
+    public class Achievement
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; }
+        public string Tagline { get; set; }
+        public string Description { get; set; }
+    }
+
+    private void ConfigureWeightedStore()
+    {
+        StoreOptions(opts => opts.Schema.For<Achievement>().WeightedFullTextIndex(idx => idx
+            .Weighted(a => a.Title, TextSearchWeight.A)
+            .Weighted(a => a.Tagline, TextSearchWeight.B)
+            .Weighted(a => a.Description, TextSearchWeight.C)));
+    }
+
+    [Fact]
+    public void the_index_is_built_over_a_pre_weighted_vector()
+    {
+        ConfigureWeightedStore();
+
+        var index = theStore.Options.Storage.MappingFor(typeof(Achievement))
+            .Indexes.OfType<FullTextIndexDefinition>().Single();
+
+        index.TsVectorExpression.ShouldNotBeNull();
+
+        // Each member converted separately and labelled, then the VECTORS concatenated.
+        index.TsVectorExpression.ShouldContain("setweight(to_tsvector('english', coalesce(data ->> 'Title', '')), 'A')");
+        index.TsVectorExpression.ShouldContain("setweight(to_tsvector('english', coalesce(data ->> 'Tagline', '')), 'B')");
+        index.TsVectorExpression.ShouldContain("setweight(to_tsvector('english', coalesce(data ->> 'Description', '')), 'C')");
+        index.TsVectorExpression.ShouldContain("||");
+
+        // And crucially NOT wrapped in another to_tsvector, which would be a type error rather than a
+        // weighted index. This is the whole reason weasel#541 existed.
+        index.IndexedTsVector.ShouldNotStartWith("to_tsvector(");
+    }
+
+    /// <summary>
+    /// The coalesce is load-bearing, not decoration: to_tsvector of NULL is NULL, and concatenating NULL
+    /// into a vector annihilates the whole expression — so one absent member would silently empty the
+    /// index row for that document rather than just omitting that field.
+    /// </summary>
+    [Fact]
+    public async Task a_document_with_a_null_member_still_indexes_its_other_members()
+    {
+        ConfigureWeightedStore();
+
+        var id = Guid.NewGuid();
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Achievement { Id = id, Title = "Dragonslayer", Tagline = null, Description = null });
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = theStore.QuerySession();
+        var found = await query.Query<Achievement>().Where(x => x.PlainTextSearch("Dragonslayer")).ToListAsync();
+
+        found.Select(x => x.Id).ShouldContain(id);
+    }
+
+    [Fact]
+    public async Task the_index_is_actually_created_in_postgresql()
+    {
+        ConfigureWeightedStore();
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+
+        await using var reader = await conn
+            .CreateCommand(
+                "select indexdef from pg_indexes where schemaname = :schema and tablename = 'mt_doc_weighted_full_text_index_achievement'")
+            .With("schema", theStore.Options.DatabaseSchemaName, NpgsqlTypes.NpgsqlDbType.Varchar)
+            .ExecuteReaderAsync(TestContext.Current.CancellationToken);
+
+        var defs = new List<string>();
+        while (await reader.ReadAsync(TestContext.Current.CancellationToken)) defs.Add(reader.GetString(0));
+
+        defs.ShouldContain(d => d.Contains("setweight"));
+    }
+
+    /// <summary>
+    /// A weighted index whose expression PostgreSQL hands back differently than we wrote it would read as
+    /// drift on every single migration — recreating the index each time, which is the outage the whole
+    /// feature is supposed to avoid. Weasel canonicalizes for this, and this asserts the composition
+    /// actually holds end to end rather than trusting it.
+    /// </summary>
+    [Fact]
+    public async Task a_weighted_index_round_trips_with_no_drift()
+    {
+        ConfigureWeightedStore();
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await Should.NotThrowAsync(() => theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync());
+
+        // ...and a second apply is a no-op rather than a drop-and-recreate.
+        await Should.NotThrowAsync(() => theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync());
+        await Should.NotThrowAsync(() => theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync());
+    }
+
+    /// <summary>
+    /// One weight, or the same weight everywhere, ranks nothing — setweight only ever expresses a
+    /// RELATIVE ordering. Refused at configuration time rather than emitting DDL that looks weighted and
+    /// is not, because otherwise the failure surfaces as a ranked screen returning arbitrary order.
+    /// </summary>
+    [Fact]
+    public void a_uniform_weighting_is_refused()
+    {
+        // MartenRegistry defers configuration into _builder.Alter, so the guard fires when the mapping
+        // is built rather than when WeightedFullTextIndex() is called. Resolving the mapping is what
+        // forces it -- asserting on the StoreOptions() call alone passes vacuously.
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+        {
+            var store = StoreOptions(opts => opts.Schema.For<Achievement>().WeightedFullTextIndex(idx => idx
+                .Weighted(a => a.Title, TextSearchWeight.A)
+                .Weighted(a => a.Description, TextSearchWeight.A)));
+
+            store.Options.Storage.MappingFor(typeof(Achievement));
+        });
+    }
+
+    [Fact]
+    public void a_weighted_index_with_no_members_is_refused()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+        {
+            var store = StoreOptions(opts => opts.Schema.For<Achievement>().WeightedFullTextIndex(idx => { }));
+            store.Options.Storage.MappingFor(typeof(Achievement));
+        });
+    }
+}

--- a/src/LinqTests/Bugs/Bug_5315_ambiguous_full_text_index.cs
+++ b/src/LinqTests/Bugs/Bug_5315_ambiguous_full_text_index.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Linq;
+using JasperFx;
+using Marten;
+using Marten.Exceptions;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Postgresql.Tables.Indexes;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+/// <summary>
+/// #5315. Filed as "the query side picks one of several full text indexes arbitrarily", which turned out
+/// to be the second of two mechanisms rather than the one the repro actually demonstrated.
+///
+/// <para>
+/// <b>The one that bites.</b> <c>FullTextIndexDefinition</c> derives its name from the TABLE — and the
+/// regConfig when non-default — never from the members it indexes. So two <c>FullTextIndex()</c> calls
+/// naming different members collide by construction, and <c>AddFullTextIndexIfDoesNotExist</c> returned
+/// the first and threw the second away. The second index was never registered, never created and never
+/// searched, with no warning. The dedupe is there so that configuring the same index twice stays
+/// idempotent, which is worth keeping; silently dropping a DIFFERENT configuration is not.
+/// </para>
+///
+/// <para>
+/// <b>The one behind it.</b> Give both indexes explicit names and they really do register — and then
+/// <c>FullTextWhereFragment</c> had a genuine choice to make with nothing in the query to make it with,
+/// since <c>regConfig</c> is the only selector the search API has. It resolved that with
+/// <c>FirstOrDefault</c>, i.e. by declaration order.
+/// </para>
+///
+/// <para>
+/// Both are refused now. Ranking (#5298) makes the second load-bearing rather than merely untidy: a
+/// <c>ts_rank</c> computed over a different vector than the <c>@@</c> filtered on is silently wrong
+/// rather than slow.
+/// </para>
+/// </summary>
+public class Bug_5315_ambiguous_full_text_index: OneOffConfigurationsContext
+{
+    public class FtsDoc
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; }
+        public string Body { get; set; }
+    }
+
+    [Fact]
+    public void a_second_index_over_different_members_is_not_silently_discarded()
+    {
+        var ex = Should.Throw<AmbiguousFullTextIndexException>(() =>
+        {
+            var store = StoreOptions(opts =>
+            {
+                opts.AutoCreateSchemaObjects = AutoCreate.None;
+                opts.Schema.For<FtsDoc>()
+                    .FullTextIndex(x => x.Title)
+                    .FullTextIndex(x => x.Body);
+            });
+
+            // MartenRegistry defers configuration into _builder.Alter, so resolving the mapping is what
+            // runs it. Asserting on the StoreOptions() call alone passes vacuously.
+            store.Options.Storage.MappingFor(typeof(FtsDoc));
+        });
+
+        // The message has to name what collided and how to get out of it. An exception that only says
+        // "ambiguous" moves the silent failure rather than fixing it.
+        ex.Message.ShouldContain("FtsDoc");
+        ex.Message.ShouldContain("explicit index name");
+    }
+
+    /// <summary>
+    /// Idempotence is the reason the dedupe exists and has to survive: configuring the same index twice is
+    /// ordinary in composed configuration and stays a no-op.
+    /// </summary>
+    [Fact]
+    public void configuring_the_same_index_twice_is_still_idempotent()
+    {
+        StoreOptions(opts =>
+        {
+            opts.AutoCreateSchemaObjects = AutoCreate.None;
+            opts.Schema.For<FtsDoc>()
+                .FullTextIndex(x => x.Title, x => x.Body)
+                .FullTextIndex(x => x.Title, x => x.Body);
+        });
+
+        theStore.Options.Storage.MappingFor(typeof(FtsDoc))
+            .Indexes.OfType<FullTextIndexDefinition>()
+            .Count().ShouldBe(1);
+    }
+
+    /// <summary>
+    /// With explicit names both indexes register, and only then is the query-side choice reachable. This
+    /// is the case the issue described.
+    /// </summary>
+    [Fact]
+    public void two_explicitly_named_indexes_sharing_a_regconfig_are_refused_at_query_time()
+    {
+        StoreOptions(opts =>
+        {
+            opts.AutoCreateSchemaObjects = AutoCreate.None;
+            opts.Schema.For<FtsDoc>()
+                .FullTextIndex(i => i.Name = "mt_fts_title", x => x.Title)
+                .FullTextIndex(i => i.Name = "mt_fts_body", x => x.Body);
+        });
+
+        // Precondition: both really did register. Without this the throw below could be coming from the
+        // discard path above, and the test would prove nothing about the query side.
+        theStore.Options.Storage.MappingFor(typeof(FtsDoc))
+            .Indexes.OfType<FullTextIndexDefinition>()
+            .Count().ShouldBe(2);
+
+        var ex = Should.Throw<AmbiguousFullTextIndexException>(() =>
+            theSession.Query<FtsDoc>().Where(x => x.PlainTextSearch("hi")).ToCommand());
+
+        ex.Message.ShouldContain("english");
+        ex.Message.ShouldContain("regConfig");
+    }
+
+    /// <summary>
+    /// The escape hatch, and why refusing is reasonable rather than a dead end: distinct regConfig values
+    /// let the query's own argument select the index.
+    /// </summary>
+    [Fact]
+    public void distinct_reg_configs_disambiguate()
+    {
+        StoreOptions(opts =>
+        {
+            opts.AutoCreateSchemaObjects = AutoCreate.None;
+            opts.Schema.For<FtsDoc>()
+                .FullTextIndex("english", x => x.Title)
+                .FullTextIndex("simple", x => x.Body);
+        });
+
+        var english = theSession.Query<FtsDoc>().Where(x => x.PlainTextSearch("hi")).ToCommand().CommandText;
+        english.ShouldContain("'Title'");
+        english.ShouldNotContain("'Body'");
+
+        var simple = theSession.Query<FtsDoc>().Where(x => x.PlainTextSearch("hi", "simple")).ToCommand().CommandText;
+        simple.ShouldContain("'Body'");
+        simple.ShouldNotContain("'Title'");
+    }
+
+    /// <summary>
+    /// One index is the overwhelmingly common case and must be untouched by either check.
+    /// </summary>
+    [Fact]
+    public void a_single_index_still_resolves()
+    {
+        StoreOptions(opts =>
+        {
+            opts.AutoCreateSchemaObjects = AutoCreate.None;
+            opts.Schema.For<FtsDoc>().FullTextIndex(x => x.Title, x => x.Body);
+        });
+
+        var sql = theSession.Query<FtsDoc>().Where(x => x.PlainTextSearch("hi")).ToCommand().CommandText;
+
+        sql.ShouldContain("'Title'");
+        sql.ShouldContain("'Body'");
+    }
+
+    /// <summary>
+    /// And a document with no full text index at all keeps falling back to the whole document body.
+    /// </summary>
+    [Fact]
+    public void no_index_falls_back_to_the_document_body()
+    {
+        StoreOptions(opts => opts.AutoCreateSchemaObjects = AutoCreate.None);
+
+        var sql = theSession.Query<FtsDoc>().Where(x => x.PlainTextSearch("hi")).ToCommand().CommandText;
+
+        sql.ShouldContain("to_tsvector('english'::regconfig, d.data)");
+    }
+}

--- a/src/Marten/Exceptions/AmbiguousFullTextIndexException.cs
+++ b/src/Marten/Exceptions/AmbiguousFullTextIndexException.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using System;
+
+namespace Marten.Exceptions;
+
+/// <summary>
+///     Thrown when a full text search cannot tell which of a document's full text indexes it should run
+///     against.
+/// </summary>
+/// <remarks>
+///     <para>
+///         #5315. <c>PlainTextSearch</c> and its siblings take a search term and a text search
+///         configuration, and <c>regConfig</c> is the only thing that selects an index. Every full text
+///         index shares the default <c>english</c> unless someone deliberately varies it, so on a document
+///         carrying two of them there is nothing in the query expressing which was meant.
+///     </para>
+///     <para>
+///         Marten used to resolve that by taking the first match, which meant a document matching only on
+///         the other index never came back — no error, and nothing in the generated SQL hinting that a
+///         second index had been considered and dropped. Which one won depended on declaration order.
+///         Refusing is the honest answer: the information needed to choose is not in the query.
+///     </para>
+/// </remarks>
+public class AmbiguousFullTextIndexException: MartenException
+{
+    public AmbiguousFullTextIndexException(string message): base(message)
+    {
+    }
+
+    public AmbiguousFullTextIndexException(string message, Exception innerException): base(message,
+        innerException)
+    {
+    }
+}

--- a/src/Marten/Linq/SqlGeneration/Filters/FullTextWhereFragment.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/FullTextWhereFragment.cs
@@ -3,6 +3,9 @@ using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Marten.Linq.Parsing.Methods.FullText;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Marten.Exceptions;
 using Marten.Schema;
 using Marten.Util;
 using Weasel.Postgresql;
@@ -24,7 +27,7 @@ internal class FullTextWhereFragment: ISqlFragment
         @"^[a-zA-Z_][a-zA-Z0-9_]{0,62}(\.[a-zA-Z_][a-zA-Z0-9_]{0,62})?$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    private readonly string _dataConfig;
+    private readonly string _vector;
     private readonly string _regConfig;
     private readonly FullTextSearchFunction _searchFunction;
     private readonly string _searchTerm;
@@ -36,9 +39,36 @@ internal class FullTextWhereFragment: ISqlFragment
 
         _regConfig = regConfig;
 
-        _dataConfig = GetDataConfig(mapping, regConfig).ApplyTableAliasToDataColumn("d");
+        _vector = ResolveVector(mapping, regConfig);
         _searchFunction = searchFunction;
         _searchTerm = searchTerm;
+    }
+
+    /// <summary>
+    ///     The <c>tsvector</c> this filter searches, which must be the same one the index was built over.
+    /// </summary>
+    /// <remarks>
+    ///     A weighted index (#5298) is built over an expression that is ALREADY a tsvector, so it cannot
+    ///     be reconstructed by wrapping a data config in <c>to_tsvector</c> the way the flat case is.
+    ///     Weasel exposes <c>IndexedTsVector</c> as the one property both its DDL and this filter read,
+    ///     precisely so the indexed vector and the searched vector cannot drift apart (weasel#541).
+    ///     <para>
+    ///     The unweighted shape is left byte-for-byte as it was. Changing it would change the SQL every
+    ///     existing full-text query emits, for no gain.
+    ///     </para>
+    /// </remarks>
+    private static string ResolveVector(DocumentMapping? mapping, string regConfig)
+    {
+        var index = FindIndex(mapping, regConfig);
+
+        if (index?.TsVectorExpression != null)
+        {
+            return index.IndexedTsVector.ApplyTableAliasToDataColumn("d");
+        }
+
+        var dataConfig = (index?.DocumentConfig ?? FullTextIndexDefinition.DataDocumentConfig)
+            .ApplyTableAliasToDataColumn("d");
+        return $"to_tsvector('{regConfig}'::regconfig, {dataConfig})";
     }
 
     private static void ValidateRegConfig(string regConfig)
@@ -59,26 +89,54 @@ internal class FullTextWhereFragment: ISqlFragment
     }
 
     // don't parameterize full-text search config as it ruins the performance with the query plan in PG
-    private string Sql =>
-        $"to_tsvector('{_regConfig}'::regconfig, {_dataConfig}) @@ {_searchFunction}('{_regConfig}'::regconfig, ?)";
+    private string Sql => $"{_vector} @@ {_searchFunction}('{_regConfig}'::regconfig, ?)";
 
     public void Apply(ICommandBuilder builder)
     {
         builder.AppendWithParameters(Sql)[0].Value = _searchTerm;
     }
 
-    private static string GetDataConfig(DocumentMapping? mapping, string regConfig)
+    /// <summary>
+    ///     The full text index this search runs against.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         #5315. This used to be <c>FirstOrDefault</c> over the indexes matching a regConfig, and every
+    ///         full text index shares the default <c>english</c> unless someone deliberately varies it — so
+    ///         on a document with two of them the filter searched one and silently ignored the other.
+    ///         A document matching only on the second index simply never came back, with no error and
+    ///         nothing in the SQL to suggest a second index had been considered and dropped. Which one won
+    ///         was a function of declaration order.
+    ///     </para>
+    ///     <para>
+    ///         Ambiguity is now refused rather than resolved arbitrarily. The query API has exactly one
+    ///         selector, <c>regConfig</c>, so when it does not narrow to a single index there is no answer
+    ///         this method could give that is better than an error — and ranking (#5298) makes the choice
+    ///         load-bearing rather than merely untidy, because a <c>ts_rank</c> over a different vector than
+    ///         the <c>@@</c> filtered on is silently wrong rather than slow.
+    ///     </para>
+    /// </remarks>
+    private static FullTextIndexDefinition? FindIndex(DocumentMapping? mapping, string regConfig)
     {
         if (mapping == null)
         {
-            return FullTextIndexDefinition.DataDocumentConfig;
+            return null;
         }
 
-        return mapping
+        var candidates = mapping
             .Indexes
             .OfType<FullTextIndexDefinition>()
             .Where(i => i.RegConfig == regConfig)
-            .Select(i => i.DataConfig)
-            .FirstOrDefault() ?? FullTextIndexDefinition.DataDocumentConfig;
+            .ToArray();
+
+        if (candidates.Length > 1)
+        {
+            var names = candidates.Select(x => x.Name).Join(", ");
+            throw new AmbiguousFullTextIndexException(
+                $"Document type {mapping.DocumentType.FullNameInCode()} has {candidates.Length} full text indexes registered for the text search configuration '{regConfig}' ({names}), so Marten cannot tell which one this search means. "
+                + "Give the indexes different regConfig values and pass the one you want as the search's regConfig argument, or register a single index covering every member you need to search.");
+        }
+
+        return candidates.FirstOrDefault();
     }
 }

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -7,6 +7,7 @@ using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Marten.Linq.Parsing;
 using Marten.Schema;
+using Marten.Schema.Indexing.FullText;
 using Marten.Schema.Identity;
 using Marten.Schema.Identity.Sequences;
 using Marten.Schema.Indexing.Unique;
@@ -398,6 +399,43 @@ public class MartenRegistry
         public DocumentMappingExpression<T> FullTextIndex(Action<FullTextIndexDefinition> configure)
         {
             _builder.Alter = m => m.AddFullTextIndex(FullTextIndexDefinition.DefaultRegConfig, configure);
+            return this;
+        }
+
+        /// <summary>
+        ///     Create a full text index whose members carry PostgreSQL <c>setweight</c> labels, so that a
+        ///     match in one field can outrank a match in another.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         #5298. Pair it with <c>OrderByTextRank()</c> to actually order by relevance; the weights
+        ///         alone only make the rank meaningful, they do not sort anything.
+        ///     </para>
+        ///     <code>
+        ///     opts.Schema.For&lt;Achievement&gt;().WeightedFullTextIndex(idx =&gt; idx
+        ///         .Weighted(a =&gt; a.Title, TextSearchWeight.A)
+        ///         .Weighted(a =&gt; a.Tagline, TextSearchWeight.B)
+        ///         .Weighted(a =&gt; a.Description, TextSearchWeight.C));
+        ///     </code>
+        ///     <para>
+        ///         A distinct method rather than an overload of <c>FullTextIndex</c>: that name already has
+        ///         an <c>Action&lt;FullTextIndexDefinition&gt;</c> overload, so an
+        ///         <c>Action&lt;WeightedFullTextIndexExpression&lt;T&gt;&gt;</c> beside it would be
+        ///         ambiguous at any call site using a lambda — the same reason Weasel exposed
+        ///         <c>ForTsVector</c> as a factory instead of a constructor overload.
+        ///     </para>
+        ///     <para>
+        ///         Adding weights to an EXISTING index changes its expression, so Weasel drops and recreates
+        ///         it. On a large table that is an outage rather than a migration — build it out of band if
+        ///         that matters.
+        ///     </para>
+        /// </remarks>
+        public DocumentMappingExpression<T> WeightedFullTextIndex(
+            Action<WeightedFullTextIndexExpression<T>> configure,
+            string regConfig = FullTextIndexDefinition.DefaultRegConfig,
+            string? indexName = null)
+        {
+            _builder.Alter = m => m.AddWeightedFullTextIndex(configure, regConfig, indexName);
             return this;
         }
 

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -672,11 +672,78 @@ public partial class DocumentMapping: IDocumentMapping, IDocumentType
         return AddFullTextIndexIfDoesNotExist(index);
     }
 
+    /// <summary>
+    ///     Adds a full text index whose members carry PostgreSQL <c>setweight</c> labels, so that a match
+    ///     in one field can outrank a match in another.
+    /// </summary>
+    /// <remarks>
+    ///     #5298. Distinct from <see cref="AddFullTextIndex(string, Action{FullTextIndexDefinition})" />
+    ///     because the DDL is a different shape, not a configured variant of the same one: weighting
+    ///     concatenates the VECTORS rather than the text, so the expression is a <c>tsvector</c> at the top
+    ///     level and goes to Weasel's <c>ForTsVector</c> factory instead of to <c>DocumentConfig</c>
+    ///     (weasel#541).
+    /// </remarks>
+    public FullTextIndexDefinition AddWeightedFullTextIndex<T>(
+        Action<WeightedFullTextIndexExpression<T>> configure,
+        string regConfig = FullTextIndexDefinition.DefaultRegConfig,
+        string? indexName = null)
+    {
+        var expression = new WeightedFullTextIndexExpression<T>();
+        configure(expression);
+
+        if (expression.IsEmpty)
+        {
+            throw new ArgumentOutOfRangeException(nameof(configure),
+                "A weighted full text index needs at least two members. Call Weighted() to add them.");
+        }
+
+        // One member, or the same label on every member, ranks nothing -- setweight only ever
+        // expresses a RELATIVE ordering. Refused at configuration time rather than emitting DDL that
+        // looks weighted and is not, because the failure otherwise shows up as a ranked screen that
+        // silently returns arbitrary order.
+        if (expression.IsUniform)
+        {
+            throw new ArgumentOutOfRangeException(nameof(configure),
+                "A weighted full text index needs at least two DIFFERENT weights -- weighting expresses a relative ranking, so one weight, or the same weight on every member, ranks nothing. Use FullTextIndex() for an unweighted index.");
+        }
+
+        var index = FullTextIndexDefinition.ForTsVector(
+            PostgresqlObjectName.From(TableName),
+            expression.BuildTsVectorExpression(this, regConfig),
+            indexName,
+            SchemaConstants.MartenPrefix);
+
+        // RegConfig takes no part in the DDL for a pre-built vector -- it is already inside the
+        // expression -- but the query side resolves an index by it, so it still has to be set.
+        index.RegConfig = regConfig;
+
+        return AddFullTextIndexIfDoesNotExist(index);
+    }
+
     private FullTextIndexDefinition AddFullTextIndexIfDoesNotExist(FullTextIndexDefinition index)
     {
         var existing = Indexes.OfType<FullTextIndexDefinition>().FirstOrDefault(x => x.Name == index.Name);
         if (existing != null)
         {
+            // #5315: the dedupe is here so that configuring the same index twice is idempotent, which is
+            // ordinary in composed configuration. But a name collision does not prove the two are the
+            // same index -- FullTextIndexDefinition derives its name from the TABLE (and the regConfig
+            // when non-default), not from its members, so two calls naming different members collide by
+            // construction:
+            //
+            //   .FullTextIndex(x => x.Title)
+            //   .FullTextIndex(x => x.Body)     // same derived name, silently discarded
+            //
+            // That returned the first index and threw the second away with no warning, so the second was
+            // never created and never searched. A document matching only on it simply never came back.
+            // Idempotence is worth keeping; silently dropping a DIFFERENT configuration is not.
+            if (existing.IndexedTsVector != index.IndexedTsVector)
+            {
+                throw new AmbiguousFullTextIndexException(
+                    $"Document type {DocumentType.FullNameInCode()} already has a full text index named '{index.Name}' over a different expression, and full text index names are derived from the table rather than from the members being indexed -- so two indexes over different members collide by construction. "
+                    + "Give at least one of them an explicit index name, or combine the members into a single FullTextIndex() call.");
+            }
+
             return existing;
         }
 

--- a/src/Marten/Schema/Indexing/FullText/WeightedFullTextIndex.cs
+++ b/src/Marten/Schema/Indexing/FullText/WeightedFullTextIndex.cs
@@ -1,0 +1,116 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Marten.Linq.Parsing;
+using Marten.Util;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables.Indexes;
+
+namespace Marten.Schema.Indexing.FullText;
+
+/// <summary>
+///     PostgreSQL's four text-search weight labels, most significant first.
+/// </summary>
+/// <remarks>
+///     The labels themselves carry no numbers. A rank function supplies the values, defaulting to
+///     <c>{D, C, B, A} = {0.1, 0.2, 0.4, 1.0}</c>, so <see cref="A" /> outranks <see cref="D" /> only
+///     because that is the default array — a query may weight them differently. <see cref="D" /> is what
+///     an unlabelled vector already means, which is why it is the default here.
+/// </remarks>
+public enum TextSearchWeight
+{
+    A,
+    B,
+    C,
+    D
+}
+
+/// <summary>
+///     Assigns a <see cref="TextSearchWeight" /> per member so that a match in one field can outrank a
+///     match in another.
+/// </summary>
+/// <remarks>
+///     <para>
+///         #5298. Marten's ordinary full-text index concatenates its members as TEXT and converts once,
+///         which produces a single flat vector in which every match is equally relevant:
+///     </para>
+///     <code>
+///     to_tsvector('english', ((data ->> 'Title') || ' ' || (data ->> 'Description')))
+///     </code>
+///     <para>
+///         Weighting cannot be expressed that way. <c>setweight</c> labels a <em>vector</em>, so each
+///         member is converted separately and the VECTORS are concatenated:
+///     </para>
+///     <code>
+///     setweight(to_tsvector('english', coalesce(data ->> 'Title', '')), 'A') ||
+///     setweight(to_tsvector('english', coalesce(data ->> 'Description', '')), 'C')
+///     </code>
+///     <para>
+///         <c>coalesce</c> is not decoration. <c>to_tsvector</c> of NULL is NULL, and concatenating NULL
+///         into a vector annihilates the whole expression — so one absent member would silently empty the
+///         index row for that document.
+///     </para>
+/// </remarks>
+public class WeightedFullTextIndexExpression<T>
+{
+    private readonly List<(MemberInfo[] Members, TextSearchWeight Weight)> _members = new();
+
+    /// <summary>
+    ///     Include a member in the index at the given weight.
+    /// </summary>
+    /// <param name="expression">The member to index</param>
+    /// <param name="weight">
+    ///     Its weight label. Defaults to <see cref="TextSearchWeight.D" />, which is what an unlabelled
+    ///     vector already means.
+    /// </param>
+    public WeightedFullTextIndexExpression<T> Weighted(
+        Expression<Func<T, object?>> expression,
+        TextSearchWeight weight = TextSearchWeight.D)
+    {
+        var members = FindMembers.Determine(expression);
+        if (members.Length == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(expression),
+                $"Unable to determine a member from {expression}.");
+        }
+
+        _members.Add((members, weight));
+        return this;
+    }
+
+    internal MemberInfo[][] Members => _members.Select(x => x.Members).ToArray();
+
+    internal bool IsEmpty => _members.Count == 0;
+
+    /// <summary>
+    ///     True when every member carries the same label, which makes the weighting a no-op.
+    /// </summary>
+    /// <remarks>
+    ///     Rejected at configuration time rather than silently emitting a pointless <c>setweight</c>.
+    ///     Relative ranking is the entire point: one weight, or the same weight everywhere, ranks nothing,
+    ///     and an index that looks weighted but is not is worse than an error — it invites a caller to
+    ///     build a ranked screen over it and ship it.
+    /// </remarks>
+    internal bool IsUniform => _members.Select(x => x.Weight).Distinct().Count() <= 1;
+
+    /// <summary>
+    ///     Build the <c>tsvector</c> expression this index is indexed over. The result is a vector at the
+    ///     top level, which is why it goes to <see cref="FullTextIndexDefinition.ForTsVector" /> rather
+    ///     than to <c>DocumentConfig</c>.
+    /// </summary>
+    internal string BuildTsVectorExpression(DocumentMapping mapping, string regConfig)
+    {
+        return _members
+            .Select(m =>
+            {
+                var locator = mapping.QueryMembers.MemberFor(m.Members).RawLocator.RemoveTableAlias("d");
+                return $"setweight(to_tsvector('{regConfig}', coalesce({locator}, '')), '{m.Weight}')";
+            })
+            .Join(" || ");
+    }
+}


### PR DESCRIPTION
Weasel **9.27.0 → 9.29.0** across all three pins, plus the full-text work that upgrade unblocks.

> **Rebased onto #5316.** This branch originally carried its own fix for #5314. @mlh758 had one in flight that I failed to check for, and **his is better** — it lives in `StringExtensions` as the explicit inverse of `RemoveTableAlias` (which is the right home, since the broken round-trip *is* the defect), takes the alias as a parameter, and covers `#>>` json-path, `data_v2` and doubled-quote escapes with tests. Mine has been dropped entirely; this branch now builds on his.

## The upgrade is what makes the rest possible

weasel#541 — raised from #5298 — added `TsVectorExpression` / `ForTsVector`, so a full-text index can be built over an expression that is **already** a `tsvector` rather than over text Weasel converts. Without it, per-member weighting is not expressible at all.

## #5298 — the index half

```csharp
opts.Schema.For<Achievement>().WeightedFullTextIndex(idx => idx
    .Weighted(a => a.Title, TextSearchWeight.A)
    .Weighted(a => a.Tagline, TextSearchWeight.B)
    .Weighted(a => a.Description, TextSearchWeight.C));
```

A distinct method rather than a `FullTextIndex` overload — that name already takes an `Action<FullTextIndexDefinition>`, so a second action-taking overload is ambiguous at every lambda call site. Same reason Weasel chose a factory.

Two decisions worth review:

- **`coalesce()` per member is load-bearing.** `to_tsvector` of NULL is NULL, and concatenating NULL into a vector annihilates the whole expression — one absent member would silently empty that document's index row. There is a test that stores a document with two null members and asserts it is still found.
- **A uniform weighting is refused at configuration time.** `setweight` only expresses a *relative* ordering, so one weight — or the same weight everywhere — ranks nothing. DDL that looks weighted and isn't invites someone to build a ranked screen over it and ship it.

The query side reads Weasel's `IndexedTsVector` for a weighted index — the one property both the DDL and the filter read, so the indexed and searched vectors cannot drift. The unweighted shape is left byte-for-byte as it was.

## #5315 — two mechanisms, and the filed one was the *second*

I only caught this because the fix I wrote for the mechanism I had reported did not make the test fail.

**The one that bites:** `FullTextIndexDefinition` derives its name from the **table**, never from the members, so two `FullTextIndex()` calls over different members collide by construction — and `AddFullTextIndexIfDoesNotExist` returned the first and threw the second away. Never registered, never created, never searched, no warning. The dedupe exists so configuring the same index twice is idempotent, which is kept; silently dropping a *different* configuration is not.

**The one behind it:** with explicit names both do register, and only then does the filter face a real choice with nothing in the query to make it with — `regConfig` is the search API's only selector. It resolved that by declaration order.

Both now throw `AmbiguousFullTextIndexException`, naming what collided and the way out. The test for the second asserts its own precondition (that both indexes really registered), or it would be passing on the first mechanism's throw and proving nothing about the query side.

## What is NOT here, and why

**The `ts_rank` ordering half of #5298.** `OrderByFragment` holds `List<string>` and appends straight to the command, so an ordering cannot carry a parameter — which is exactly why the ngram precedent inlines its term with quote-doubling. #5298 explicitly asks the new ordering to **parameterize** instead, and that means reworking shared ordering machinery across every producer of an ordering. Larger and riskier than everything here combined, and it should be its own PR rather than a rider on a dependency bump. #5298 stays open for it.

## Verification

| Suite | Result |
|---|---|
| LinqTests | 1474, 0 failed |
| DocumentDbTests | 1104, 0 failed |
| EventSourcingTests | 2005, 0 failed |
| CoreTests | 592, 4 pre-existing failures |

The four `CoreTests` failures (`Bug_4185`, `Bug_4187`, `rolling_range_partitioning`, `divergent_application_assembly_reuse_warning`) are the same classes already failing on `master` before this branch, and **each passes in isolation** — order-dependent, not a Weasel regression.

The weighted index is verified against a real PostgreSQL rather than on generated strings: the index is created carrying `setweight`, and it round-trips with **no drift** across a second apply and an `AssertDatabaseMatchesConfigurationAsync`. That matters — an expression PostgreSQL hands back differently than we wrote it would recreate the index on every migration, the exact outage the feature exists to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDX5UV1He5if9vVo8Bdi7g