### PR TITLE
Keep EnableExtendedProgressionTracking defaulting to false (#5310 reversal)

### DIFF
--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -686,12 +686,15 @@ past the event type's introduction.
 A shard that recovers clears its failure columns on the next successful start, so a supervisor built on
 them does not keep alerting on a failure that was fixed an hour ago.
 
-**Default: on.** The columns are useful for any stuck-shard diagnosis -- not just CritterWatch --
-and the write-side cost is negligible, because they carry already-computed daemon-internal values.
+**Default: off.** Opt in explicitly. The columns are useful for any stuck-shard diagnosis -- not just
+CritterWatch -- and the write-side cost is negligible, because they carry already-computed
+daemon-internal values. That is a good reason to turn it on, and not a reason for Marten to turn it on
+for you: an existing store that never asked for monitoring should not start writing six columns on
+every shard state transition because it upgraded.
 
 The columns themselves are created for **every** store regardless of this setting, and the next
-`ApplyAllConfiguredChangesToDatabaseAsync()` adds them to an existing database. They are nullable,
-so no backfill is required, and a store that leaves tracking off simply never writes them.
+`ApplyAllConfiguredChangesToDatabaseAsync()` adds them to an existing database. They are nullable, so
+no backfill is required, and a store that leaves tracking off never writes them.
 
 That the shape does not depend on the setting is deliberate. It used to, and two `DocumentStore`s
 pointed at the same `DatabaseSchemaName` that disagreed about the flag then stripped each other's
@@ -700,10 +703,10 @@ processes over one schema is an ordinary arrangement (a service beside a seeder,
 a migration tool), so the table shape is now the same for all of them
 (see [marten#5309](https://github.com/JasperFx/marten/issues/5309)).
 
-To turn the tracking off, set the toggle explicitly:
+Opt in (e.g. for CritterWatch monitoring or your own shard health tooling) by setting the toggle:
 
 ```cs
-opts.Events.EnableExtendedProgressionTracking = false;
+opts.Events.EnableExtendedProgressionTracking = true;
 ```
 
 Marten registers a storage-agnostic

--- a/src/CoreTests/Events/EventGraph_IEventStoreInstrumentation.cs
+++ b/src/CoreTests/Events/EventGraph_IEventStoreInstrumentation.cs
@@ -14,44 +14,54 @@ namespace CoreTests.Events;
 public class EventGraph_IEventStoreInstrumentation
 {
 
-    // #4687: default flipped from false → true (Critter Stack 1.0 timing). The monitoring
-    // columns are written from existing daemon runtime state so the cost is negligible, and
-    // they're useful for any stuck-shard diagnosis -- not just CritterWatch.
+    // The default is OFF, deliberately and permanently, and this is the third time it has come up --
+    // so the reasoning lives here rather than in a commit message.
     //
-    // #5310: this guard is the whole reason that flip regressed unnoticed. 824e3b783 added the
-    // `= true` and renamed this test to default_is_enabled; 769a6fd5e reverted both the next day
-    // while moving the property onto the SetEventStoreInstrumentation adapters, leaving this
-    // comment arguing for a default the test underneath it pinned as false. Both shipped in
-    // V9.30.0. If this is ever flipped back, flip the comment with it.
+    // #4687 argued for flipping it to true, on the grounds that the columns are cheap because they
+    // carry daemon runtime state that already exists. #5310 then found that the flip had landed in
+    // 824e3b783 and been lost the next day in 769a6fd5e, and restored it as an unintended regression.
+    //
+    // That restoration was reversed. Turning this on by default is a BREAKING change: every existing
+    // store that never asked for monitoring silently starts writing six columns on every shard state
+    // transition after an upgrade. "It was originally meant to be true" is a reason to document the
+    // opt-in well; it is not a reason to change what someone else's deployment does without them
+    // asking. The cheapness argument is a fine argument for turning it ON and no argument at all for
+    // turning it on for somebody else.
+    //
+    // If you are here because you are about to flip it again: don't, without a major version.
     [Fact]
-    public void default_is_enabled()
+    public void default_is_disabled()
     {
-        new StoreOptions().EventGraph.EnableExtendedProgressionTracking.ShouldBeTrue();
+        new StoreOptions().EventGraph.EnableExtendedProgressionTracking.ShouldBeFalse();
     }
 
-    // #5310: the scope of the regression was wider than "a bare DocumentStore.For(...) gets false"
-    // -- no path defaulted to true, AddMarten included. Pin the DI path separately, since it runs
-    // the adapters and the bare StoreOptions constructor does not.
+    // The DI path is pinned separately from the bare constructor because it runs the
+    // SetEventStoreInstrumentation adapters and the constructor does not -- so "off by default" has to
+    // be true of both, and an adapter that clobbers is exactly how that would stop being true.
     [Fact]
-    public void add_marten_alone_is_enabled()
+    public void add_marten_alone_is_disabled()
     {
         var collection = new ServiceCollection();
         collection.AddMarten(ConnectionSource.ConnectionString);
 
         using var provider = collection.BuildServiceProvider();
         provider.GetRequiredService<IDocumentStore>()
-            .Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+            .Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
     }
 
-    // #5310: with a true default, an opt-out has to actually opt out. #4981's guard was
-    // `if (ExtendedProgressionEnabled)`, which cannot fire for false -- correct while the default
-    // was false, silently inert the moment it is true. The adapter now distinguishes unset from
-    // explicitly-false, so this is the case that would regress if it ever goes back to a plain bool.
+    // The adapter distinguishes unset from explicitly-false, which is a no-op against today's false
+    // default -- kept because it is the difference between an opt-out that works and one that silently
+    // does nothing, and #4981's `if (ExtendedProgressionEnabled)` could not tell those apart. Pinned so
+    // that a future default change does not quietly break the opt-out the way it nearly did.
     [Fact]
     public void explicit_opt_out_on_the_di_singleton_is_honored()
     {
         var collection = new ServiceCollection();
-        collection.AddMarten(ConnectionSource.ConnectionString);
+        collection.AddMarten(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Events.EnableExtendedProgressionTracking = true;
+        });
 
         using var provider = collection.BuildServiceProvider();
         provider.GetRequiredService<IEventStoreInstrumentation>().ExtendedProgressionEnabled = false;
@@ -60,8 +70,7 @@ public class EventGraph_IEventStoreInstrumentation
             .Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
     }
 
-    // #5310: and the direct opt-out has to survive the adapter too -- the mirror of
-    // direct_toggle_inside_add_marten_survives_store_build, which only covered opting IN.
+    // The mirror of direct_toggle_inside_add_marten_survives_store_build, which only covered opting IN.
     [Fact]
     public void direct_opt_out_inside_add_marten_survives_store_build()
     {
@@ -112,9 +121,8 @@ public class EventGraph_IEventStoreInstrumentation
         store.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
     }
 
-    // #4981: the adapter must apply, not clobber. Under the #5310 true default the interesting
-    // direction is the opposite one from the original test -- an untouched DI singleton must leave
-    // a direct opt-OUT alone, which is exactly what an unconditional assignment would break.
+    // #4981: the adapter must apply, not clobber. An untouched DI singleton has to leave a direct
+    // opt-IN alone, which is the case that unconditional assignment broke.
     [Fact]
     public void untouched_di_singleton_does_not_clobber_a_direct_toggle()
     {
@@ -122,17 +130,17 @@ public class EventGraph_IEventStoreInstrumentation
         collection.AddMarten(opts =>
         {
             opts.Connection(ConnectionSource.ConnectionString);
-            opts.Events.EnableExtendedProgressionTracking = false;
+            opts.Events.EnableExtendedProgressionTracking = true;
         });
 
         using var provider = collection.BuildServiceProvider();
 
-        // Never assigned, so the adapter has nothing to apply and the direct toggle stands. The
-        // getter reports the EventGraph default it would leave in place rather than default(bool).
-        provider.GetRequiredService<IEventStoreInstrumentation>().ExtendedProgressionEnabled.ShouldBeTrue();
+        // Never assigned, so the adapter has nothing to apply and the direct toggle stands. The getter
+        // reports the EventGraph default it would leave in place.
+        provider.GetRequiredService<IEventStoreInstrumentation>().ExtendedProgressionEnabled.ShouldBeFalse();
 
         var store = provider.GetRequiredService<IDocumentStore>();
-        store.Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+        store.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
     }
 
     [Fact]

--- a/src/CoreTests/Events/extended_progression_gate.cs
+++ b/src/CoreTests/Events/extended_progression_gate.cs
@@ -7,33 +7,20 @@ using Xunit;
 namespace CoreTests.Events;
 
 // #750 regression guard. The async daemon's ExtendedProgressionWriter observer gates on
-// IEventStore.ExtendedProgressionEnabled. Marten's DocumentStore must reflect the store setting here
-// or the observer silently never fires and the extended progression columns (heartbeat /
-// agent_status / pause_reason / running_on_node) stay NULL -- exactly the "a feature that was built
-// and never connected" failure #750 reported. Since #5310 the store default is true, so the failure
-// #750 describes now lives on the opt-OUT side: a store that turns tracking off must be reported as
-// off, or the observer fires for a deployment that asked it not to.
+// IEventStore.ExtendedProgressionEnabled, whose interface default is false. Marten's DocumentStore
+// must reflect the store opt-in here or the observer silently never fires and the extended
+// progression columns (heartbeat / agent_status / pause_reason / running_on_node) stay NULL --
+// exactly the "a feature that was built and never connected" failure #750 reported.
+//
+// Both polarities are pinned. The property has to TRACK the store option rather than be hardcoded,
+// which is the actual contract; which value happens to be the default is a separate decision, and one
+// that has now changed twice (#4687, #5310).
 public class extended_progression_gate
 {
-    // #5310: the default is true again. What #750 is actually about is that this property must TRACK
-    // the store option rather than being hardcoded, so the guard is that both polarities are reported
-    // faithfully -- not that either one of them is the default.
     [Fact]
-    public void event_store_reports_extended_progression_enabled_by_default()
+    public void event_store_reports_extended_progression_disabled_by_default()
     {
         using var store = DocumentStore.For(ConnectionSource.ConnectionString);
-        ((IEventStore)store).ExtendedProgressionEnabled.ShouldBeTrue();
-    }
-
-    [Fact]
-    public void event_store_reflects_the_extended_progression_opt_out()
-    {
-        using var store = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.Events.EnableExtendedProgressionTracking = false;
-        });
-
         ((IEventStore)store).ExtendedProgressionEnabled.ShouldBeFalse();
     }
 

--- a/src/CoreTests/jasper_fx_mechanics.cs
+++ b/src/CoreTests/jasper_fx_mechanics.cs
@@ -408,11 +408,9 @@ public class jasper_fx_mechanics
     [Fact]
     public async Task advanced_tracking_off_leaves_extended_progression_tracking_at_default()
     {
-        // Sanity: when EnableAdvancedTracking is not set (default false), ReadJasperFxOptions does
-        // not touch EnableExtendedProgressionTracking at all -- the stores keep whatever the Marten
-        // default is. #5310 restored that default to true, so "at default" now means true; the point
-        // of the test is that JasperFxOptions is not the thing deciding it, which is why the
-        // assertions read the same for every store below.
+        // Sanity: when EnableAdvancedTracking is not set (default false), ReadJasperFxOptions does not
+        // touch EnableExtendedProgressionTracking at all -- the stores keep the Marten default, which is
+        // off. The point is that JasperFxOptions is not the thing deciding it.
         using var host = await Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
             {
@@ -432,10 +430,10 @@ public class jasper_fx_mechanics
             }).StartAsync();
 
         var main = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
-        main.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+        main.Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
 
         var first = host.Services.GetRequiredService<IFirstStore>().As<DocumentStore>();
-        first.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+        first.Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
     }
 
     [Fact]

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -284,25 +284,31 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     /// <summary>
     /// When enabled, the daemon writes heartbeat, agent_status, pause_reason, running_on_node and the
     /// failure_* columns of the event progression table, and progression reads hydrate them, for
-    /// CritterWatch monitoring. Defaults to <c>true</c>.
+    /// CritterWatch monitoring. Defaults to <c>false</c>; opt in explicitly.
     /// </summary>
     /// <remarks>
-    /// #4687 flipped this default from false to true; the values are written from daemon runtime state
-    /// that already exists, so the cost is negligible and the columns are useful for any stuck-shard
-    /// diagnosis, not just CritterWatch. #5310: that flip landed in 824e3b783 and was lost the next day
-    /// in 769a6fd5e, which moved the property onto the SetEventStoreInstrumentation adapters and did not
-    /// carry the initializer over -- taking the regression guard with it, which is why nothing caught it.
+    /// #5310 restored a `= true` default here, on the reading that #4687 had intended it and the flip was
+    /// lost to a refactor. That was reversed deliberately: turning it on by default is a BREAKING change,
+    /// because every existing store that never asked for monitoring would silently start writing six
+    /// columns on every shard state transition. "It was meant to be true" is not sufficient reason to
+    /// change what a deployment does on upgrade without it opting in.
     /// <para>
-    /// This no longer decides the SHAPE of mt_event_progression. Since #5309 the columns are always
-    /// created, because a table shape that depends on configuration means two stores over one schema can
-    /// disagree about it and strip each other's columns. This flag now gates only reads and writes.
+    /// The default is therefore false and stays false. #4687's argument -- the values are cheap because
+    /// they come from daemon runtime state that already exists -- remains a fine argument for turning it
+    /// ON, and none at all for turning it on for somebody else.
+    /// </para>
+    /// <para>
+    /// This does not decide the SHAPE of mt_event_progression either way. Since #5309 the columns are
+    /// always created, because a table shape that depends on configuration means two stores over one
+    /// schema can disagree about it and strip each other's columns. This flag gates only reads and
+    /// writes, so leaving it off costs nothing but the (nullable, never-written) columns.
     /// </para>
     /// </remarks>
     public bool EnableExtendedProgressionTracking
     {
         get;
         set;
-    } = true;
+    }
 
     /// <summary>
     /// Optional best-effort observer invoked after each successful <c>SaveChangesAsync</c> with the

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -1148,11 +1148,11 @@ internal class SetEventStoreInstrumentation: IConfigureMarten, IEventStoreInstru
         // `opts.Events.EnableExtendedProgressionTracking = true` (and any directly-set
         // AppendObserver) back to the adapter defaults at store build.
         //
-        // #5310: "was it assigned" and "is it true" have to be different questions. #4981's guard was
-        // `if (ExtendedProgressionEnabled)`, which was a correct opt-out only while the EventGraph
-        // default was false -- once the default is true, that guard cannot fire for
-        // `ExtendedProgressionEnabled = false` and the opt-out silently stops working. Keying off the
-        // backing field instead means unset still never clobbers, while an explicit false is applied.
+        // #5310: "was it assigned" and "is it true" are different questions, and keying off the backing
+        // field keeps them apart. #4981's guard was `if (ExtendedProgressionEnabled)`, which cannot
+        // distinguish "left alone" from "deliberately turned off" -- harmless while the EventGraph
+        // default is false, and silently wrong the moment anything changes that. Kept even though the
+        // default went back to false, because it is correct for either one and costs nothing.
         if (_extendedProgressionEnabled.HasValue)
         {
             options.EventGraph.EnableExtendedProgressionTracking = _extendedProgressionEnabled.Value;
@@ -1168,9 +1168,9 @@ internal class SetEventStoreInstrumentation: IConfigureMarten, IEventStoreInstru
 
     public bool ExtendedProgressionEnabled
     {
-        // Unset reads as the EventGraph default this adapter would leave in place, so reading the
-        // property before the store is built does not misreport what the store will get.
-        get => _extendedProgressionEnabled ?? true;
+        // Unset reads as the EventGraph default this adapter would leave in place (false), so reading
+        // the property before the store is built does not misreport what the store will get.
+        get => _extendedProgressionEnabled ?? false;
         set => _extendedProgressionEnabled = value;
     }
 
@@ -1198,7 +1198,7 @@ internal class SetEventStoreInstrumentation<T>: IConfigureMarten<T>, IEventStore
 
     public bool ExtendedProgressionEnabled
     {
-        get => _extendedProgressionEnabled ?? true;
+        get => _extendedProgressionEnabled ?? false;
         set => _extendedProgressionEnabled = value;
     }
 


### PR DESCRIPTION
Reverses the default flip from #5312. **Turning this on by default is a breaking change**, and it should not have gone in.

#5310 restored a `= true` default on the reading that #4687 intended it and the flip was lost to a refactor. That reading was right about the history and wrong about the consequence: every existing store that never asked for monitoring would silently start writing six columns on every shard state transition after an upgrade.

*"It was originally meant to be true"* is a reason to document the opt-in well. It is not a reason to change what somebody else's deployment does without them asking. #4687's own argument — the values are cheap because they come from daemon runtime state that already exists — is a fine argument for turning it **on**, and no argument at all for turning it on for someone else.

The reasoning now lives in the regression guard rather than in a commit message, because this has come up three times (#4687, #5310, this reversal), and each time the previous round's reasoning had to be reconstructed from git archaeology. The test says plainly not to flip it again without a major version.

## Deliberately kept from #5312

Both are independent of the default and still correct:

**The `bool?` backing field on the `SetEventStoreInstrumentation` adapters.** #4981's guard was `if (ExtendedProgressionEnabled)`, which cannot distinguish *"left alone"* from *"deliberately turned off"*. That is harmless against a false default and silently wrong the moment anything changes it — which is precisely the trap this PR is stepping back from, so it is worth keeping correct while we are here. The getters now report `false` when unset, so reading the property before the store is built does not misreport what the store will get.

**#5309's unconditional columns.** The shape of `mt_event_progression` still does not depend on configuration, so two stores over one schema cannot disagree and strip each other's columns. This is what makes an off-by-default cheap rather than a compromise: leaving the flag off now costs only the nullable, never-written columns, and the co-tenant strip cannot happen either way.

## Verification

| Suite | Result |
|---|---|
| CoreTests | 606, 4 pre-existing failures |
| DaemonTests | 319, 0 failed |

The four `CoreTests` failures (`Bug_4185`, `Bug_4187`, `rolling_range_partitioning`, `divergent_application_assembly_reuse_warning`) are the same order-dependent classes already failing on `master`; each passes in isolation.

Docs updated back to **Default: off**, keeping the corrected description of how the adapter composes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDX5UV1He5if9vVo8Bdi7g