### PR TITLE
ts_rank relevance ordering, and an ordering pipeline that can carry a parameter (#5298)

### DIFF
--- a/docs/cSpell.json
+++ b/docs/cSpell.json
@@ -128,6 +128,7 @@
     "unindexed",
     "SQLSTATE",
     "SQLSTATEs",
+    "tsvector",
     "unpartitioned"
   ],
   "ignoreRegExpList": [

--- a/docs/documents/full-text.md
+++ b/docs/documents/full-text.md
@@ -305,6 +305,87 @@ var posts = (await session.Query<BlogPost>()
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Indexes/full_text_index.cs#L405-L411' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_text_search_with_non_default_regconfig_sample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Weighted Full Text Indexes and Relevance Ranking <Badge type="tip" text="9.31" />
+
+By default a full text index concatenates its members into one flat vector, so a match in a title is
+exactly as relevant as a match in a long description. PostgreSQL can do better: `setweight()` labels
+each member, and `ts_rank()` then scores a title match above a body match.
+
+### Weighting the index
+
+```csharp
+opts.Schema.For<Achievement>().WeightedFullTextIndex(idx => idx
+    .Weighted(a => a.Title, TextSearchWeight.A)
+    .Weighted(a => a.Tagline, TextSearchWeight.B)
+    .Weighted(a => a.Description, TextSearchWeight.C));
+```
+
+which produces:
+
+```sql
+create index mt_doc_achievement_idx_fts on public.mt_doc_achievement using gin ((
+  setweight(to_tsvector('english', coalesce(data ->> 'Title', '')), 'A') ||
+  setweight(to_tsvector('english', coalesce(data ->> 'Tagline', '')), 'B') ||
+  setweight(to_tsvector('english', coalesce(data ->> 'Description', '')), 'C')
+));
+```
+
+Note that each member is converted to a vector *separately* and the vectors are concatenated. That is
+what `setweight` requires, and it is why weighting is a distinct method rather than an option on
+`FullTextIndex()` — the DDL is a different shape, not a configured variant of the same one.
+
+There are four weight labels, `A` through `D`. They carry no numbers of their own; the rank function
+supplies those, defaulting to `{D, C, B, A} = {0.1, 0.2, 0.4, 1.0}`. `D` is what an unlabelled vector
+already means, so it is the default.
+
+::: warning
+A weighted index needs at least two *different* weights. Weighting expresses a relative ordering, so
+one weight — or the same weight on every member — ranks nothing, and Marten refuses it at
+configuration time rather than emitting an index that looks weighted and is not.
+:::
+
+### Ordering by relevance
+
+`OrderByTextRank()` sorts by `ts_rank()`, highest first:
+
+```csharp
+var results = await session
+    .Query<Achievement>()
+    .Where(a => a.WebStyleSearch(term))
+    .OrderByTextRank(term, TextSearchFunction.WebStyle)
+    .ToListAsync();
+```
+
+Use `ThenByTextRank()` to add relevance after another ordering.
+
+The search function is explicit and has no default. Ranking with a different `tsquery` function than
+the `Where` clause used is always a mistake, and a friendly default would be occasionally wrong and
+silently so — so pass the one that matches your filter: `Plain`, `Phrase`, `WebStyle` or `Raw`.
+
+The rank resolves the *same* tsvector the `Where` clause matched on, read from the index definition.
+That is deliberate rather than incidental: a rank computed over a different vector than the filter
+matched on returns rows in an order that looks plausible and means nothing, which is a far quieter
+failure than returning the wrong rows.
+
+::: tip
+The search term is passed as a parameter rather than interpolated into the SQL.
+:::
+
+### Costs worth knowing before you use it
+
+**GIN indexes cannot order.** `ts_rank` is a post-filter sort over everything the `@@` matched, so
+ranking a broad query sorts a lot of rows. Narrow the filter before reaching for the rank.
+
+**Adding weights to an existing index is not a free migration.** Weights change the index expression,
+so Weasel drops and recreates the index on the next schema apply. On a large table that is an outage
+rather than a migration — consider building it out of band, as described in
+[the ignore-indexes documentation](/documents/indexing/ignore-indexes).
+
+**One index per text search configuration.** If a document has two full text indexes sharing a
+`regConfig`, Marten cannot tell which one a search means and will refuse the query rather than pick
+one. Give them different `regConfig` values, or register a single index covering every member you
+want to search.
+
 ## Partial text search in a multi-word text (NGram search)
 
 Marten provides the ability to search partial text or words in a string containing multiple words using NGram search. This is quite similar in functionality to [NGrams in Elastic Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-ngram-tokenizer.html). As an example, we can now accurately match `rich com text` within `Communicating Across Contexts (Enriched)`. NGram search uses English by default. NGram search also encompasses and handles unigrams, bigrams and trigrams. This functionality is added in v5.

--- a/src/DocumentDbTests/Indexes/full_text_rank_ordering.cs
+++ b/src/DocumentDbTests/Indexes/full_text_rank_ordering.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Schema.Indexing.FullText;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.Indexes;
+
+/// <summary>
+/// #5298, ordering half. <c>ts_rank</c> orders results by relevance, resolving the SAME tsvector the
+/// <c>Where</c> matched on — including a weighted one — so the rank and the filter cannot disagree.
+///
+/// <para>
+/// The search term is bound as a parameter. The ngram precedent inlines its term with
+/// <c>Replace("'", "''")</c>, which exists only because <c>OrderByFragment</c> held a
+/// <c>List&lt;string&gt;</c> and had nowhere to put a parameter. It holds fragments now.
+/// </para>
+/// </summary>
+[Collection("OneOffs")]
+public class full_text_rank_ordering: OneOffConfigurationsContext
+{
+    public class Article
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; }
+        public string Body { get; set; }
+    }
+
+    private async Task SeedWeightedStoreAsync()
+    {
+        StoreOptions(opts => opts.Schema.For<Article>().WeightedFullTextIndex(idx => idx
+            .Weighted(a => a.Title, TextSearchWeight.A)
+            .Weighted(a => a.Body, TextSearchWeight.D)));
+
+        await using var session = theStore.LightweightSession();
+        session.Store(
+            // "kangaroo" in the BODY only -- weight D
+            new Article { Id = Guid.NewGuid(), Title = "Something else entirely", Body = "a kangaroo appears here" },
+            // "kangaroo" in the TITLE -- weight A, so this must rank first
+            new Article { Id = Guid.NewGuid(), Title = "The kangaroo", Body = "nothing relevant in this body" });
+        await session.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// The whole point of weighting, end to end: a title match outranks a body match. Asserting on the
+    /// generated SQL would not catch a rank computed over the wrong vector, which is the failure mode
+    /// that matters here — so this asserts on the ORDER of real rows from PostgreSQL.
+    /// </summary>
+    [Fact]
+    public async Task a_title_match_outranks_a_body_match()
+    {
+        await SeedWeightedStoreAsync();
+
+        await using var query = theStore.QuerySession();
+        var results = await query.Query<Article>()
+            .Where(a => a.PlainTextSearch("kangaroo"))
+            .OrderByTextRank("kangaroo", TextSearchFunction.Plain)
+            .ToListAsync();
+
+        results.Count.ShouldBe(2);
+        results[0].Title.ShouldBe("The kangaroo");
+    }
+
+    /// <summary>
+    /// The term is a parameter, not inlined. Checked on the command rather than by trusting the
+    /// implementation, because this is the improvement over the ngram precedent that #5298 explicitly
+    /// asked for.
+    /// </summary>
+    [Fact]
+    public async Task the_search_term_is_parameterized()
+    {
+        await SeedWeightedStoreAsync();
+
+        var command = theStore.QuerySession().Query<Article>()
+            .Where(a => a.PlainTextSearch("kangaroo"))
+            .OrderByTextRank("kangaroo", TextSearchFunction.Plain)
+            .ToCommand();
+
+        command.CommandText.ShouldContain("ts_rank(");
+        command.CommandText.ShouldContain("order by");
+
+        // The term appears only as a parameter value, never inlined into the SQL text.
+        command.CommandText.ShouldNotContain("'kangaroo'");
+        command.Parameters.Count.ShouldBe(2);
+        command.Parameters.Any(p => (p.Value as string) == "kangaroo").ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// The rank has to resolve the same vector the filter did. With a weighted index that vector is a
+    /// pre-built <c>setweight(...) || setweight(...)</c> expression rather than a
+    /// <c>to_tsvector(config, text)</c> wrapper, so a rank that rebuilt the flat shape would rank over a
+    /// different vector than it filtered on and be silently wrong.
+    /// </summary>
+    [Fact]
+    public async Task the_rank_uses_the_same_vector_as_the_filter()
+    {
+        await SeedWeightedStoreAsync();
+
+        var sql = theStore.QuerySession().Query<Article>()
+            .Where(a => a.PlainTextSearch("kangaroo"))
+            .OrderByTextRank("kangaroo", TextSearchFunction.Plain)
+            .ToCommand().CommandText;
+
+        var filterVector = sql.Split(" @@ ")[0].Split("where ")[1];
+        var rankVector = sql.Split("ts_rank(")[1].Split(", plainto_tsquery")[0];
+
+        rankVector.ShouldBe(filterVector);
+        rankVector.ShouldContain("setweight");
+    }
+
+    /// <summary>
+    /// Ranking must also work on an ordinary unweighted index, where the vector is the flat
+    /// to_tsvector shape. Default ts_rank weights still separate a document mentioning the term twice
+    /// from one mentioning it once.
+    /// </summary>
+    [Fact]
+    public async Task ranking_works_over_an_unweighted_index()
+    {
+        StoreOptions(opts => opts.Schema.For<Article>().FullTextIndex(a => a.Title, a => a.Body));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(
+                new Article { Id = Guid.NewGuid(), Title = "one mention", Body = "wombat" },
+                new Article { Id = Guid.NewGuid(), Title = "wombat wombat", Body = "wombat wombat wombat" });
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = theStore.QuerySession();
+        var results = await query.Query<Article>()
+            .Where(a => a.PlainTextSearch("wombat"))
+            .OrderByTextRank("wombat", TextSearchFunction.Plain)
+            .ToListAsync();
+
+        results.Count.ShouldBe(2);
+        results[0].Title.ShouldBe("wombat wombat");
+    }
+
+    /// <summary>
+    /// ThenByTextRank composes after a primary ordering rather than replacing it.
+    /// </summary>
+    [Fact]
+    public async Task then_by_text_rank_composes_after_another_ordering()
+    {
+        await SeedWeightedStoreAsync();
+
+        var sql = theStore.QuerySession().Query<Article>()
+            .Where(a => a.PlainTextSearch("kangaroo"))
+            .OrderBy(a => a.Title)
+            .ThenByTextRank("kangaroo", TextSearchFunction.Plain)
+            .ToCommand().CommandText;
+
+        var orderBy = sql.Split("order by ")[1];
+        orderBy.IndexOf("Title", StringComparison.Ordinal)
+            .ShouldBeLessThan(orderBy.IndexOf("ts_rank", StringComparison.Ordinal));
+    }
+}

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -42,7 +42,7 @@ public partial class CollectionUsage
 
         foreach (var ordering in OrderingExpressions)
         {
-            statement.Ordering.Expressions.Add(ordering.BuildExpression(collection));
+            statement.Ordering.Expressions.Add(ordering.BuildFragment(collection));
         }
 
         statement.ParseWhereClause(WhereExpressions, session, collection, storage);
@@ -150,7 +150,7 @@ public partial class CollectionUsage
         var keySql = member.BuildOrderingExpression(
             new Ordering(DistinctByExpression, OrderingDirection.Asc), CasingRule.CaseSensitive);
 
-        statement.Ordering.Expressions.Insert(0, keySql);
+        statement.Ordering.Expressions.Insert(0, new LiteralOrdering(keySql));
 
         if (statement.SelectClause is IDistinctOnSelectClause distinctOn)
         {
@@ -201,7 +201,7 @@ public partial class CollectionUsage
         statement.IsDistinct = IsDistinct;
 
         foreach (var ordering in OrderingExpressions)
-            statement.Ordering.Expressions.Add(ordering.BuildExpression(collection));
+            statement.Ordering.Expressions.Add(ordering.BuildFragment(collection));
 
         statement.ParseWhereClause(WhereExpressions, session, collection);
 
@@ -588,7 +588,7 @@ public partial class CollectionUsage
         {
             if (!string.IsNullOrEmpty(ordering.Literal))
             {
-                joinStatement.Ordering.Expressions.Add(ordering.Literal!);
+                joinStatement.Ordering.Expressions.Add(new LiteralOrdering(ordering.Literal!));
                 continue;
             }
 
@@ -643,7 +643,7 @@ public partial class CollectionUsage
                     + "inner sides of the GroupJoin (or neither). Order by a member of one side.");
             }
 
-            joinStatement.Ordering.Expressions.Add(sql);
+            joinStatement.Ordering.Expressions.Add(new LiteralOrdering(sql));
         }
 
         // Transfer Distinct() from the SelectMany usage chain. JoinSelectClause implements

--- a/src/Marten/Linq/Parsing/Operators/OperatorLibrary.cs
+++ b/src/Marten/Linq/Parsing/Operators/OperatorLibrary.cs
@@ -38,6 +38,8 @@ internal class OperatorLibrary
         Add<OrderBySqlOperator>();
         Add<ThenBySqlOperator>();
         Add<OrderByNgramRankOperator>();
+        Add<OrderByTextRankOperator>();
+        Add<ThenByTextRankOperator>();
 
         foreach (var mode in Enum.GetValues<SingleValueMode>()) addSingleValueMode(mode);
     }

--- a/src/Marten/Linq/Parsing/Operators/OrderByTextRankOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/OrderByTextRankOperator.cs
@@ -1,0 +1,68 @@
+#nullable enable
+using System.Linq.Expressions;
+using Marten.Schema;
+using Marten.Storage;
+using Marten.Schema.Indexing.FullText;
+
+namespace Marten.Linq.Parsing.Operators;
+
+/// <summary>
+///     Parses <c>OrderByTextRank()</c> / <c>ThenByTextRank()</c> into a <c>ts_rank</c> ordering (#5298).
+/// </summary>
+/// <remarks>
+///     The pieces are captured here and resolved during <c>BuildFragment</c>, the same deferral
+///     <see cref="OrderByNgramRankOperator" /> uses — the document mapping and the member collection are
+///     not available at parse time.
+/// </remarks>
+internal class OrderByTextRankOperator: LinqOperator
+{
+    private readonly bool _then;
+
+    public OrderByTextRankOperator(): this(nameof(QueryableExtensions.OrderByTextRank), false)
+    {
+    }
+
+    protected OrderByTextRankOperator(string methodName, bool then): base(methodName)
+    {
+        _then = then;
+    }
+
+    public override void Apply(ILinqQuery query, MethodCallExpression expression)
+    {
+        var usage = query.CollectionUsageFor(expression);
+
+        var searchTerm = (string)(expression.Arguments[1].ReduceToConstant().Value ?? "");
+        var function = (TextSearchFunction)expression.Arguments[2].ReduceToConstant().Value!;
+        var regConfig = (string)expression.Arguments[3].ReduceToConstant().Value!;
+
+        var mapping = usage.Options == null
+            ? null
+            : ((IReadOnlyStoreOptions)usage.Options).FindOrResolveDocumentType(usage.ElementType) as DocumentMapping;
+
+        var ordering = new Ordering(expression, OrderingDirection.Desc)
+        {
+            TextRank = new TextRankOrdering(searchTerm, function, regConfig, mapping),
+
+            // Ranking is a computed expression rather than a member, so it cannot be combined with a
+            // Distinct(Select()) usage -- the same reason the ngram rank marks itself transformed.
+            IsTransformed = true
+        };
+
+        // OrderBy replaces any ordering ahead of it; ThenBy appends after one.
+        if (_then)
+        {
+            usage.OrderingExpressions.Add(ordering);
+        }
+        else
+        {
+            usage.OrderingExpressions.Insert(0, ordering);
+        }
+    }
+}
+
+internal class ThenByTextRankOperator: OrderByTextRankOperator
+{
+    public ThenByTextRankOperator(): base(nameof(QueryableExtensions.ThenByTextRank), true)
+    {
+    }
+}

--- a/src/Marten/Linq/Parsing/Operators/Ordering.cs
+++ b/src/Marten/Linq/Parsing/Operators/Ordering.cs
@@ -5,6 +5,9 @@ using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Marten.Linq.Members;
 using Marten.Linq.Members.Dictionaries;
+using Marten.Linq.SqlGeneration;
+using Marten.Schema.Indexing.FullText;
+using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Parsing.Operators;
 
@@ -58,6 +61,31 @@ public class Ordering
     /// For NgramRank ordering: the store options for schema name and unaccent config.
     /// </summary>
     internal StoreOptions? NgramRankOptions { get; init; }
+
+    /// <summary>
+    /// For ts_rank ordering (#5298): everything needed to render a relevance ordering that resolves the
+    /// same tsvector the Where clause matched on, and binds its search term as a parameter.
+    /// </summary>
+    internal TextRankOrdering? TextRank { get; init; }
+
+    /// <summary>
+    ///     Build this ordering as a SQL fragment, so that an ordering carrying a user value can bind it as
+    ///     a parameter rather than interpolating it (#5298).
+    /// </summary>
+    /// <remarks>
+    ///     Every other ordering is a member locator or a caller-supplied literal, neither of which
+    ///     contains user input, so those keep going through <see cref="BuildExpression" /> and are wrapped
+    ///     as a <see cref="LiteralOrdering" />.
+    /// </remarks>
+    public ISqlFragment BuildFragment(IQueryableMemberCollection collection)
+    {
+        if (TextRank != null)
+        {
+            return TextRank.Build(collection, Direction);
+        }
+
+        return new LiteralOrdering(BuildExpression(collection));
+    }
 
     public string BuildExpression(IQueryableMemberCollection collection)
     {

--- a/src/Marten/Linq/SqlGeneration/Filters/FullTextWhereFragment.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/FullTextWhereFragment.cs
@@ -7,6 +7,7 @@ using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Marten.Exceptions;
 using Marten.Schema;
+using Marten.Schema.Indexing.FullText;
 using Marten.Util;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
@@ -39,36 +40,9 @@ internal class FullTextWhereFragment: ISqlFragment
 
         _regConfig = regConfig;
 
-        _vector = ResolveVector(mapping, regConfig);
+        _vector = FullTextIndexResolver.ResolveVector(mapping, regConfig);
         _searchFunction = searchFunction;
         _searchTerm = searchTerm;
-    }
-
-    /// <summary>
-    ///     The <c>tsvector</c> this filter searches, which must be the same one the index was built over.
-    /// </summary>
-    /// <remarks>
-    ///     A weighted index (#5298) is built over an expression that is ALREADY a tsvector, so it cannot
-    ///     be reconstructed by wrapping a data config in <c>to_tsvector</c> the way the flat case is.
-    ///     Weasel exposes <c>IndexedTsVector</c> as the one property both its DDL and this filter read,
-    ///     precisely so the indexed vector and the searched vector cannot drift apart (weasel#541).
-    ///     <para>
-    ///     The unweighted shape is left byte-for-byte as it was. Changing it would change the SQL every
-    ///     existing full-text query emits, for no gain.
-    ///     </para>
-    /// </remarks>
-    private static string ResolveVector(DocumentMapping? mapping, string regConfig)
-    {
-        var index = FindIndex(mapping, regConfig);
-
-        if (index?.TsVectorExpression != null)
-        {
-            return index.IndexedTsVector.ApplyTableAliasToDataColumn("d");
-        }
-
-        var dataConfig = (index?.DocumentConfig ?? FullTextIndexDefinition.DataDocumentConfig)
-            .ApplyTableAliasToDataColumn("d");
-        return $"to_tsvector('{regConfig}'::regconfig, {dataConfig})";
     }
 
     private static void ValidateRegConfig(string regConfig)
@@ -96,47 +70,4 @@ internal class FullTextWhereFragment: ISqlFragment
         builder.AppendWithParameters(Sql)[0].Value = _searchTerm;
     }
 
-    /// <summary>
-    ///     The full text index this search runs against.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         #5315. This used to be <c>FirstOrDefault</c> over the indexes matching a regConfig, and every
-    ///         full text index shares the default <c>english</c> unless someone deliberately varies it — so
-    ///         on a document with two of them the filter searched one and silently ignored the other.
-    ///         A document matching only on the second index simply never came back, with no error and
-    ///         nothing in the SQL to suggest a second index had been considered and dropped. Which one won
-    ///         was a function of declaration order.
-    ///     </para>
-    ///     <para>
-    ///         Ambiguity is now refused rather than resolved arbitrarily. The query API has exactly one
-    ///         selector, <c>regConfig</c>, so when it does not narrow to a single index there is no answer
-    ///         this method could give that is better than an error — and ranking (#5298) makes the choice
-    ///         load-bearing rather than merely untidy, because a <c>ts_rank</c> over a different vector than
-    ///         the <c>@@</c> filtered on is silently wrong rather than slow.
-    ///     </para>
-    /// </remarks>
-    private static FullTextIndexDefinition? FindIndex(DocumentMapping? mapping, string regConfig)
-    {
-        if (mapping == null)
-        {
-            return null;
-        }
-
-        var candidates = mapping
-            .Indexes
-            .OfType<FullTextIndexDefinition>()
-            .Where(i => i.RegConfig == regConfig)
-            .ToArray();
-
-        if (candidates.Length > 1)
-        {
-            var names = candidates.Select(x => x.Name).Join(", ");
-            throw new AmbiguousFullTextIndexException(
-                $"Document type {mapping.DocumentType.FullNameInCode()} has {candidates.Length} full text indexes registered for the text search configuration '{regConfig}' ({names}), so Marten cannot tell which one this search means. "
-                + "Give the indexes different regConfig values and pass the one you want as the search's regConfig argument, or register a single index covering every member you need to search.");
-        }
-
-        return candidates.FirstOrDefault();
-    }
 }

--- a/src/Marten/Linq/SqlGeneration/OrderByFragment.cs
+++ b/src/Marten/Linq/SqlGeneration/OrderByFragment.cs
@@ -6,9 +6,38 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.SqlGeneration;
 
+/// <summary>
+///     The <c>order by</c> clause of a statement.
+/// </summary>
+/// <remarks>
+///     <para>
+///         #5298. <c>Expressions</c> used to be a <c>List&lt;string&gt;</c> appended straight to the
+///         command, which meant an ordering could not carry a parameter — the whole clause was one opaque
+///         piece of SQL text. That is why <c>OrderByNgramRank</c> inlines its search term with
+///         <c>Replace("'", "''")</c> rather than parameterizing it: there was nowhere to put a parameter.
+///     </para>
+///     <para>
+///         Holding fragments instead lets an ordering that needs a user value bind it properly.
+///         <see cref="LiteralOrdering" /> carries the ordinary member and literal cases, which are built
+///         from member locators and never contain user input.
+///     </para>
+///     <para>
+///         This is a breaking change to a public member, made deliberately: the alternative was a second
+///         parallel list, which leaves two ways to express the same clause and a standing chance of one
+///         being written and the other read.
+///     </para>
+/// </remarks>
 public class OrderByFragment: ISqlFragment
 {
-    public List<string> Expressions { get; } = new();
+    public List<ISqlFragment> Expressions { get; } = new();
+
+    /// <summary>
+    ///     Add an ordering expression that is already complete SQL and carries no parameters.
+    /// </summary>
+    public void Add(string expression)
+    {
+        Expressions.Add(new LiteralOrdering(expression));
+    }
 
     public void Apply(ICommandBuilder builder)
     {
@@ -18,12 +47,32 @@ public class OrderByFragment: ISqlFragment
         }
 
         builder.Append(" order by ");
-        builder.Append(Expressions[0]);
+        Expressions[0].Apply(builder);
         for (var i = 1; i < Expressions.Count; i++)
         {
             builder.Append(", ");
-            builder.Append(Expressions[i]);
+            Expressions[i].Apply(builder);
         }
     }
+}
 
+/// <summary>
+///     An ordering that is a fixed piece of SQL — a member locator, or a literal supplied through
+///     <c>OrderBySql()</c>.
+/// </summary>
+public class LiteralOrdering: ISqlFragment
+{
+    public LiteralOrdering(string sql)
+    {
+        Sql = sql;
+    }
+
+    public string Sql { get; }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        builder.Append(Sql);
+    }
+
+    public override string ToString() => Sql;
 }

--- a/src/Marten/QueryableExtensions.cs
+++ b/src/Marten/QueryableExtensions.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal.Sessions;
 using Marten.Linq;
+using Marten.Schema.Indexing.FullText;
+using Weasel.Postgresql.Tables.Indexes;
 using Marten.Linq.Includes;
 using Marten.Services.BatchQuerying;
 using Npgsql;
@@ -839,6 +841,68 @@ public static class QueryableExtensions
                 queryable.Expression,
                 memberExpression,
                 Expression.Constant(searchTerm)));
+    }
+
+    private static MethodInfo _orderByTextRankMethod = typeof(QueryableExtensions).GetMethod(
+        nameof(OrderByTextRank), BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic)!;
+
+    private static MethodInfo _thenByTextRankMethod = typeof(QueryableExtensions).GetMethod(
+        nameof(ThenByTextRank), BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic)!;
+
+    /// <summary>
+    ///     Order results by full text search relevance, using PostgreSQL's <c>ts_rank</c>. Highest
+    ///     relevance first.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Pair with a matching full text search in the <c>Where</c> clause. The rank resolves the same
+    ///         tsvector the filter does — including a weighted one from <c>WeightedFullTextIndex</c> — so
+    ///         the two cannot drift apart.
+    ///     </para>
+    ///     <code>
+    ///     session.Query&lt;Achievement&gt;()
+    ///         .Where(a =&gt; a.WebStyleSearch(term))
+    ///         .OrderByTextRank(term, TextSearchFunction.WebStyle)
+    ///     </code>
+    ///     <para>
+    ///         <paramref name="function" /> is explicit and has no default on purpose: ranking with a
+    ///         different tsquery function than the <c>Where</c> used is always a mistake, and a friendly
+    ///         default would be occasionally wrong and silently so.
+    ///     </para>
+    ///     <para>
+    ///         GIN cannot order, so this is a post-filter sort over the matched set. Ranking a broad query
+    ///         sorts a lot of rows.
+    ///     </para>
+    /// </remarks>
+    /// <param name="searchTerm">The term to rank against — normally the same one the Where clause used</param>
+    /// <param name="function">The tsquery function, which must match the one the Where clause used</param>
+    /// <param name="regConfig">The text search configuration, defaulting to 'english'</param>
+    public static IQueryable<T> OrderByTextRank<T>(this IQueryable<T> queryable, string searchTerm,
+        TextSearchFunction function, string regConfig = FullTextIndexDefinition.DefaultRegConfig)
+    {
+        return queryable.Provider.CreateQuery<T>(
+            Expression.Call(null,
+                _orderByTextRankMethod.MakeGenericMethod(typeof(T)),
+                queryable.Expression,
+                Expression.Constant(searchTerm),
+                Expression.Constant(function),
+                Expression.Constant(regConfig)));
+    }
+
+    /// <summary>
+    ///     Add a <c>ts_rank</c> relevance ordering after an existing ordering. See
+    ///     <see cref="OrderByTextRank{T}" />.
+    /// </summary>
+    public static IQueryable<T> ThenByTextRank<T>(this IQueryable<T> queryable, string searchTerm,
+        TextSearchFunction function, string regConfig = FullTextIndexDefinition.DefaultRegConfig)
+    {
+        return queryable.Provider.CreateQuery<T>(
+            Expression.Call(null,
+                _thenByTextRankMethod.MakeGenericMethod(typeof(T)),
+                queryable.Expression,
+                Expression.Constant(searchTerm),
+                Expression.Constant(function),
+                Expression.Constant(regConfig)));
     }
 
     /// <summary>

--- a/src/Marten/Schema/Indexing/FullText/FullTextIndexResolver.cs
+++ b/src/Marten/Schema/Indexing/FullText/FullTextIndexResolver.cs
@@ -1,0 +1,93 @@
+#nullable enable
+using System.Linq;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Marten.Exceptions;
+using Marten.Util;
+using Weasel.Postgresql.Tables.Indexes;
+
+namespace Marten.Schema.Indexing.FullText;
+
+/// <summary>
+///     Resolves which full text index a search runs against, and the <c>tsvector</c> expression to search
+///     or rank over.
+/// </summary>
+/// <remarks>
+///     Shared by the <c>@@</c> filter and the <c>ts_rank</c> ordering, and that sharing is the point
+///     rather than a convenience. A rank computed over a different vector than the one the filter matched
+///     on is <em>silently wrong</em> — it returns rows in an order that looks plausible and means nothing
+///     — where a mismatch in the filter at least returns visibly wrong rows. Having one resolver is what
+///     makes the two incapable of disagreeing.
+/// </remarks>
+internal static class FullTextIndexResolver
+{
+    /// <summary>
+    ///     The full text index this search runs against, or null when the document has none.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         #5315. This used to be <c>FirstOrDefault</c> over the indexes matching a regConfig, and
+    ///         every full text index shares the default <c>english</c> unless someone deliberately varies
+    ///         it — so on a document with two of them the filter searched one and silently ignored the
+    ///         other. A document matching only on the second simply never came back, with no error and
+    ///         nothing in the SQL to suggest a second index had been considered and dropped. Which one won
+    ///         was a function of declaration order.
+    ///     </para>
+    ///     <para>
+    ///         Ambiguity is refused rather than resolved arbitrarily. The query API has exactly one
+    ///         selector, <c>regConfig</c>, so when it does not narrow to a single index there is no answer
+    ///         better than an error.
+    ///     </para>
+    /// </remarks>
+    public static FullTextIndexDefinition? FindIndex(DocumentMapping? mapping, string regConfig)
+    {
+        if (mapping == null)
+        {
+            return null;
+        }
+
+        var candidates = mapping
+            .Indexes
+            .OfType<FullTextIndexDefinition>()
+            .Where(i => i.RegConfig == regConfig)
+            .ToArray();
+
+        if (candidates.Length > 1)
+        {
+            var names = candidates.Select(x => x.Name).Join(", ");
+            throw new AmbiguousFullTextIndexException(
+                $"Document type {mapping.DocumentType.FullNameInCode()} has {candidates.Length} full text indexes registered for the text search configuration '{regConfig}' ({names}), so Marten cannot tell which one this search means. "
+                + "Give the indexes different regConfig values and pass the one you want as the search's regConfig argument, or register a single index covering every member you need to search.");
+        }
+
+        return candidates.FirstOrDefault();
+    }
+
+    /// <summary>
+    ///     The <c>tsvector</c> expression to search or rank over, aliased for the query.
+    /// </summary>
+    /// <remarks>
+    ///     A weighted index (#5298) is built over an expression that is ALREADY a tsvector, so it cannot
+    ///     be reconstructed by wrapping a data config in <c>to_tsvector</c> the way the flat case is.
+    ///     Weasel exposes <c>IndexedTsVector</c> as the one property both its DDL and this read, precisely
+    ///     so the indexed vector and the searched vector cannot drift apart (weasel#541).
+    ///     <para>
+    ///     The unweighted shape is byte-for-byte what it has always been. Changing it would change the SQL
+    ///     every existing full-text query emits, for no gain.
+    ///     </para>
+    /// </remarks>
+    public static string ResolveVector(DocumentMapping? mapping, string regConfig)
+    {
+        var index = FindIndex(mapping, regConfig);
+
+        if (index?.TsVectorExpression != null)
+        {
+            return index.IndexedTsVector.ApplyTableAliasToDataColumn("d");
+        }
+
+        var dataConfig = (index?.DocumentConfig ?? FullTextIndexDefinition.DataDocumentConfig)
+            .ApplyTableAliasToDataColumn("d");
+
+        return $"to_tsvector('{regConfig}'::regconfig, {dataConfig})";
+    }
+}

--- a/src/Marten/Schema/Indexing/FullText/TextRankOrdering.cs
+++ b/src/Marten/Schema/Indexing/FullText/TextRankOrdering.cs
@@ -1,0 +1,117 @@
+#nullable enable
+using System;
+using Marten.Linq;
+using Marten.Linq.Members;
+using Marten.Schema;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+using Weasel.Postgresql.Tables.Indexes;
+
+namespace Marten.Schema.Indexing.FullText;
+
+/// <summary>
+///     Which <c>tsquery</c> function a text search — and a rank over it — is built with.
+/// </summary>
+/// <remarks>
+///     Deliberately explicit with no default. Ranking with a different tsquery function than the
+///     <c>Where</c> used is always a mistake, and inferring it from a sibling <c>Where</c> clause is
+///     fragile. A friendly default here would be occasionally wrong and silently so.
+/// </remarks>
+public enum TextSearchFunction
+{
+    /// <summary><c>plainto_tsquery</c> — every word required, no operators.</summary>
+    Plain,
+
+    /// <summary><c>phraseto_tsquery</c> — words required, in order and adjacent.</summary>
+    Phrase,
+
+    /// <summary><c>websearch_to_tsquery</c> — web-style syntax: quotes, <c>or</c>, <c>-</c>.</summary>
+    WebStyle,
+
+    /// <summary><c>to_tsquery</c> — raw tsquery syntax, operators and all.</summary>
+    Raw
+}
+
+/// <summary>
+///     A <c>ts_rank</c> relevance ordering (#5298).
+/// </summary>
+/// <remarks>
+///     <para>
+///         The vector is resolved through <see cref="FullTextIndexResolver" />, the same path the
+///         <c>@@</c> filter uses. That is the whole design constraint: a rank computed over a different
+///         vector than the filter matched on is <em>silently wrong</em> rather than merely slow — rows
+///         come back in an order that looks plausible and means nothing. Resolving both through one place
+///         is what makes them incapable of disagreeing.
+///     </para>
+///     <para>
+///         The search term is bound as a parameter. The ngram precedent
+///         (<c>Ordering.BuildNgramRankExpression</c>) inlines its term with <c>Replace("'", "''")</c>,
+///         which is correct under <c>standard_conforming_strings</c> but exists only because the ordering
+///         pipeline used to be a list of strings with nowhere to put a parameter. Now that it holds
+///         fragments, there is no reason to interpolate a user value into SQL — a class of bug this repo
+///         has shipped advisories for more than once.
+///     </para>
+/// </remarks>
+internal class TextRankOrdering
+{
+    public TextRankOrdering(string searchTerm, TextSearchFunction function, string regConfig,
+        DocumentMapping? mapping)
+    {
+        SearchTerm = searchTerm;
+        Function = function;
+        RegConfig = regConfig;
+        Mapping = mapping;
+    }
+
+    public string SearchTerm { get; }
+    public TextSearchFunction Function { get; }
+    public string RegConfig { get; }
+    public DocumentMapping? Mapping { get; }
+
+    public ISqlFragment Build(IQueryableMemberCollection collection, OrderingDirection direction)
+    {
+        var vector = FullTextIndexResolver.ResolveVector(Mapping, RegConfig);
+        return new TextRankFragment(vector, RegConfig, Function, SearchTerm, direction);
+    }
+
+    internal static string ToSqlFunction(TextSearchFunction function) =>
+        function switch
+        {
+            TextSearchFunction.Plain => "plainto_tsquery",
+            TextSearchFunction.Phrase => "phraseto_tsquery",
+            TextSearchFunction.WebStyle => "websearch_to_tsquery",
+            TextSearchFunction.Raw => "to_tsquery",
+            _ => throw new ArgumentOutOfRangeException(nameof(function), function, "Unknown text search function")
+        };
+}
+
+internal class TextRankFragment: ISqlFragment
+{
+    private readonly OrderingDirection _direction;
+    private readonly TextSearchFunction _function;
+    private readonly string _regConfig;
+    private readonly string _searchTerm;
+    private readonly string _vector;
+
+    public TextRankFragment(string vector, string regConfig, TextSearchFunction function, string searchTerm,
+        OrderingDirection direction)
+    {
+        _vector = vector;
+        _regConfig = regConfig;
+        _function = function;
+        _searchTerm = searchTerm;
+        _direction = direction;
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        // regConfig is interpolated rather than parameterized, matching FullTextWhereFragment: it ruins
+        // the query plan as a parameter, and it is validated against a strict identifier pattern before
+        // it reaches here. The search TERM is the user value, and it is bound.
+        var direction = _direction == OrderingDirection.Desc ? " desc" : " asc";
+        var sql =
+            $"ts_rank({_vector}, {TextRankOrdering.ToSqlFunction(_function)}('{_regConfig}'::regconfig, ?)){direction}";
+
+        builder.AppendWithParameters(sql)[0].Value = _searchTerm;
+    }
+}


### PR DESCRIPTION
Closes the **ordering half** of #5298. The index half shipped in #5317; this is the part that lets anyone actually sort by relevance.

```csharp
session.Query<Achievement>()
    .Where(a => a.WebStyleSearch(term))
    .OrderByTextRank(term, TextSearchFunction.WebStyle)
```

## The pipeline change, which was the real blocker

`OrderByFragment.Expressions` was a `List<string>` appended straight to the command, and `Ordering.BuildExpression` returned a `string`. An ordering therefore **could not carry a parameter at all** — the whole clause was one opaque piece of SQL text.

That is why `OrderByNgramRank` inlines its search term with `Replace("'", "''")` rather than binding it: there was nowhere to put a parameter. Not an oversight.

`Expressions` now holds `ISqlFragment`. Ordinary member and literal orderings are wrapped in `LiteralOrdering` and behave identically; only an ordering that needs to bind a value does anything different. **Five call sites, one consumer** — smaller than I first estimated when I said this was riskier than the whole index half. It isn't.

This breaks a public member deliberately, per your go-ahead. The alternative was a second parallel list, which leaves two ways to express the same clause and a standing chance of one being written and the other read.

## The correctness constraint

`FullTextIndexResolver` is now shared by the `@@` filter and the `ts_rank` ordering, and that sharing is the point rather than tidiness.

A rank computed over a different vector than the filter matched on is **silently wrong** — rows come back in an order that looks plausible and means nothing — where a mismatched filter at least returns visibly wrong rows. One resolver is what makes the two incapable of disagreeing, and it is why #5315 had to be settled before this could land.

It matters most with a weighted index, whose vector is a pre-built `setweight(…) || setweight(…)` expression rather than a `to_tsvector(config, text)` wrapper. A rank that rebuilt the flat shape would compile, run, and rank over something the filter never used.

## Decisions

**`TextSearchFunction` is explicit with no default.** Ranking with a different `tsquery` function than the `Where` used is always a mistake, and inferring it from a sibling `Where` clause is fragile. A friendly default would be occasionally wrong and silently so.

**Deferred, as #5298 itself proposed:** `TextRankOptions` (`ts_rank_cd`, the `{D,C,B,A}` weights array, the normalization bitmask) and `ts_rank` in the select list for projecting a score.

## Verification

The relevance assertion is on the **order of real rows out of PostgreSQL**, not on generated SQL: a document with "kangaroo" in a weight-`A` title ranks above one with it in a weight-`D` body. Asserting on SQL would not catch a rank over the wrong vector, which is exactly the failure that matters here.

Also pinned:

- the term appears **only** as a parameter value and never in the command text
- the rank vector is character-identical to the filter vector, and contains `setweight`
- ranking works over an unweighted index too
- `ThenByTextRank` composes after a primary ordering rather than replacing it

| Suite | Result |
|---|---|
| LinqTests | 1474, 0 failed |
| DocumentDbTests | 1109, 0 failed |

The ordering pipeline change disturbs no existing ordering.

## Docs

New section in `docs/documents/full-text.md` covering weighting (which #5317 shipped undocumented), ordering, and the three costs worth knowing before reaching for it: GIN cannot order so this is a post-filter sort; adding weights drops and recreates the index; one index per `regConfig`. markdownlint and cspell clean across all 143 doc files, with `tsvector` added to the dictionary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDX5UV1He5if9vVo8Bdi7g