### PR TITLE
Aggregate write cache for the Live lifecycle (#5225)

### DIFF
--- a/docs/events/optimizing.md
+++ b/docs/events/optimizing.md
@@ -155,8 +155,9 @@ when your projection is constantly updating a relatively small number of differe
 ## Caching Aggregate Snapshots for FetchForWriting <Badge type="tip" text="9.26" />
 
 The cache above is the *daemon's*. This one is the command side's: an opt-in, node-local cache of aggregate
-snapshots that lets `FetchForWriting` skip loading the stored snapshot and read only the events after it.
-Think of it as an identity map for aggregates with a lifetime longer than a session.
+snapshots that gives `FetchForWriting` a baseline to start from, so it reads only the events after it
+instead of the stored snapshot or the whole stream. Think of it as an identity map for aggregates with a
+lifetime longer than a session.
 
 It is off for every aggregate type, and is enabled per type:
 
@@ -165,6 +166,14 @@ opts.Projections.Snapshot<Order>(SnapshotLifecycle.Async);
 
 // Keep up to 1000 recently fetched Order snapshots
 opts.Events.CacheAggregatesForWriting<Order>(sizeLimit: 1000);
+```
+
+It works on all three lifecycles, including `Live` aggregates that have no stored snapshot at all:
+
+```csharp
+opts.Projections.LiveStreamAggregation<Order>();
+
+opts.Events.CacheAggregatesForWriting<Order>();
 ```
 
 Per type rather than store-wide because the win is proportional to how often *one* stream is fetched for
@@ -187,20 +196,40 @@ A "trusted" variant that also skipped the version read was built, measured and *
 0.19 ms of a 13.2 ms round, about 1.4%, in exchange for the concurrency guarantee. Do not reintroduce it.
 :::
 
-### The two lifecycles differ
+### The three lifecycles differ
 
-| | Async | Inline |
-| --- | --- | --- |
-| Cached entry is | a baseline; newer events are folded onto it | usable only on an **exact** version match |
-| Written to the cache | as soon as the fetch completes | only **after a successful commit** |
+| | Live | Async | Inline |
+| --- | --- | --- | --- |
+| Without the cache, a fetch reads | the whole stream | the snapshot + the daemon's lag | the snapshot only |
+| Cached entry is | a baseline; newer events are folded onto it | a baseline; newer events are folded onto it | usable only on an **exact** version match |
+| Written to the cache | as soon as the fetch completes | as soon as the fetch completes | only **after a successful commit** |
+| A hit removes | reading and folding the events below the baseline | the snapshot load | the snapshot load |
 
-The asymmetry is not an implementation accident. An Inline snapshot is written in the same transaction as
-the events, so it is always exactly at the stream head and there is no delta query to reconcile a stale
-entry with. And under Inline the projection applies the caller's appended events to the very instance
-`FetchForWriting` handed out, during `SaveChangesAsync` — so an entry written at fetch time would describe
-state that is durable only if that commit happens to succeed. Deferring the write to after the commit
-removes the hazard rather than mitigating it: a rolled-back commit simply leaves no entry, and the next
-fetch reloads from the database.
+The Inline asymmetry is not an implementation accident. An Inline snapshot is written in the same
+transaction as the events, so it is always exactly at the stream head and there is no delta query to
+reconcile a stale entry with. And under Inline the projection applies the caller's appended events to the
+very instance `FetchForWriting` handed out, during `SaveChangesAsync` — so an entry written at fetch time
+would describe state that is durable only if that commit happens to succeed. Deferring the write to after
+the commit removes the hazard rather than mitigating it: a rolled-back commit simply leaves no entry, and
+the next fetch reloads from the database.
+
+### What the cache removes under Live
+
+Live is the lifecycle with the most to gain and the least machinery, because there is no stored snapshot
+in the first place: uncached, every `FetchForWriting` replays the entire stream and folds it from scratch.
+A hit turns that into the same delta query the Async plan issues, with the baseline coming from memory
+instead of from a document table — so the events the baseline already accounts for are neither read nor
+folded.
+
+This is the shape a chain of cascading commands over one stream hits, where each hop is its own message,
+session and transaction and therefore fetches the same stream again. The
+`marten.fetch_for_writing.events_replayed` histogram measures it directly here, unlike under Inline:
+tagged `fetch.plan = Live`, it drops from the full stream length to the size of the delta.
+
+One case is specific to Live. An archived stream's events are filtered out of the event query, so an
+uncached fetch answers `null` where a cached entry still holds the aggregate. Marten reads `is_archived`
+alongside the stream version and discards the entry rather than resurrecting it, so a cache hit and a cold
+fetch agree.
 
 ### What the cache actually removes under Inline
 

--- a/src/EventSourcingTests/FetchForWriting/caching_live_aggregates_for_writing.cs
+++ b/src/EventSourcingTests/FetchForWriting/caching_live_aggregates_for_writing.cs
@@ -133,6 +133,46 @@ public class caching_live_aggregates_for_writing: OneOffConfigurationsContext
     }
 
     [Fact]
+    public async Task fetch_latest_in_the_same_session_does_not_poison_the_entry()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        // Seed the cache
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        // FetchForWriting -> append -> FetchLatest is the aggregate handler workflow's shape. Its item map
+        // optimization folds the appended events onto the very instance the fetch handed out, and for an
+        // aggregate that applies events in place -- which SimpleAggregate does, like most class aggregates
+        // -- that instance is the one an entry stored at fetch time would still be pointing at. Left alone,
+        // the entry would then claim a version below the state it actually holds, and the next fetch would
+        // fold the same events onto it a second time.
+        await using (var writer = theStore.LightweightSession())
+        {
+            var stream = await writer.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.AppendOne(new AEvent());
+
+            var latest = await writer.Events.FetchLatest<SimpleAggregate>(streamId);
+            latest.ACount.ShouldBe(4);
+
+            await writer.SaveChangesAsync();
+        }
+
+        await using var session = theStore.LightweightSession();
+        var reread = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        var expected = await session.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+        reread.CurrentVersion.ShouldBe(4);
+        reread.Aggregate.ACount.ShouldBe(expected.ACount);
+    }
+
+    [Fact]
     public async Task stale_cache_entry_still_yields_the_correct_aggregate()
     {
         UseCachedLiveAggregates();

--- a/src/EventSourcingTests/FetchForWriting/caching_live_aggregates_for_writing.cs
+++ b/src/EventSourcingTests/FetchForWriting/caching_live_aggregates_for_writing.cs
@@ -1,0 +1,350 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
+using JasperFx.Events;
+using Marten;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.FetchForWriting;
+
+/// <summary>
+///     Covers the opt in aggregate snapshot cache for FetchForWriting against Live aggregates — the
+///     lifecycle the cache was proposed for, because it is the one with no stored snapshot to start from.
+///     Uncached, every fetch replays the whole stream; cached, the entry is the baseline and only the events
+///     after it are read.
+/// </summary>
+/// <remarks>
+///     The load bearing claim is the same as for the other two lifecycles: the entry is only ever a
+///     baseline. The stream version and every event after the cached version still come from the database,
+///     so a stale or outright wrong entry degrades to a bigger delta query rather than a wrong aggregate.
+/// </remarks>
+public class caching_live_aggregates_for_writing: OneOffConfigurationsContext
+{
+    private readonly MartenTestAggregateWriteCache theCache = new();
+
+    private void UseCachedLiveAggregates()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.LiveStreamAggregation<SimpleAggregate>();
+            opts.Events.AggregateWriteCaching.Cache = theCache;
+            opts.Events.CacheAggregatesForWriting<SimpleAggregate>();
+        });
+    }
+
+    [Fact]
+    public async Task cold_fetch_matches_the_uncached_aggregate_and_seeds_the_cache()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent(), new BEvent(),
+            new BEvent(), new CEvent(), new CEvent());
+        await theSession.SaveChangesAsync();
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        theCache.Hits.ShouldBe(0);
+        theCache.Misses.ShouldBe(1);
+
+        stream.CurrentVersion.ShouldBe(6);
+
+        // Cross check against an independent live replay of the same stream
+        var expected = await session.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+        stream.Aggregate.ACount.ShouldBe(expected.ACount);
+        stream.Aggregate.BCount.ShouldBe(expected.BCount);
+        stream.Aggregate.CCount.ShouldBe(expected.CCount);
+        stream.Aggregate.Id.ShouldBe(streamId);
+
+        // ... and the fetch left a snapshot behind at the stream version
+        var (_, version) = theCache.SingleEntry();
+        version.ShouldBe(6);
+    }
+
+    [Fact]
+    public async Task cache_hit_folds_only_the_delta()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        // Seed the cache
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        // Deliberately poison the cached baseline. If the next fetch replays the whole stream — which is
+        // exactly what the uncached Live plan does — ACount comes back 5. If it folds only events 4 and 5
+        // onto the baseline we handed it, it comes back 102. There is no other way to land on 102.
+        var key = theCache.SingleKey();
+        theCache.Overwrite(key, new SimpleAggregate { Id = streamId, ACount = 100 }, 3);
+
+        await using (var other = theStore.LightweightSession())
+        {
+            other.Events.Append(streamId, new AEvent(), new AEvent());
+            await other.SaveChangesAsync();
+        }
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        theCache.Hits.ShouldBe(1);
+        stream.CurrentVersion.ShouldBe(5);
+        stream.Aggregate.ACount.ShouldBe(102);
+
+        // and the poisoned-but-now-folded snapshot is written back at the real stream version
+        var (aggregate, version) = theCache.SingleEntry();
+        version.ShouldBe(5);
+        ((SimpleAggregate)aggregate).ACount.ShouldBe(102);
+    }
+
+    [Fact]
+    public async Task cache_hit_with_no_new_events_returns_the_baseline_unchanged()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent(), new CEvent());
+        await theSession.SaveChangesAsync();
+
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        // The empty-delta case is the one a chain of cascading commands over one stream actually hits, so
+        // it needs to be right rather than merely fast.
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        theCache.Hits.ShouldBe(1);
+        stream.CurrentVersion.ShouldBe(3);
+        stream.Aggregate.ACount.ShouldBe(1);
+        stream.Aggregate.BCount.ShouldBe(1);
+        stream.Aggregate.CCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task stale_cache_entry_still_yields_the_correct_aggregate()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        // The cache is now three versions behind
+        await using (var other = theStore.LightweightSession())
+        {
+            other.Events.Append(streamId, new BEvent(), new BEvent(), new CEvent());
+            await other.SaveChangesAsync();
+        }
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        theCache.Hits.ShouldBe(1);
+        stream.CurrentVersion.ShouldBe(6);
+
+        var expected = await session.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+        stream.Aggregate.ACount.ShouldBe(expected.ACount);
+        stream.Aggregate.BCount.ShouldBe(expected.BCount);
+        stream.Aggregate.CCount.ShouldBe(expected.CCount);
+    }
+
+    [Fact]
+    public async Task optimistic_concurrency_still_fires_against_a_warm_cache()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+        theCache.Hits.ShouldBe(1);
+        stream.CurrentVersion.ShouldBe(3);
+        stream.AppendOne(new EEvent());
+
+        // Somebody else gets there first
+        await using (var other = theStore.LightweightSession())
+        {
+            other.Events.Append(streamId, new EEvent());
+            await other.SaveChangesAsync();
+        }
+
+        // The safety net is untouched by the cache: the version handed to AppendToStream came from the
+        // database, never from the entry.
+        await Should.ThrowAsync<EventStreamUnexpectedMaxEventIdException>(async () =>
+        {
+            await session.SaveChangesAsync();
+        });
+    }
+
+    [Fact]
+    public async Task cache_ahead_of_the_database_falls_back_to_the_uncached_path()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        // Pretend the database was restored out from under a cache that had run ahead
+        var key = theCache.SingleKey();
+        theCache.Overwrite(key, new SimpleAggregate { Id = streamId, ACount = 100 }, 99);
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        stream.CurrentVersion.ShouldBe(3);
+        stream.Aggregate.ACount.ShouldBe(3);
+
+        // and the cache healed itself on the same call rather than staying poisoned
+        var (aggregate, version) = theCache.SingleEntry();
+        version.ShouldBe(3);
+        ((SimpleAggregate)aggregate).ACount.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task an_archived_stream_is_not_resurrected_from_the_cache()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        // Archiving is the one case where a Live delta of zero events does not mean "nothing changed": the
+        // events are filtered out, so an uncached fetch answers null where the entry still holds the
+        // aggregate. Without the is_archived check the cache would resurrect it.
+        await using (var archiver = theStore.LightweightSession())
+        {
+            archiver.Events.ArchiveStream(streamId);
+            await archiver.SaveChangesAsync();
+        }
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        theCache.Hits.ShouldBe(1);
+        stream.Aggregate.ShouldBeNull();
+
+        // The uncached retry found nothing to cache, and take-on-read already dropped the stale entry
+        theCache.Keys.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task cached_aggregates_do_not_leak_across_tenants()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Projections.LiveStreamAggregation<SimpleAggregate>();
+            opts.Events.AggregateWriteCaching.Cache = theCache;
+            opts.Events.CacheAggregatesForWriting<SimpleAggregate>();
+        });
+
+        // Same stream id, two tenants, deliberately different shapes
+        var streamId = Guid.NewGuid();
+
+        await using (var one = theStore.LightweightSession("one"))
+        {
+            one.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+            await one.SaveChangesAsync();
+        }
+
+        await using (var two = theStore.LightweightSession("two"))
+        {
+            two.Events.StartStream<SimpleAggregate>(streamId, new BEvent(), new BEvent());
+            await two.SaveChangesAsync();
+        }
+
+        // Cold fetches to seed both tenants
+        await using (var one = theStore.LightweightSession("one"))
+        {
+            var stream = await one.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.Aggregate.ACount.ShouldBe(3);
+            stream.Aggregate.BCount.ShouldBe(0);
+        }
+
+        await using (var two = theStore.LightweightSession("two"))
+        {
+            var stream = await two.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.Aggregate.ACount.ShouldBe(0);
+            stream.Aggregate.BCount.ShouldBe(2);
+        }
+
+        theCache.Keys.Count.ShouldBe(2);
+        theCache.Keys.Select(x => x.TenantId).OrderBy(x => x).ShouldBe(new[] { "one", "two" });
+
+        // Warm fetches must stay in their lane
+        await using (var one = theStore.LightweightSession("one"))
+        {
+            var stream = await one.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.Aggregate.ACount.ShouldBe(3);
+            stream.Aggregate.BCount.ShouldBe(0);
+        }
+
+        await using (var two = theStore.LightweightSession("two"))
+        {
+            var stream = await two.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.Aggregate.ACount.ShouldBe(0);
+            stream.Aggregate.BCount.ShouldBe(2);
+        }
+
+        theCache.Hits.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task caching_is_off_unless_the_aggregate_type_opts_in()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.LiveStreamAggregation<SimpleAggregate>();
+            opts.Events.AggregateWriteCaching.Cache = theCache;
+            // deliberately NOT calling CacheAggregatesForWriting<SimpleAggregate>()
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using var session = theStore.LightweightSession();
+        await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+        await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        theCache.Hits.ShouldBe(0);
+        theCache.Misses.ShouldBe(0);
+        theCache.Keys.ShouldBeEmpty();
+    }
+}

--- a/src/EventSourcingTests/FetchForWriting/caching_live_aggregates_for_writing.cs
+++ b/src/EventSourcingTests/FetchForWriting/caching_live_aggregates_for_writing.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using EventSourcingTests.Aggregation;
+using JasperFx;
 using JasperFx.Events;
 using Marten;
 using Marten.Storage;
@@ -241,6 +242,95 @@ public class caching_live_aggregates_for_writing: OneOffConfigurationsContext
     }
 
     [Fact]
+    public async Task two_writers_on_one_stream_leave_the_cache_in_a_correct_state()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        // Two writers racing for one stream -- a message handler and an HTTP endpoint, say. Take-on-read
+        // means exactly one of them claims the entry and the other takes the uncached path; both read the
+        // true stream version, so both assert against 3 on append.
+        await using var first = theStore.LightweightSession();
+        await using var second = theStore.LightweightSession();
+
+        var firstStream = await first.Events.FetchForWriting<SimpleAggregate>(streamId);
+        var secondStream = await second.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        // Both get a hit, not one: the first writer's store put the entry back before the second fetched.
+        theCache.Hits.ShouldBe(2);
+        theCache.Misses.ShouldBe(1);
+
+        firstStream.AppendOne(new BEvent());
+        secondStream.AppendOne(new CEvent());
+
+        await first.SaveChangesAsync();
+
+        // The loser is refused, exactly as it would be with no cache in play
+        await Should.ThrowAsync<EventStreamUnexpectedMaxEventIdException>(async () =>
+        {
+            await second.SaveChangesAsync();
+        });
+
+        // Both writers stored an entry at the version they read, and the loser's commit never happened --
+        // so whatever is left behind must still agree with a cold replay rather than carry the discarded
+        // event or claim a version it cannot back up.
+        await using var reread = theStore.LightweightSession();
+        var stream = await reread.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        var expected = await reread.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+        stream.CurrentVersion.ShouldBe(4);
+        stream.Aggregate.ACount.ShouldBe(expected.ACount);
+        stream.Aggregate.BCount.ShouldBe(expected.BCount);
+        stream.Aggregate.CCount.ShouldBe(expected.CCount);
+    }
+
+    [Fact]
+    public async Task a_second_fetch_must_not_fold_onto_an_instance_another_session_still_holds()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        // One writer fetches and holds its aggregate for the length of its session, as a handler does.
+        await using var holder = theStore.LightweightSession();
+        var held = await holder.Events.FetchForWriting<SimpleAggregate>(streamId);
+        held.Aggregate.ACount.ShouldBe(3);
+
+        // Meanwhile the stream moves on somewhere else
+        await using (var other = theStore.LightweightSession())
+        {
+            other.Events.Append(streamId, new AEvent());
+            await other.SaveChangesAsync();
+        }
+
+        // A second writer now fetches the same stream and folds its delta. If it was handed the very
+        // instance the first writer is still holding, that fold lands in the first writer's aggregate --
+        // which then reports state it never fetched and never asserted a version against.
+        await using (var second = theStore.LightweightSession())
+        {
+            var stream = await second.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.Aggregate.ACount.ShouldBe(4);
+        }
+
+        held.Aggregate.ACount.ShouldBe(3);
+    }
+
+    [Fact]
     public async Task cache_ahead_of_the_database_falls_back_to_the_uncached_path()
     {
         UseCachedLiveAggregates();
@@ -301,6 +391,84 @@ public class caching_live_aggregates_for_writing: OneOffConfigurationsContext
 
         // The uncached retry found nothing to cache, and take-on-read already dropped the stale entry
         theCache.Keys.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task an_expected_version_below_the_stream_still_throws_against_a_warm_cache()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        await using var session = theStore.LightweightSession();
+
+        // The expected version overload asserts against the version it read from the database, so it has
+        // to refuse a claim of 1 against a stream at 3 whether or not an entry is sitting in the cache.
+        await Should.ThrowAsync<ConcurrencyException>(async () =>
+        {
+            await session.Events.FetchForWriting<SimpleAggregate>(streamId, 1);
+        });
+
+        // ... and it neither consumed nor replaced the entry, because that overload does not cache
+        theCache.Hits.ShouldBe(0);
+        var (_, version) = theCache.SingleEntry();
+        version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task an_expected_version_below_the_stream_still_throws_in_a_batch()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        await using (var warmUp = theStore.LightweightSession())
+        {
+            await warmUp.Events.FetchForWriting<SimpleAggregate>(streamId);
+        }
+
+        await using var session = theStore.LightweightSession();
+
+        // Same assertion down the batched query handler, which composes the stream version statement
+        // itself rather than going through FetchForWriting
+        await Should.ThrowAsync<ConcurrencyException>(async () =>
+        {
+            var batch = session.CreateBatchQuery();
+            var streamQuery = batch.Events.FetchForWriting<SimpleAggregate>(streamId, 1);
+            await batch.Execute();
+            await streamQuery;
+        });
+    }
+
+    [Fact]
+    public async Task a_batched_fetch_for_writing_reads_the_widened_version_statement()
+    {
+        UseCachedLiveAggregates();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent(), new BEvent());
+        await theSession.SaveChangesAsync();
+
+        // The batched handler builds the version statement itself and takes no cache attempt, so it is the
+        // one path that reads is_archived at ordinal 1 with nothing to compare it against.
+        await using var session = theStore.LightweightSession();
+        var batch = session.CreateBatchQuery();
+        var streamQuery = batch.Events.FetchForWriting<SimpleAggregate>(streamId);
+        await batch.Execute();
+        var stream = await streamQuery;
+
+        stream.CurrentVersion.ShouldBe(3);
+        stream.Aggregate.ACount.ShouldBe(1);
+        stream.Aggregate.BCount.ShouldBe(2);
     }
 
     [Fact]

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -1106,10 +1106,16 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     ///     shared with every other Critter Stack store (jasperfx#674).
     ///     </para>
     ///     <para>
-    ///     Supported for both <see cref="ProjectionLifecycle.Async" /> and
-    ///     <see cref="ProjectionLifecycle.Inline" />, but they behave differently:
+    ///     Supported for all three of <see cref="ProjectionLifecycle.Live" />,
+    ///     <see cref="ProjectionLifecycle.Async" /> and <see cref="ProjectionLifecycle.Inline" />, but they
+    ///     behave differently:
     ///     </para>
     ///     <list type="bullet">
+    ///         <item><b>Live</b> — there is no stored snapshot at all, so uncached every fetch replays the
+    ///         whole stream. The cached snapshot is a <i>baseline</i> and only the events after it are read
+    ///         and folded, which makes this the lifecycle with the most to gain. Written as soon as the
+    ///         fetch completes, like Async. An archived stream discards the entry rather than resurrecting
+    ///         it, because its events are filtered out and an uncached fetch would answer null.</item>
     ///         <item><b>Async</b> — the cached snapshot is a <i>baseline</i>. Events after the cached
     ///         version are read and folded onto it, so a stale entry just means a larger delta query. The
     ///         entry is written as soon as the fetch completes, because the daemon (not the session) applies

--- a/src/Marten/Events/EventStore.ConcurrentAppends.cs
+++ b/src/Marten/Events/EventStore.ConcurrentAppends.cs
@@ -15,7 +15,11 @@ internal partial class EventStore
     public void BuildCommandForReadingVersionForStream(bool isGlobal, ICommandBuilder builder, Guid streamId,
         bool forUpdate)
     {
-        builder.Append("select version from ");
+        // is_archived rides along in the same statement because the aggregate write cache needs it: a
+        // cache hit on a stream archived elsewhere would otherwise resurrect the cached aggregate, where
+        // an uncached Live fetch answers null. Every other reader takes the version by ordinal 0 and is
+        // unaffected.
+        builder.Append("select version, is_archived from ");
         builder.Append(_store.Events.DatabaseSchemaName);
         builder.Append('.');
         builder.Append("mt_streams where id = ");
@@ -36,7 +40,11 @@ internal partial class EventStore
     public void BuildCommandForReadingVersionForStream(bool isGlobal, ICommandBuilder builder, string streamKey,
         bool forUpdate)
     {
-        builder.Append("select version from ");
+        // is_archived rides along in the same statement because the aggregate write cache needs it: a
+        // cache hit on a stream archived elsewhere would otherwise resurrect the cached aggregate, where
+        // an uncached Live fetch answers null. Every other reader takes the version by ordinal 0 and is
+        // unaffected.
+        builder.Append("select version, is_archived from ");
         builder.Append(_store.Events.DatabaseSchemaName);
         builder.Append('.');
         builder.Append("mt_streams where id = ");

--- a/src/Marten/Events/Fetching/FetchLivePlan.ForReading.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.ForReading.cs
@@ -25,6 +25,16 @@ internal partial class FetchLivePlan<TDoc, TId>
                 var starting = stream.Aggregate;
                 var appendedEvents = stream.Events;
 
+                // An aggregate that applies events in place -- which most class aggregates do -- is moved
+                // past its stream version by the fold below, and the write cache may be holding that exact
+                // instance filed under the version it was fetched at. Drop the entry rather than leave one
+                // whose version understates the state it points at, which the next fetch would top up with
+                // events it already has.
+                if (appendedEvents.Count > 0)
+                {
+                    _cache?.Evict(cacheKeyFor(session, id));
+                }
+
                 return await _aggregator.BuildAsync(appendedEvents, session, starting, id, _documentStorage, cancellation).ConfigureAwait(false);
             }
         }

--- a/src/Marten/Events/Fetching/FetchLivePlan.ForUpdate.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.ForUpdate.cs
@@ -12,6 +12,8 @@ using Marten.Linq.QueryHandlers;
 using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
+using JasperFx.Events.Fetching;
+using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Events.Fetching;
 
@@ -19,6 +21,22 @@ internal partial class FetchLivePlan<TDoc, TId>
 {
     public async Task<IEventStream<TDoc>> FetchForWriting(DocumentSessionBase session, TId id, bool forUpdate,
         CancellationToken cancellation = default)
+    {
+        try
+        {
+            return await fetchForWriting(session, id, forUpdate, true, cancellation).ConfigureAwait(false);
+        }
+        catch (CachedSnapshotUnusableException)
+        {
+            // Either the entry claimed a higher version than the stream has, or the stream has since been
+            // archived. TryTake already removed it; redo the fetch on the uncached path, which replays the
+            // whole stream and is always correct.
+            return await fetchForWriting(session, id, forUpdate, false, cancellation).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<IEventStream<TDoc>> fetchForWriting(DocumentSessionBase session, TId id, bool forUpdate,
+        bool useCachedSnapshot, CancellationToken cancellation)
     {
         var selector = await _identityStrategy.EnsureEventStorageExists<TDoc>(session, cancellation)
             .ConfigureAwait(false);
@@ -28,12 +46,25 @@ internal partial class FetchLivePlan<TDoc, TId>
             await session.BeginTransactionAsync(cancellation).ConfigureAwait(false);
         }
 
+        var cache = _cache;
+        var cacheKey = cache == null ? default : cacheKeyFor(session, id);
+        object? cachedAggregate = null;
+        var cachedVersion = 0L;
+        var cacheHit = cache != null && useCachedSnapshot &&
+                       cache.TryTake(cacheKey, out cachedAggregate, out cachedVersion);
+
         var builder = new BatchBuilder{TenantId = session.TenantId};
         _identityStrategy.BuildCommandForReadingVersionForStream(IsGlobal, builder, id, forUpdate);
 
         builder.StartNewCommand();
 
-        var handler = _identityStrategy.BuildEventQueryHandler(IsGlobal, id, selector);
+        // The whole cost this cache removes under Live is reading and folding the events the cached
+        // snapshot already accounts for, so a hit narrows the event query to the delta after it. This is
+        // FetchAsyncPlan's strategy with the baseline coming from memory instead of the document table.
+        var handler = cacheHit
+            ? _identityStrategy.BuildEventQueryHandler(IsGlobal, id, selector,
+                new WhereFragment("d.version > ?", cachedVersion))
+            : _identityStrategy.BuildEventQueryHandler(IsGlobal, id, selector);
         handler.ConfigureCommand(builder, session);
 
         try
@@ -41,7 +72,12 @@ internal partial class FetchLivePlan<TDoc, TId>
             await using var reader =
                 await session.ExecuteReaderAsync(builder.Compile(), cancellation).ConfigureAwait(false);
 
-            return await ReadIntoStream(session, id, cancellation, reader, handler).ConfigureAwait(false);
+            return await ReadIntoStream(session, id, cancellation, reader, handler,
+                new CacheAttempt(cache, cacheKey, cacheHit, cachedAggregate, cachedVersion)).ConfigureAwait(false);
+        }
+        catch (CachedSnapshotUnusableException)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -59,25 +95,75 @@ internal partial class FetchLivePlan<TDoc, TId>
         }
     }
 
+    /// <summary>
+    ///     Everything the read side needs to know about a cache attempt. Default value == caching off.
+    /// </summary>
+    private readonly record struct CacheAttempt(
+        IAggregateWriteCache? Cache,
+        AggregateCacheKey Key,
+        bool Hit,
+        object? Aggregate,
+        long Version);
+
+    /// <summary>
+    ///     Signals that a cached snapshot cannot serve as a baseline and the fetch must be redone uncached.
+    ///     Never escapes <see cref="FetchForWriting" />.
+    /// </summary>
+    /// <remarks>
+    ///     Derives from <see cref="MartenException" /> for the same reason as the equivalents in the Async
+    ///     and Inline plans: the assembly-wide convention test does not exempt nested private types, and
+    ///     should not.
+    /// </remarks>
+    private sealed class CachedSnapshotUnusableException: MartenException;
+
     private async Task<IEventStream<TDoc>> ReadIntoStream(DocumentSessionBase session, TId id, CancellationToken cancellation,
-        DbDataReader reader, IQueryHandler<IReadOnlyList<IEvent>> handler)
+        DbDataReader reader, IQueryHandler<IReadOnlyList<IEvent>> handler, CacheAttempt cacheAttempt = default)
     {
         long version = 0;
+        var archived = false;
         try
         {
             if (await reader.ReadAsync(cancellation).ConfigureAwait(false))
             {
                 version = await reader.GetFieldValueAsync<long>(0, cancellation).ConfigureAwait(false);
+                archived = await reader.GetFieldValueAsync<bool>(1, cancellation).ConfigureAwait(false);
+            }
+
+            if (cacheAttempt.Hit && (cacheAttempt.Version > version || archived))
+            {
+                // Either the cache is ahead of the database -- a restore, a rollback, or a key collision
+                // bug -- so the delta could not reconstitute it; or the stream has been archived, and an
+                // uncached fetch would answer null rather than the aggregate this entry still holds.
+                // Nothing here can recover, so drain the batch to leave the connection clean and let
+                // FetchForWriting retry uncached.
+                while (await reader.NextResultAsync(cancellation).ConfigureAwait(false))
+                {
+                }
+
+                throw new CachedSnapshotUnusableException();
             }
 
             await reader.NextResultAsync(cancellation).ConfigureAwait(false);
             var events = await handler.HandleAsync(reader, session, cancellation).ConfigureAwait(false);
             _telemetry.RecordEventsReplayed(events.Count, _aggregateTypeName, OpenTelemetryOptions.LivePlan);
 
-            var document = await _aggregator.BuildAsync(events, session, default, id, _documentStorage, cancellation).ConfigureAwait(false);
+            // On a hit the events read are only the delta after the cached snapshot, so that snapshot is
+            // the baseline the fold starts from. An empty delta returns the baseline unchanged.
+            var document = cacheAttempt.Hit
+                ? await _aggregator.BuildAsync(events, session, (TDoc)cacheAttempt.Aggregate!, id, _documentStorage, cancellation).ConfigureAwait(false)
+                : await _aggregator.BuildAsync(events, session, default, id, _documentStorage, cancellation).ConfigureAwait(false);
             if (document != null)
             {
                 _documentStorage.SetIdentity(document, id);
+            }
+
+            // The aggregate is now at the stream version that came out of the database, which is what the
+            // next fetch measures its delta against. Stored here rather than after the commit because
+            // take-on-read already made this caller the only owner of the instance, and under Live nothing
+            // in the commit applies the caller's new events to it.
+            if (cacheAttempt.Cache != null && document != null && version > 0)
+            {
+                cacheAttempt.Cache.Store(cacheAttempt.Key, document, version);
             }
 
             var stream = version == 0
@@ -91,6 +177,10 @@ internal partial class FetchLivePlan<TDoc, TId>
             }
 
             return stream;
+        }
+        catch (CachedSnapshotUnusableException)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/src/Marten/Events/Fetching/FetchLivePlan.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.cs
@@ -14,6 +14,7 @@ using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
 using System.Diagnostics.CodeAnalysis;
+using JasperFx.Events.Fetching;
 
 namespace Marten.Events.Fetching;
 
@@ -28,6 +29,7 @@ internal partial class FetchLivePlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> 
     private readonly IEventIdentityStrategy<TId> _identityStrategy;
     private readonly OpenTelemetryOptions _telemetry;
     private readonly string _aggregateTypeName = typeof(TDoc).FullNameInCode();
+    private readonly IAggregateWriteCache? _cache;
 
     public FetchLivePlan(EventGraph events, IEventIdentityStrategy<TId> identityStrategy,
         IIdentitySetter<TDoc, TId> documentStorage)
@@ -37,6 +39,14 @@ internal partial class FetchLivePlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> 
         _identityStrategy = identityStrategy;
         _documentStorage = documentStorage;
         _telemetry = events.Options.OpenTelemetry;
+
+        // Resolved once per plan, never per fetch, and left null when nobody enrolled this type -- the
+        // cached path builds an AggregateCacheKey per fetch, which boxes the stream id, and a null check
+        // keeps that allocation off every FetchForWriting in every store that never opted in.
+        if (events.AggregateWriteCaching.IsEnabled(typeof(TDoc)))
+        {
+            _cache = events.AggregateWriteCaching.ResolveCache(typeof(TDoc));
+        }
 
         var raw = events.Options.Projections.AggregatorFor<TDoc>();
 
@@ -59,4 +69,17 @@ internal partial class FetchLivePlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> 
     public bool IsGlobal { get; }
 
     public ProjectionLifecycle Lifecycle => ProjectionLifecycle.Live;
+
+    /// <summary>
+    ///     Composes the cache key for a stream. Getting the tenant or database wrong here would be a
+    ///     cross-tenant data leak rather than a performance bug, so both are always part of the key.
+    /// </summary>
+    private AggregateCacheKey cacheKeyFor(DocumentSessionBase session, TId id)
+    {
+        return new AggregateCacheKey(
+            typeof(TDoc),
+            session.Database.Identifier,
+            IsGlobal ? AggregateCacheKey.GlobalTenant : session.TenantId,
+            id);
+    }
 }

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -68,7 +68,7 @@ namespace Marten.Events
         ///     semantics, which are shared across the Critter Stack.
         ///     </para>
         ///     <para>
-        ///     Supported for both the Async and Inline lifecycles; see
+        ///     Supported for the Live, Async and Inline lifecycles; see
         ///     <see cref="EventGraph.CacheAggregatesForWriting{T}" /> for how they differ.
         ///     </para>
         /// </summary>


### PR DESCRIPTION
Closes the remaining scope of #5225: the aggregate write cache on the `Live` lifecycle.

## Why

The cache that landed in #5256 covers `Async` and `Inline`. `Live` is the lifecycle #5225 was written for — *"Make `FetchForWriting()` cheap … **without forcing the aggregate onto an `Inline` or `Async` snapshot**"* — and it is the one with no stored snapshot to skip, so it was the one with the most to gain. Today `CacheAggregatesForWriting<T>()` on a `Live` aggregate silently does nothing: `FetchLivePlan` has no cache path, so the call compiles, enrols the type, and never produces a hit.

That is also the shape the issue was motivated by. In an application where one business operation is a chain of cascading commands over a single stream — each hop its own message, session and transaction, by design, so each is independently retryable — every hop calls `FetchForWriting` on the same stream and replays the entire stream from scratch.

## What a hit does

The same strategy `FetchAsyncPlan` already uses, with the baseline coming from memory instead of the document table: read the stream version, read only the events after the cached version, fold those onto the cached instance.

`IEventIdentityStrategy<TId>.BuildEventQueryHandler` already takes an optional `ISqlFragment` filter, so the delta needs no new SQL machinery — just `new WhereFragment("d.version > ?", cachedVersion)`.

The version handed to `AppendToStream` still comes from the database on every call, so the optimistic concurrency assertion is untouched and a stale entry costs a larger delta query rather than a wrong aggregate — the load-bearing property from `IAggregateWriteCache`.

## Two things specific to Live

**Archived streams.** Under `Live` a zero-event delta does not mean "nothing changed": `IsNotArchivedFilter` removes an archived stream's events, so an uncached fetch answers `null` where a cached entry still holds the aggregate. Left alone the cache would resurrect it. `BuildCommandForReadingVersionForStream` now reads `is_archived` alongside the version (`select version, is_archived from mt_streams …`) and a hit on an archived stream discards the entry and retries uncached. Every other reader of that statement takes the version by ordinal 0 and is unaffected. This is the eviction the issue anticipated under "Other correctness details".

**`FetchLatest` after an append in the same session.** This one bit me while building it, and it is the more interesting half.

`FetchForWriting` → append → `FetchLatest` is the aggregate-handler workflow's shape, and `FetchForReading`'s item-map optimisation folds the appended events onto the very instance the fetch handed out:

```csharp
var starting = stream.Aggregate;
var appendedEvents = stream.Events;
return await _aggregator.BuildAsync(appendedEvents, session, starting, id, _documentStorage, cancellation);
```

For an aggregate that applies events in place — which most class aggregates do, `SimpleAggregate.Apply(AEvent _) { ACount++; }` included — that moves `starting` past the version the cache entry files it under. `RecentlyUsedAggregateWriteCache.Store` keeps the reference, not a copy, so the entry now understates the state it points at, and the next fetch tops it up with events it already has.

Fixed by **evicting on the fold** rather than deferring the write to after the commit. Deferring (the `Inline` strategy) would be wrong whenever `FetchLatest` was *not* called — the instance stays at the fetched version while the stream moves on — and the two cases are not distinguishable at commit time. Eviction fails safe: the next fetch replays the stream. It is guarded on there being events to fold, so a read-only `FetchLatest` keeps its entry.

## Heads-up: the same hazard exists on the merged Async path

While proving the above I checked whether `Async` has it too, and it does. `FetchAsyncPlan.ForUpdate` stores immediately after the fold, justified in a comment as:

> Under the Async lifecycle any events the caller appends are not applied to this instance in session, so it cannot drift ahead of the database.

But `FetchAsyncPlan.ForReading` performs exactly the same item-map fold onto `stream.Aggregate`. Reproduced with a temporary test against `caching_async_aggregates_for_writing` (not included here): after `FetchForWriting` → `AppendOne` → `FetchLatest` → commit, a re-fetch in a new session returns `ACount` 5 where 4 is correct.

I have deliberately **not** fixed that here. It is released behaviour (9.28+), the fix is the same few lines in `FetchAsyncPlan.ForReading`, and it deserves its own review and possibly its own patch — a PR titled "Live support" quietly changing `Async` correctness would be hard to review. Happy to open it as a separate issue + PR, or to fold it in here if you would rather have both at once. Your call.

## Tests

`caching_live_aggregates_for_writing`, mirroring the Async and Inline suites, plus the two Live-specific cases:

- cold fetch matches an independent live replay and seeds the entry
- a hit folds **only** the delta (the baseline is deliberately poisoned to 100, so the correct answer 102 is unreachable by a full replay)
- a hit with an empty delta returns the baseline unchanged — the case a cascading chain actually hits
- a stale entry still yields the correct aggregate
- optimistic concurrency still fires against a warm cache
- a cache ahead of the database falls back to the uncached path and heals in one round
- an archived stream is not resurrected
- `FetchLatest` in the same session does not poison the entry
- entries do not leak across tenants
- caching is off unless the type opts in

Verified red without the change rather than assumed: removing the delta narrowing fails 4 of them with double-counted state, and removing the eviction fails the `FetchLatest` test.

Full `EventSourcingTests` run: **2003 passed, 7 skipped, 5 failed** — all 5 being `Projections.testing_projections`, which hardcodes `Host=localhost;Port=5432;Username=postgres` and cannot reach a database in my setup. They fail in Weasel's `executeMigration` while opening the connection, so they touch none of this.

Docs updated in `docs/events/optimizing.md`: the lifecycle table is now three columns, with a section on what the cache removes under `Live` and the archived-stream note.
