### PR TITLE
Cover jasperfx#733: constructor-based Create dropped when ShouldDelete is present

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -376,16 +376,36 @@
          that replays one projection over a stream slice or DCB tag match and prints per-event
          before/after state, writing nothing. It is picked up by JasperFx.CommandLine discovery, so
          every Marten host referencing JasperFx.Events gains the command on this bump with no Marten
-         change, which is worth knowing about when it shows up in the CLI help output. -->
-    <PackageVersion Include="JasperFx" Version="2.60.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.60.0" />
+         change, which is worth knowing about when it shows up in the CLI help output.
+
+         JasperFx 2.61.0: jasperfx#733, a source generator fix that only bites self-aggregating
+         snapshots whose "Create" handler is an event-shaped constructor, `public Foo(FooCreated e)`,
+         rather than a named `static Create`. That works on its own. Adding a ShouldDelete method
+         to the same aggregate switched the generator to a different emitter, one that built its
+         dispatch switch from named conventional methods only, so the constructor's event type got no
+         case arm at all. Nothing failed loudly: the constructor never ran, and the next Apply-only
+         event built the aggregate through RuntimeHelpers.GetUninitializedObject, skipping every
+         field initializer. The reporter saw an ApplyEventException wrapping a NullReferenceException
+         out of an Apply that appended to a collection property; the general symptom is a silently
+         blank aggregate. Both documented workarounds (converting the constructor to a static Create,
+         or registering the delete through DeleteEvent&lt;T&gt;() instead of ShouldDelete) become
+         unnecessary on this bump.
+
+         The same omission was in the generated EventTypes property on EVERY self-aggregating path,
+         including the ones whose dispatch was already correct, so an aggregate with a constructor
+         Create and no ShouldDelete also gains its creating event in that list here.
+
+         Covered by Bug_jasperfx_733_event_constructor_create_with_should_delete, which fails on
+         2.60.0 (inline, async and live) and passes on this pin. -->
+    <PackageVersion Include="JasperFx" Version="2.61.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.61.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.60.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.61.0" />
     <!--
       No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
       whole family moves together, and this note is kept for the history below. This package is
@@ -404,11 +424,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.60.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.61.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.60.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.61.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/Bugs/Bug_jasperfx_733_event_constructor_create_with_should_delete.cs
+++ b/src/EventSourcingTests/Bugs/Bug_jasperfx_733_event_constructor_create_with_should_delete.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+/// <summary>
+/// https://github.com/JasperFx/jasperfx/issues/733.
+///
+/// A self-aggregating snapshot may declare its "Create" handler as an event-shaped constructor
+/// (<c>public Foo(FooCreated e)</c>) instead of a named <c>static Create</c>. That works on its own,
+/// but adding a <c>ShouldDelete</c> method to the same aggregate switched the source generator to a
+/// different emitter — one that built its dispatch switch from named conventional methods only. The
+/// constructor's event type got no case arm at all and no diagnostic, so the constructor never ran.
+/// The next Apply-only event then built the aggregate through
+/// <c>RuntimeHelpers.GetUninitializedObject</c>, skipping every field initializer: the reporter saw a
+/// NullReferenceException out of an Apply that appended to a collection property, and in general got
+/// a blank aggregate.
+///
+/// Fixed in JasperFx 2.61.0 by folding event constructors into the DetermineAction emitter's switch
+/// (and into the generated EventTypes, which had the same omission on every self-aggregating path).
+/// </summary>
+public class Bug_jasperfx_733_event_constructor_create_with_should_delete : BugIntegrationContext
+{
+    [Fact]
+    public async Task inline_constructor_create_runs_when_should_delete_is_present()
+    {
+        StoreOptions(opts => opts.Projections.Snapshot<TaggedThing>(SnapshotLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream<TaggedThing>(streamId,
+            new ThingCreated(streamId, "widget"),
+            new TagAdded(streamId, "red"),
+            new TagAdded(streamId, "large"));
+        await theSession.SaveChangesAsync();
+
+        var thing = await theSession.LoadAsync<TaggedThing>(streamId);
+
+        thing.ShouldNotBeNull();
+
+        // Before the fix this was null: the constructor never ran, so nothing assigned Name and the
+        // Tags initializer never executed either.
+        thing.Name.ShouldBe("widget");
+        thing.Tags.ShouldBe(new List<string> { "red", "large" });
+    }
+
+    [Fact]
+    public async Task async_constructor_create_runs_when_should_delete_is_present()
+    {
+        StoreOptions(opts => opts.Projections.Snapshot<TaggedThing>(SnapshotLifecycle.Async));
+
+        using var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream<TaggedThing>(streamId,
+            new ThingCreated(streamId, "widget"),
+            new TagAdded(streamId, "red"));
+        await theSession.SaveChangesAsync();
+
+        await daemon.WaitForNonStaleData(15.Seconds());
+
+        var thing = await theSession.Query<TaggedThing>().FirstOrDefaultAsync(x => x.Id == streamId);
+
+        thing.ShouldNotBeNull();
+        thing.Name.ShouldBe("widget");
+        thing.Tags.ShouldBe(new List<string> { "red" });
+    }
+
+    /// <summary>
+    /// The ShouldDelete arm is the whole reason the broken emitter was selected, so assert it still
+    /// deletes rather than only asserting the newly-restored Create.
+    /// </summary>
+    [Fact]
+    public async Task should_delete_still_deletes_the_snapshot()
+    {
+        StoreOptions(opts => opts.Projections.Snapshot<TaggedThing>(SnapshotLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream<TaggedThing>(streamId,
+            new ThingCreated(streamId, "widget"),
+            new TagAdded(streamId, "red"));
+        await theSession.SaveChangesAsync();
+
+        (await theSession.LoadAsync<TaggedThing>(streamId)).ShouldNotBeNull();
+
+        theSession.Events.Append(streamId, new ThingDeleted(streamId));
+        await theSession.SaveChangesAsync();
+
+        (await theSession.LoadAsync<TaggedThing>(streamId)).ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Live aggregation goes through the same generated evolver, so a stream that opens with the
+    /// constructor event has to fold identically without any snapshot on hand.
+    /// </summary>
+    [Fact]
+    public async Task live_aggregation_uses_the_event_constructor()
+    {
+        StoreOptions(_ => { });
+
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream<TaggedThing>(streamId,
+            new ThingCreated(streamId, "widget"),
+            new TagAdded(streamId, "red"));
+        await theSession.SaveChangesAsync();
+
+        var thing = await theSession.Events.AggregateStreamAsync<TaggedThing>(streamId);
+
+        thing.ShouldNotBeNull();
+        thing.Name.ShouldBe("widget");
+        thing.Tags.ShouldBe(new List<string> { "red" });
+    }
+}
+
+public record ThingCreated(Guid Id, string Name);
+
+public record TagAdded(Guid Id, string Tag);
+
+public record ThingDeleted(Guid Id);
+
+public class TaggedThing
+{
+    // The Create handler is this constructor, NOT a named static Create — that distinction is the
+    // whole bug. Tags is deliberately initialized here rather than in an Apply so that skipping the
+    // constructor shows up as a null collection.
+    public TaggedThing(ThingCreated @event)
+    {
+        Id = @event.Id;
+        Name = @event.Name;
+    }
+
+    // Deliberately private: the generator only emits `new TaggedThing()` for a PUBLIC parameterless
+    // constructor, and falls back to GetUninitializedObject otherwise. Keeping it private preserves
+    // the exact reported symptom (an NRE out of Apply on a null Tags) instead of quietly papering
+    // over it, while still giving System.Text.Json a constructor it can deserialize through.
+    [JsonConstructor]
+    private TaggedThing()
+    {
+    }
+
+    public Guid Id { get; set; }
+    public string Name { get; set; } = "";
+    public List<string> Tags { get; set; } = new();
+
+    public void Apply(TagAdded @event)
+    {
+        Tags.Add(@event.Tag);
+    }
+
+    public bool ShouldDelete(ThingDeleted @event) => true;
+}


### PR DESCRIPTION
Draft: **pinned at JasperFx 2.61.0, which is not published yet.** The fix lives in [JasperFx/jasperfx#733](https://github.com/JasperFx/jasperfx/issues/733) (branch `gh-733/event-ctor-create-with-should-delete`). CI will not go green here until 2.61.0 is on nuget.org.

## The bug

A self-aggregating snapshot may declare its Create handler as an event-shaped constructor, `public Foo(FooCreated e)`, instead of a named `static Create`. That works on its own. Adding a `ShouldDelete` method to the same aggregate switched the source generator to a different emitter — one that built its dispatch switch from named conventional methods only — so the constructor's event type got **no case arm at all**.

Nothing failed loudly. The generated code compiled, the constructor never ran, and the next Apply-only event built the aggregate through `RuntimeHelpers.GetUninitializedObject`, skipping every field initializer. The reporter saw:

```
JasperFx.Events.Daemon.ApplyEventException: Failure to apply event #0 Id(...)
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at TempGuidAggregate.Apply(TagAdded @event)
```

...out of an `Apply` that appended to a collection property. The quieter outcome, where no `Apply` happens to dereference anything, is a silently blank aggregate.

## What is in this PR

- `Bug_jasperfx_733_event_constructor_create_with_should_delete` — the reporter's shape across inline, async and live aggregation, plus the delete arm itself so the fix is not asserted only on the newly restored Create. All four fail on 2.60.0 and pass on 2.61.0.
- The JasperFx pin bump to 2.61.0, with the usual note in `Directory.Packages.props`.

The test aggregate's parameterless constructor is deliberately private and `[JsonConstructor]`-annotated. The generator only emits `new Foo()` for a **public** parameterless constructor and falls back to `GetUninitializedObject` otherwise, so keeping it private preserves the reported NRE instead of papering over it, while still giving System.Text.Json something to deserialize through.

## Upstream fix

Three changes in `EvolverCodeEmitter`, all mirroring what the Evolve emitters already did:

1. `EmitSelfAggregatingDetermineAction`'s event-type set now concats `info.EventConstructors`, and a type whose only Create is a constructor emits `snapshot = new T(data);` under the same `snapshot == null` guard.
2. `EmitSelfAggregatingCreateApplyStatements` takes the constructor too, so an event covered by *both* a constructor and a `ShouldDelete` predicate returning false still folds in the delete arm's `else` — the #652 shape, which had the same gap.
3. `EmitEventTypesProperty` folds constructors in as well. That omission was wider than the reported bug: it dropped the creating event from the generated `EventTypes` on **every** self-aggregating path, including the ones whose dispatch was already correct.

## Verification

Run against a local 2.61.0 prerelease pack of the fix:

- `EventSourcingTests` — 2002 passed, 0 failed, 7 skipped
- `DaemonTests` — 319 passed, 0 failed
- New suite — 4/4 fail on 2.60.0, 4/4 pass on the fix

Both documented workarounds from the issue (convert the constructor to a `static Create`, or register the delete through `DeleteEvent<T>()` instead of `ShouldDelete`) become unnecessary on this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)