### PR TITLE
Report the failing SQL when a batched write fails (9.31.2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.31.1</Version>
+        <Version>9.31.2</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/src/CoreTests/Exceptions/MartenCommandExceptionTests.cs
+++ b/src/CoreTests/Exceptions/MartenCommandExceptionTests.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Threading.Tasks;
 using Marten.Exceptions;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Npgsql;
 using Shouldly;
 using Xunit;
 
@@ -13,5 +17,74 @@ public class MartenCommandExceptionTests
         var createWithNullCommand = () => new MartenCommandException(null, new Exception());
 
         createWithNullCommand.ShouldNotThrow();
+    }
+
+    [Fact]
+    public void command_text_is_recovered_from_a_recorded_batch_when_there_is_no_command()
+    {
+        var batch = new NpgsqlBatch();
+        batch.BatchCommands.Add(new NpgsqlBatchCommand("select 1"));
+        batch.BatchCommands.Add(new NpgsqlBatchCommand("delete from public.mt_doc_target where "));
+
+        var inner = new Exception("boom");
+        inner.RecordNpgsqlBatch(batch);
+
+        var ex = new MartenCommandException(null, inner);
+
+        ex.CommandText.ShouldContain("delete from public.mt_doc_target where");
+        ex.Message.ShouldContain("delete from public.mt_doc_target where");
+    }
+
+    [Fact]
+    public void a_big_batch_is_truncated_rather_than_dumped_in_full()
+    {
+        var batch = new NpgsqlBatch();
+        for (var i = 0; i < 25; i++)
+        {
+            batch.BatchCommands.Add(new NpgsqlBatchCommand($"select {i}"));
+        }
+
+        var inner = new Exception("boom");
+        inner.RecordNpgsqlBatch(batch);
+
+        var ex = new MartenCommandException(null, inner);
+
+        ex.CommandText.ShouldContain("select 0");
+        ex.CommandText.ShouldNotContain("select 24");
+        ex.CommandText.ShouldContain("and 20 more statement(s) in this batch");
+    }
+}
+
+/// <summary>
+///     A batched write that fails on malformed SQL has to report the offending statement.
+///     Before this, ExecuteBatchPagesAsync threw a MartenCommandException whose message rendered an
+///     empty CommandText, so the SQL was unrecoverable from the exception and from logs.
+/// </summary>
+public class batched_command_failures_report_their_sql: OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task malformed_sql_in_a_batch_reports_the_failing_statement()
+    {
+
+        // The exact shape reported in the field: a delete whose where clause rendered to nothing,
+        // which PostgreSQL rejects with 42601 "syntax error at end of input".
+        var badSql = $"delete from {SchemaName}.mt_doc_target where ";
+
+        await using var session = theStore.LightweightSession();
+        session.Store(Target.Random());
+        session.QueueSqlCommand(badSql);
+
+        var ex = await Should.ThrowAsync<MartenCommandException>(async () =>
+            await session.SaveChangesAsync());
+
+        ex.InnerException.ShouldBeOfType<PostgresException>()
+            .SqlState.ShouldBe(PostgresErrorCodes.SyntaxError);
+
+        ex.CommandText.ShouldNotBeNull();
+        ex.CommandText.ShouldContain("mt_doc_target");
+        ex.CommandText.Trim().ShouldEndWith("where");
+
+        // and the same SQL has to be in the message, which is all most users ever see
+        ex.Message.ShouldContain($"delete from {SchemaName}.mt_doc_target where");
     }
 }

--- a/src/Marten/Exceptions/MartenCommandException.cs
+++ b/src/Marten/Exceptions/MartenCommandException.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Npgsql;
 
 namespace Marten.Exceptions;
@@ -13,6 +16,13 @@ public class MartenCommandException: MartenException
         "Postgresql timed out while trying to read data. This may be caused by trying to read locked rows";
 
     /// <summary>
+    ///     The most statements from a failed <see cref="NpgsqlBatch" /> that are written into the exception
+    ///     message when PostgreSQL did not tell us which one it rejected. A single projection page can carry
+    ///     hundreds of operations, and dumping all of them turns one failure into an unreadable log entry.
+    /// </summary>
+    internal const int MaximumRenderedBatchCommands = 5;
+
+    /// <summary>
     ///     Creates MartenCommandException based on the command and innerException information with formatted message.
     /// </summary>
     /// <param name="command">failed Postgres command</param>
@@ -20,6 +30,8 @@ public class MartenCommandException: MartenException
     public MartenCommandException(NpgsqlCommand? command, Exception innerException)
         : base(ToMessage(command, innerException) + innerException.Message, innerException)
     {
+        CommandText = ResolveCommandText(command, innerException);
+
         if (command == null)
             return;
 
@@ -48,6 +60,8 @@ public class MartenCommandException: MartenException
         string? prefix
     ): base(ToMessage(command, innerException, prefix) + innerException.Message, innerException)
     {
+        CommandText = ResolveCommandText(command, innerException);
+
         if (command == null)
             return;
 
@@ -68,6 +82,14 @@ public class MartenCommandException: MartenException
     ///     Failed Postgres command
     /// </summary>
     public NpgsqlCommand? Command { get; }
+
+    /// <summary>
+    ///     The SQL Marten was able to recover for the failed statement. On the batched write path
+    ///     (<c>ExecuteBatchPagesAsync</c>) there is no single <see cref="NpgsqlCommand" /> to report,
+    ///     so this is sourced from the failing <see cref="NpgsqlBatchCommand" /> instead and is the
+    ///     only place the SQL is available. Null only when nothing could be recovered.
+    /// </summary>
+    public string? CommandText { get; }
 
     protected static string ToMessage(
         NpgsqlCommand? command,
@@ -91,6 +113,80 @@ public class MartenCommandException: MartenException
         }
 
         return
-            $"Marten Command Failure:${Environment.NewLine}{prefix}{explanation}{command?.CommandText}${Environment.NewLine}${Environment.NewLine}";
+            $"Marten Command Failure:${Environment.NewLine}{prefix}{explanation}{ResolveCommandText(command, innerException)}${Environment.NewLine}${Environment.NewLine}";
+    }
+
+    /// <summary>
+    ///     Recover the SQL for a failed command. The batched write path used by SaveChangesAsync and by
+    ///     every async projection has no single NpgsqlCommand to hand us, so before this fell back to
+    ///     rendering nothing at all and the SQL was unrecoverable from the exception. Sources, in order:
+    ///     the command itself, the batch statement PostgreSQL actually rejected, and finally the batch
+    ///     that was recorded on the exception by <see cref="MartenExceptionTransformer.WrapAndThrow(NpgsqlBatch, Exception)" />.
+    /// </summary>
+    internal static string? ResolveCommandText(NpgsqlCommand? command, Exception innerException)
+    {
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(command?.CommandText))
+            {
+                return command!.CommandText;
+            }
+
+            // Npgsql hands back the exact statement the server rejected whenever the failure came out
+            // of a batch execution, which makes this the precise answer rather than a guess.
+            if (innerException is NpgsqlException { BatchCommand: not null } npgsql &&
+                !string.IsNullOrWhiteSpace(npgsql.BatchCommand.CommandText))
+            {
+                return npgsql.BatchCommand.CommandText;
+            }
+
+            return DescribeBatch(innerException.ReadNpgsqlBatch());
+        }
+        catch (Exception)
+        {
+            // Building a diagnostic message must never be the thing that throws. Losing the SQL is
+            // bad; replacing the real failure with a formatting error is worse.
+            return null;
+        }
+    }
+
+    private static string? DescribeBatch(NpgsqlBatch? batch)
+    {
+        if (batch == null)
+        {
+            return null;
+        }
+
+        // NpgsqlBatchCommandCollection is not generically enumerable, so index it directly.
+        var texts = new List<string>(batch.BatchCommands.Count);
+        for (var i = 0; i < batch.BatchCommands.Count; i++)
+        {
+            var text = batch.BatchCommands[i].CommandText;
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                texts.Add(text);
+            }
+        }
+
+        if (texts.Count == 0)
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder();
+        foreach (var text in texts.Take(MaximumRenderedBatchCommands))
+        {
+            builder.Append(text.TrimEnd());
+            builder.Append(Environment.NewLine);
+        }
+
+        if (texts.Count > MaximumRenderedBatchCommands)
+        {
+            builder.Append(
+                $"-- and {texts.Count - MaximumRenderedBatchCommands} more statement(s) in this batch");
+            builder.Append(Environment.NewLine);
+        }
+
+        return builder.ToString().TrimEnd();
     }
 }

--- a/src/Marten/Exceptions/MartenExceptionTransformer.cs
+++ b/src/Marten/Exceptions/MartenExceptionTransformer.cs
@@ -47,6 +47,33 @@ internal static class MartenExceptionTransformer
             : null;
     }
 
+    /// <summary>
+    ///     The batch recorded by <see cref="WrapAndThrow(NpgsqlBatch, Exception)" /> or
+    ///     <see cref="RecordNpgsqlBatch" />. On the batched write path there is no single
+    ///     NpgsqlCommand to report, so this is how <see cref="MartenCommandException" /> gets
+    ///     at the SQL.
+    /// </summary>
+    internal static NpgsqlBatch? ReadNpgsqlBatch(this Exception ex)
+    {
+        return ex.Data.Contains(nameof(NpgsqlBatch))
+            ? ex.Data[nameof(NpgsqlBatch)] as NpgsqlBatch
+            : null;
+    }
+
+    /// <summary>
+    ///     Record the batch an exception came out of so the SQL survives all the way to the
+    ///     MartenCommandException message. Call this anywhere a batch is executed without going
+    ///     through <see cref="WrapAndThrow(NpgsqlBatch, Exception)" />. The first writer wins, so
+    ///     an inner frame that knows the exact failing page is not overwritten by an outer one.
+    /// </summary>
+    internal static void RecordNpgsqlBatch(this Exception ex, NpgsqlBatch? batch)
+    {
+        if (batch != null && !ex.Data.Contains(nameof(NpgsqlBatch)))
+        {
+            ex.Data[nameof(NpgsqlBatch)] = batch;
+        }
+    }
+
     internal static void WrapAndThrow(NpgsqlCommand? command, Exception exception)
     {
         if (command != null)

--- a/src/Marten/Internal/Sessions/AutoClosingLifetime.cs
+++ b/src/Marten/Internal/Sessions/AutoClosingLifetime.cs
@@ -245,6 +245,11 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
                     catch (Exception e)
                     {
                         Logger.LogFailure(batch, e);
+
+                        // This lifetime executes the batch itself rather than going through
+                        // handleCommandException, so the batch has to be recorded here or the SQL is
+                        // gone by the time the outer catch builds a MartenCommandException.
+                        e.RecordNpgsqlBatch(batch);
                         throw;
                     }
 


### PR DESCRIPTION
## Problem

A batched write that fails throws a `MartenCommandException` whose message renders an **empty** `CommandText`. Reported from the field on 8.37.0, from an async projection:

```
Marten Command Failure:$ $ $ 42601: syntax error at end of input POSITION: 56
Error trying to build and apply changes to event subscription AlertboardLocationView:All
```

The `$ $ $` is `ToMessage` interpolating `command?.CommandText` where `command` is null. `ReadNpgsqlCommand()` reads `ex.Data["NpgsqlCommand"]`, and on the `ExecuteBatchPagesAsync` path there is no single `NpgsqlCommand` to put there — `AutoClosingLifetime` calls `TransformAndThrow(e)` with nothing recorded at all, and `WrapAndThrow(NpgsqlBatch, ...)` records under a key nothing reads.

So the SQL is unrecoverable from the exception and from the logs — for **every** async projection write, which is exactly where hand-written SQL tends to go wrong. The user in this case could not see which statement was malformed.

## Fix

`MartenCommandException` now recovers the SQL from three sources in order:

1. the `NpgsqlCommand` it was handed;
2. `NpgsqlException.BatchCommand` — Npgsql names the precise statement the server rejected on a batch execution (verified: it is populated for exactly this failure);
3. an `NpgsqlBatch` recorded on the exception.

The recovered text is also exposed as a new `MartenCommandException.CommandText` property.

`AutoClosingLifetime` executes its batches inline rather than through `handleCommandException`, so it records the batch itself. The other three lifetimes (`TransactionalConnection`, `AmbientTransactionLifetime`, `ExternalTransaction`) already route through `WrapAndThrow(NpgsqlBatch, ...)` and only needed the reader.

Two guardrails: a batch renders at most 5 statements so a 500-operation projection page cannot turn one failure into an unreadable log entry, and the whole resolution is wrapped in a `catch` — building a diagnostic must never replace the real failure.

No overload was added to the constructor, deliberately: `new MartenCommandException(null, ex)` appears in the existing tests and an `NpgsqlBatch` overload would make that call ambiguous.

## Verification

- Reproduced the reported failure standalone against PostgreSQL: SQLSTATE 42601, `syntax error at end of input`, POSITION 56.
- The new integration test **fails without the fix** (message comes back as the bare `42601 ... POSITION: nn` with no SQL) and passes with it.
- Full `CoreTests` green, plus `DaemonTests.Bug_4720_adaptive_eventloader_timeout` (the other `MartenCommandException` consumer).

Diagnostics only — no behavioural change to the write path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDX5UV1He5if9vVo8Bdi7g