### PR TITLE
Implement the broadened EventQuery (jasperfx#737) and enroll EventQueryCompliance

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -396,16 +396,26 @@
          Create and no ShouldDelete also gains its creating event in that list here.
 
          Covered by Bug_jasperfx_733_event_constructor_create_with_should_delete, which fails on
-         2.60.0 (inline, async and live) and passes on this pin. -->
-    <PackageVersion Include="JasperFx" Version="2.61.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.61.0" />
+         2.60.0 (inline, async and live) and passes on this pin.
+
+         JasperFx 2.62.0: jasperfx#737 (merged as jasperfx#738) — the broadened cross-stream
+         EventQuery: EventTypeNames (union with the single name via CombinedEventTypeNames),
+         inclusive timestamp and sequence windows, the folded EventTagQuerySpec tag conditions,
+         the sequence-ascending ordering contract, and the AssertFiltersAreSupported guard rail
+         (honor or refuse by name, never silently ignore). Marten's implementation is in
+         QueryEventStore.QueryEventsAsync (marten#5330), and the new EventQueryCompliance suite
+         is enrolled as compliance wave 11. Two compile-breaking fixture seams landed with it:
+         the abstract SetUserName on EventStoreComplianceFixture and
+         ComplianceStoreConfig.EnableUserNameTracking, both closed in MartenComplianceFixture. -->
+    <PackageVersion Include="JasperFx" Version="2.62.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.62.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.61.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.62.0" />
     <!--
       No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
       whole family moves together, and this note is kept for the history below. This package is
@@ -424,11 +434,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.61.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.62.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.61.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.62.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/DocumentDbTests/Metadata/event_diagnostics_metadata_filter_tests.cs
+++ b/src/DocumentDbTests/Metadata/event_diagnostics_metadata_filter_tests.cs
@@ -22,9 +22,11 @@ namespace DocumentDbTests.Metadata;
 /// Each of the three new filters (<see cref="EventQuery.CorrelationId"/>,
 /// <see cref="EventQuery.CausationId"/>, <see cref="EventQuery.UserName"/>) is honored only
 /// when both the option is set AND the event store has the corresponding metadata column
-/// enabled. When set but disabled, the filter is silently skipped — the LINQ member
-/// registration in <c>EventQueryMapping</c> is gated by the same flag, so a Where on a
-/// disabled member would fail to translate at runtime if we didn't skip it here.
+/// enabled. When set but disabled, the query is REFUSED with a <see cref="NotSupportedException"/>
+/// naming the field — the jasperfx#737 guard rail (<see cref="EventQuery.AssertFiltersAreSupported"/>).
+/// Pre-#737 the filter was silently skipped, which returned unfiltered results that read as
+/// filtered; the LINQ member registration in <c>EventQueryMapping</c> is gated by the same
+/// flag, so the disabled column is subtracted from the declared filter set instead.
 ///
 /// Seeding strategy mirrors the doc-filter suite: 8 events, each one appended in its own
 /// session so each carries distinct (CorrelationId / CausationId / UserName) session-scoped
@@ -91,7 +93,7 @@ public class event_diagnostics_metadata_filter_tests
     }
 
     [Fact]
-    public async Task filter_is_silently_ignored_when_correlation_id_column_is_disabled()
+    public async Task filter_is_refused_by_name_when_correlation_id_column_is_disabled()
     {
         const string schema = "diag4791_evt_corr_off";
         using var host = await BuildHost(schema, enableCorr: false, enableCaus: true, enableUser: true);
@@ -100,18 +102,20 @@ public class event_diagnostics_metadata_filter_tests
         var store = host.Services.GetRequiredService<IDocumentStore>();
         var readStore = ((IEventStore)store).OpenReadOnlyEventStore();
 
-        var result = await readStore.QueryEventsAsync(new EventQuery
+        // jasperfx#737: a store that does not capture the column must refuse the filter by name,
+        // never silently return unfiltered results that read as filtered.
+        var ex = await Should.ThrowAsync<NotSupportedException>(() => readStore.QueryEventsAsync(new EventQuery
         {
             PageNumber = 1,
             PageSize = 50,
-            CorrelationId = "c0" // would otherwise narrow to 4 events
-        }, CancellationToken.None);
+            CorrelationId = "c0"
+        }, CancellationToken.None));
 
-        result.TotalCount.ShouldBe(8);
+        ex.Message.ShouldContain(nameof(EventQuery.CorrelationId));
     }
 
     [Fact]
-    public async Task filter_is_silently_ignored_when_causation_id_column_is_disabled()
+    public async Task filter_is_refused_by_name_when_causation_id_column_is_disabled()
     {
         const string schema = "diag4791_evt_caus_off";
         using var host = await BuildHost(schema, enableCorr: true, enableCaus: false, enableUser: true);
@@ -120,18 +124,18 @@ public class event_diagnostics_metadata_filter_tests
         var store = host.Services.GetRequiredService<IDocumentStore>();
         var readStore = ((IEventStore)store).OpenReadOnlyEventStore();
 
-        var result = await readStore.QueryEventsAsync(new EventQuery
+        var ex = await Should.ThrowAsync<NotSupportedException>(() => readStore.QueryEventsAsync(new EventQuery
         {
             PageNumber = 1,
             PageSize = 50,
             CausationId = "u0"
-        }, CancellationToken.None);
+        }, CancellationToken.None));
 
-        result.TotalCount.ShouldBe(8);
+        ex.Message.ShouldContain(nameof(EventQuery.CausationId));
     }
 
     [Fact]
-    public async Task filter_is_silently_ignored_when_user_name_column_is_disabled()
+    public async Task filter_is_refused_by_name_when_user_name_column_is_disabled()
     {
         const string schema = "diag4791_evt_user_off";
         using var host = await BuildHost(schema, enableCorr: true, enableCaus: true, enableUser: false);
@@ -140,18 +144,18 @@ public class event_diagnostics_metadata_filter_tests
         var store = host.Services.GetRequiredService<IDocumentStore>();
         var readStore = ((IEventStore)store).OpenReadOnlyEventStore();
 
-        var result = await readStore.QueryEventsAsync(new EventQuery
+        var ex = await Should.ThrowAsync<NotSupportedException>(() => readStore.QueryEventsAsync(new EventQuery
         {
             PageNumber = 1,
             PageSize = 50,
             UserName = "n0"
-        }, CancellationToken.None);
+        }, CancellationToken.None));
 
-        result.TotalCount.ShouldBe(8);
+        ex.Message.ShouldContain(nameof(EventQuery.UserName));
     }
 
     [Fact]
-    public async Task filter_set_alongside_an_enabled_filter_when_a_column_is_disabled_still_narrows_via_the_enabled_one()
+    public async Task a_disabled_column_filter_alongside_enabled_ones_still_refuses_the_whole_query()
     {
         const string schema = "diag4791_evt_mixed";
         using var host = await BuildHost(schema, enableCorr: true, enableCaus: false, enableUser: true);
@@ -160,22 +164,20 @@ public class event_diagnostics_metadata_filter_tests
         var store = host.Services.GetRequiredService<IDocumentStore>();
         var readStore = ((IEventStore)store).OpenReadOnlyEventStore();
 
-        var result = await readStore.QueryEventsAsync(new EventQuery
+        // Pre-#737 this returned the two events matching the enabled filters while silently
+        // dropping the disabled one — a partially-filtered answer that read as fully filtered.
+        // The guard rail refuses the query outright, naming only the unsupported field.
+        var ex = await Should.ThrowAsync<NotSupportedException>(() => readStore.QueryEventsAsync(new EventQuery
         {
             PageNumber = 1,
             PageSize = 50,
-            CorrelationId = "c0",   // honored — 4 events
-            CausationId = "u0",      // silently ignored — column disabled
-            UserName = "n0"          // honored — narrows to 2
-        }, CancellationToken.None);
+            CorrelationId = "c0",   // supported — the column is captured
+            CausationId = "u0",     // NOT captured — this is the refusal
+            UserName = "n0"         // supported
+        }, CancellationToken.None));
 
-        // corr=c0 (events 0,1,2,3) ∩ user=n0 (events 0,2,4,6) = events 0, 2.
-        result.TotalCount.ShouldBe(2);
-        var returnedIndices = result.Events
-            .Select(e => ((EventMetaPayload)e.Data).Index)
-            .OrderBy(i => i)
-            .ToList();
-        returnedIndices.ShouldBe(new[] { 0, 2 });
+        ex.Message.ShouldContain(nameof(EventQuery.CausationId));
+        ex.Message.ShouldNotContain(nameof(EventQuery.CorrelationId));
     }
 
     [Fact]

--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave11.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave11.cs
@@ -1,0 +1,28 @@
+using JasperFx.Events.ComplianceTests;
+using Marten;
+using Marten.Testing.Harness;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * Wave 11 -- the broadened cross-stream EventQuery surface, shipped in JasperFx 2.62.0
+ * (jasperfx#737, merged as jasperfx#738). Same shape as the earlier enrollment files: an empty
+ * subclass closing the shared suite over Marten's session pair.
+ *
+ * The suite covers every EventQuery filter field (single + multi event type names via
+ * CombinedEventTypeNames, stream id, correlation/causation/user metadata, the inclusive
+ * timestamp and sequence windows, and the folded EventTagQuerySpec tag conditions), the
+ * sequence-ascending ordering contract, and the paging/TotalCount contract -- each fact
+ * asserting exact membership so a silently-dropped filter fails rather than passes.
+ *
+ * Two fixture seams landed with the suite: the abstract SetUserName(TOperations, string?)
+ * (Marten: session.LastModifiedBy) and ComplianceStoreConfig.EnableUserNameTracking (Marten:
+ * Events.MetadataConfig.UserNameEnabled), both in MartenComplianceFixture.
+ *
+ * The EventQuery.TenantId filter is deliberately not exercised here -- it lives with
+ * ConjoinedEventTenancyCompliance (wave 8 enrollment), which gained two EventQuery facts of
+ * its own on the same bump.
+ */
+
+public class event_query_compliance
+    : EventQueryCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;

--- a/src/EventSourcingTests/Dcb/event_query_tag_conditions_hstore_tests.cs
+++ b/src/EventSourcingTests/Dcb/event_query_tag_conditions_hstore_tests.cs
@@ -1,0 +1,143 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Dcb;
+
+/// <summary>
+/// The jasperfx#737 <see cref="EventQuery.TagConditions"/> filter under
+/// <see cref="DcbStorageMode.HStore"/>. The shared EventQueryCompliance suite exercises the
+/// default TagTables translation (a correlated tag-table subquery); this class pins the
+/// hstore-containment branch of the same filter, which no shared suite reaches because the
+/// storage mode is a Marten-only opt-in.
+/// </summary>
+[Collection("OneOffs")]
+public class event_query_tag_conditions_hstore_tests: OneOffConfigurationsContext, IAsyncLifetime
+{
+    private void ConfigureStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.AddEventType<StudentEnrolled>();
+            opts.Events.AddEventType<AssignmentSubmitted>();
+
+            opts.Events.DcbStorageMode = DcbStorageMode.HStore;
+
+            opts.Events.RegisterTagType<StudentId>("student");
+            opts.Events.RegisterTagType<CourseId>("course");
+        });
+    }
+
+    public override ValueTask InitializeAsync()
+    {
+        ConfigureStore();
+        return default;
+    }
+
+    public override ValueTask DisposeAsync() => base.DisposeAsync();
+
+    private Task<PagedEvents> queryAsync(EventQuery query)
+        => ((IReadOnlyEventStore)theSession.Events).QueryEventsAsync(query, CancellationToken.None);
+
+    [Fact]
+    public async Task tag_conditions_filter_by_hstore_containment()
+    {
+        var matching = new StudentId(Guid.NewGuid());
+        var other = new StudentId(Guid.NewGuid());
+
+        var tagged = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        tagged.WithTag(matching);
+        theSession.Events.Append(Guid.NewGuid(), tagged);
+
+        var decoy = theSession.Events.BuildEvent(new StudentEnrolled("Bob", "Math"));
+        decoy.WithTag(other);
+        theSession.Events.Append(Guid.NewGuid(), decoy);
+
+        // And one event carrying no tag at all, so "returned everything" cannot pass.
+        theSession.Events.Append(Guid.NewGuid(), new StudentEnrolled("Carol", "Art"));
+        await theSession.SaveChangesAsync();
+
+        var result = await queryAsync(new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(matching)),
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Data.ShouldBeOfType<StudentEnrolled>().StudentName.ShouldBe("Alice");
+    }
+
+    [Fact]
+    public async Task a_condition_scoped_to_an_event_type_narrows_the_unscoped_match()
+    {
+        var student = new StudentId(Guid.NewGuid());
+
+        var enrolled = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(student);
+        theSession.Events.Append(Guid.NewGuid(), enrolled);
+
+        var submitted = theSession.Events.BuildEvent(new AssignmentSubmitted("HW1", 95));
+        submitted.WithTag(student);
+        theSession.Events.Append(Guid.NewGuid(), submitted);
+        await theSession.SaveChangesAsync();
+
+        var unscoped = await queryAsync(new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(student)),
+            PageSize = 1000
+        });
+        unscoped.TotalCount.ShouldBe(2);
+
+        var scoped = await queryAsync(new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(
+                new EventTagQuery().Or<StudentEnrolled, StudentId>(student)),
+            PageSize = 1000
+        });
+
+        scoped.TotalCount.ShouldBe(1);
+        scoped.Events.Single().Data.ShouldBeOfType<StudentEnrolled>();
+    }
+
+    [Fact]
+    public async Task tag_conditions_and_compose_with_the_other_filters()
+    {
+        var student = new StudentId(Guid.NewGuid());
+
+        var first = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        first.WithTag(student);
+        theSession.Events.Append(Guid.NewGuid(), first);
+
+        var second = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Art"));
+        second.WithTag(student);
+        theSession.Events.Append(Guid.NewGuid(), second);
+        await theSession.SaveChangesAsync();
+
+        var all = await queryAsync(new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(student)),
+            PageSize = 1000
+        });
+        all.TotalCount.ShouldBe(2);
+
+        // The sequence window admits only the second tagged event — proving the tag selection
+        // ANDs with the rest of the query rather than replacing it.
+        var windowed = await queryAsync(new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(student)),
+            SequenceFloor = all.Events[^1].Sequence,
+            PageSize = 1000
+        });
+
+        windowed.TotalCount.ShouldBe(1);
+        windowed.Events.Single().Sequence.ShouldBe(all.Events[^1].Sequence);
+    }
+}

--- a/src/EventSourcingTests/event_query_command_end_to_end.cs
+++ b/src/EventSourcingTests/event_query_command_end_to_end.cs
@@ -1,0 +1,179 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events.CommandLine;
+using Marten;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+#region test events
+
+public record CliCargoLoaded(string Cargo);
+
+public record CliCargoInspected(string Inspector);
+
+#endregion
+
+/// <summary>
+/// End-to-end coverage for the <c>event-query</c> CLI command (jasperfx#737 / JasperFx 2.62.0)
+/// against a real Marten store — upstream carries only input-mapping unit tests, and nothing else
+/// executes the command against a store. Drives <see cref="EventQueryCommand.Execute"/> directly
+/// with a real <see cref="EventQueryInput"/> whose <c>HostBuilder</c> wires Marten at the test
+/// database, exactly the way JasperFx.CommandLine hands the command an application host; stdout
+/// is captured and the default JSON report parsed, so the assertion covers the full path an
+/// operator or agent consumes: flags → EventQuery → QueryEventsAsync → JSON on stdout.
+/// </summary>
+public class event_query_command_end_to_end
+{
+    private static IHostBuilder martenHostBuilder(string schemaName, bool enableUserName = false)
+    {
+        return Host.CreateDefaultBuilder()
+            .ConfigureServices(services => services.AddMarten(opts =>
+            {
+                opts.Connection(ConnectionSource.ConnectionString);
+                opts.DatabaseSchemaName = schemaName;
+                opts.AutoCreateSchemaObjects = AutoCreate.All;
+                opts.DisableNpgsqlLogging = true;
+
+                opts.Events.AddEventType<CliCargoLoaded>();
+                opts.Events.AddEventType<CliCargoInspected>();
+
+                if (enableUserName)
+                {
+                    opts.Events.MetadataConfig.UserNameEnabled = true;
+                }
+            }));
+    }
+
+    /// <summary>
+    /// Runs the command against a fresh host the same way the CLI does — the command builds and
+    /// disposes the host itself — capturing everything it writes to stdout.
+    /// </summary>
+    private static async Task<(bool Success, JsonDocument Report)> executeAsync(EventQueryInput input)
+    {
+        var original = Console.Out;
+        var console = new StringWriter();
+        Console.SetOut(console);
+
+        bool success;
+        try
+        {
+            success = await new EventQueryCommand().Execute(input);
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        var output = console.ToString();
+
+        // The report is the only JSON object on stdout; anchor on its first brace so an incidental
+        // plain-text line from the host bootstrap cannot break the parse.
+        var start = output.IndexOf('{');
+        start.ShouldBeGreaterThanOrEqualTo(0, $"expected a JSON report on stdout, but got: {output}");
+
+        return (success, JsonDocument.Parse(output[start..]));
+    }
+
+    [Fact]
+    public async Task queries_a_real_store_with_an_event_type_filter_and_page_size()
+    {
+        const string schema = "event_query_cli_e2e";
+
+        // Seed through an ordinary Marten host: two Loaded events on separate streams with an
+        // Inspected decoy between them, so the type filter has something to demonstrably exclude
+        // and the ascending ordering shows across streams.
+        string loadedTypeName;
+        using (var host = martenHostBuilder(schema).Build())
+        {
+            var store = host.Services.GetRequiredService<IDocumentStore>();
+            await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+            loadedTypeName = ((DocumentStore)store).Options.EventGraph
+                .EventMappingFor(typeof(CliCargoLoaded)).EventTypeName;
+
+            await using var session = store.LightweightSession();
+            session.Events.Append(Guid.NewGuid(), new CliCargoLoaded("grain"));
+            session.Events.Append(Guid.NewGuid(), new CliCargoInspected("alice"));
+            session.Events.Append(Guid.NewGuid(), new CliCargoLoaded("coal"));
+            await session.SaveChangesAsync();
+        }
+
+        var (success, report) = await executeAsync(new EventQueryInput
+        {
+            HostBuilder = martenHostBuilder(schema),
+            EventTypeFlag = loadedTypeName,
+            PageSizeFlag = 10
+        });
+
+        success.ShouldBeTrue();
+
+        var root = report.RootElement;
+
+        // The report serializes with WhenWritingNull, so a successful run has no error member at all.
+        root.TryGetProperty("error", out _).ShouldBeFalse();
+        root.GetProperty("totalCount").GetInt32().ShouldBe(2);
+        root.GetProperty("pageNumber").GetInt32().ShouldBe(1);
+        root.GetProperty("pageSize").GetInt32().ShouldBe(10);
+        root.GetProperty("hasMore").GetBoolean().ShouldBeFalse();
+        // Uri.ToString() adds the trailing slash to the marten://main subject.
+        root.GetProperty("store").GetString().ShouldBe("marten://main/");
+
+        var events = root.GetProperty("events").EnumerateArray().ToList();
+        events.Count.ShouldBe(2);
+
+        // Exactly the two Loaded events, payloads included, in sequence-ascending order — the
+        // Inspected decoy filtered out.
+        events.ShouldAllBe(e => e.GetProperty("eventType").GetString() == loadedTypeName);
+        events.Select(e => e.GetProperty("data").GetProperty("Cargo").GetString())
+            .ShouldBe(["grain", "coal"]);
+        events[0].GetProperty("sequence").GetInt64()
+            .ShouldBeLessThan(events[1].GetProperty("sequence").GetInt64());
+    }
+
+    /// <summary>
+    /// The honesty path, end to end: a filter on a metadata column this store does not capture is
+    /// refused by name with a failing return — never an unfiltered answer that reads as filtered.
+    /// The same JSON report shape carries the error, so a script parses one shape either way.
+    /// </summary>
+    [Fact]
+    public async Task refuses_an_unsupported_filter_by_name_with_a_failing_return()
+    {
+        const string schema = "event_query_cli_refuse";
+
+        using (var host = martenHostBuilder(schema).Build())
+        {
+            var store = host.Services.GetRequiredService<IDocumentStore>();
+            await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+            await using var session = store.LightweightSession();
+            session.Events.Append(Guid.NewGuid(), new CliCargoLoaded("grain"));
+            await session.SaveChangesAsync();
+        }
+
+        // user_name capture is NOT enabled on this host, so the jasperfx#737 guard rail refuses
+        // the filter rather than silently returning the seeded event.
+        var (success, report) = await executeAsync(new EventQueryInput
+        {
+            HostBuilder = martenHostBuilder(schema),
+            UserNameFlag = "helen"
+        });
+
+        success.ShouldBeFalse();
+
+        var root = report.RootElement;
+        root.GetProperty("error").GetString().ShouldNotBeNull();
+        root.GetProperty("error").GetString()!.ShouldContain("UserName");
+        root.GetProperty("totalCount").GetInt32().ShouldBe(0);
+        root.GetProperty("events").GetArrayLength().ShouldBe(0);
+    }
+}

--- a/src/Marten.Testing/Harness/MartenComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenComplianceFixture.cs
@@ -50,6 +50,14 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
             options.Events.MetadataConfig.CausationIdEnabled = true;
         }
 
+        // Opt-in exactly like correlation tracking above -- the user_name column is only
+        // captured (and only queryable) when the store enables it. Added for the jasperfx#737
+        // EventQueryCompliance suite's user-name filter facts.
+        if (config.EnableUserNameTracking)
+        {
+            options.Events.MetadataConfig.UserNameEnabled = true;
+        }
+
         if (config.EnableHeaders)
         {
             options.Events.MetadataConfig.HeadersEnabled = true;
@@ -114,6 +122,12 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
 
     public override void SetCorrelationId(IDocumentOperations session, string? correlationId)
         => ((IQuerySession)session).CorrelationId = correlationId;
+
+    // Same seam shape as SetCorrelationId: Marten hangs the user-name metadata off the session
+    // as LastModifiedBy, which stamps the user_name column on appended events when
+    // MetadataConfig.UserNameEnabled is on (see ComplianceStoreConfig.EnableUserNameTracking).
+    public override void SetUserName(IDocumentOperations session, string? userName)
+        => ((IDocumentSession)session).LastModifiedBy = userName;
 
     public override IEventStore EventStore => _store;
 

--- a/src/Marten/Events/QueryEventStore.cs
+++ b/src/Marten/Events/QueryEventStore.cs
@@ -6,7 +6,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Marten.Events.Dcb;
 using Marten.Events.Querying;
+using Marten.Linq.MatchesSql;
 using Marten.Internal.Sessions;
 using Marten.Internal.Storage;
 using Marten.Linq;
@@ -246,6 +249,36 @@ internal class QueryEventStore: IQueryEventStore, IReadOnlyEventStore
 
     public async Task<PagedEvents> QueryEventsAsync(EventQuery query, CancellationToken token = default)
     {
+        // jasperfx#737 guard rail, first thing: declare exactly what this store honors, so a query
+        // carrying anything else is refused with a NotSupportedException naming the field rather
+        // than silently ignored (unfiltered results would read as filtered).
+        //
+        // Marten honors every EventQuery filter, with one honesty carve-out: the metadata filters
+        // (correlation_id, causation_id, user_name) are only queryable when the store actually
+        // captures the corresponding column — the LINQ member registration in EventQueryMapping is
+        // itself gated by the Metadata.X.Enabled flag (see EventQueryMapping.cs), so a Where on a
+        // disabled member would fail to translate. Pre-#737 this method silently skipped those
+        // filters; now the disabled column is subtracted from the declared set so the assert
+        // refuses the filter by name instead.
+        var eventMetadata = _store.Events.Metadata;
+        var supportedFilters = EventQueryFilters.All;
+        if (!eventMetadata.CorrelationId.Enabled)
+        {
+            supportedFilters &= ~EventQueryFilters.CorrelationId;
+        }
+
+        if (!eventMetadata.CausationId.Enabled)
+        {
+            supportedFilters &= ~EventQueryFilters.CausationId;
+        }
+
+        if (!eventMetadata.UserName.Enabled)
+        {
+            supportedFilters &= ~EventQueryFilters.UserName;
+        }
+
+        query.AssertFiltersAreSupported(supportedFilters);
+
         await _tenant.Database.EnsureStorageExistsAsync(typeof(IEvent), token).ConfigureAwait(false);
 
         var queryable = QueryAllRawEvents();
@@ -263,9 +296,18 @@ internal class QueryEventStore: IQueryEventStore, IReadOnlyEventStore
             queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.TenantIsOneOf(query.TenantId));
         }
 
-        if (query.EventTypeName != null)
+        // jasperfx#737: EventTypeName and EventTypeNames are one filter with two spellings — the
+        // union semantics live upstream in CombinedEventTypeNames() so all three stores agree.
+        var eventTypeNames = query.CombinedEventTypeNames();
+        if (eventTypeNames.Count == 1)
         {
-            queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.EventTypeName == query.EventTypeName);
+            var single = eventTypeNames[0];
+            queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.EventTypeName == single);
+        }
+        else if (eventTypeNames.Count > 1)
+        {
+            var names = eventTypeNames.ToArray();
+            queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.EventTypeName.IsOneOf(names));
         }
 
         if (query.StreamId != null)
@@ -280,28 +322,58 @@ internal class QueryEventStore: IQueryEventStore, IReadOnlyEventStore
             }
         }
 
-        // #4791 / CritterWatch #629: exact-match filters on the event's metadata columns
-        // (correlation_id, causation_id, user_name). A filter is honored only when both the
-        // EventQuery option is set AND the event store has the corresponding metadata column
-        // enabled — the LINQ member registration in EventQueryMapping is itself gated by the
-        // Metadata.X.Enabled flag (see EventQueryMapping.cs:46-59), so a Where on a disabled
-        // member would fail to translate. We mirror that gate here to silently skip the filter
-        // (per the JasperFx EventQuery contract: "Only honored when the store advertises and
-        // captures the metadata column").
-        var eventMetadata = _store.Events.Metadata;
-        if (query.CorrelationId != null && eventMetadata.CorrelationId.Enabled)
+        // #4791 / CritterWatch #629: exact-match filters on the event's metadata columns. The
+        // AssertFiltersAreSupported call above already refused any of these whose column is not
+        // captured, so reaching here means the member is registered and translates.
+        if (query.CorrelationId != null)
         {
             queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.CorrelationId == query.CorrelationId);
         }
 
-        if (query.CausationId != null && eventMetadata.CausationId.Enabled)
+        if (query.CausationId != null)
         {
             queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.CausationId == query.CausationId);
         }
 
-        if (query.UserName != null && eventMetadata.UserName.Enabled)
+        if (query.UserName != null)
         {
             queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.UserName == query.UserName);
+        }
+
+        // jasperfx#737: inclusive timestamp window on the server-assigned timestamp. An inverted
+        // window needs no special case — the AND of the two bounds already matches nothing.
+        if (query.TimestampFrom != null)
+        {
+            var from = query.TimestampFrom.Value;
+            queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.Timestamp >= from);
+        }
+
+        if (query.TimestampTo != null)
+        {
+            var to = query.TimestampTo.Value;
+            queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.Timestamp <= to);
+        }
+
+        // jasperfx#737: inclusive sequence window on the store-global sequence, same shape.
+        if (query.SequenceFloor != null)
+        {
+            var floor = query.SequenceFloor.Value;
+            queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.Sequence >= floor);
+        }
+
+        if (query.SequenceCeiling != null)
+        {
+            var ceiling = query.SequenceCeiling.Value;
+            queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.Sequence <= ceiling);
+        }
+
+        // jasperfx#737: the folded DCB tag conditions. The spec's OR'd conditions select events,
+        // and that selection ANDs into everything above via a raw SQL fragment that mirrors the
+        // translation HasTagParser / BuildTagQuerySql use for the same storage modes.
+        if (query.TagConditions != null)
+        {
+            var (tagSql, tagParameters) = buildTagConditionsFilter(query.TagConditions);
+            queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.MatchesSql(tagSql, tagParameters));
         }
 
         var totalCount = await queryable.CountAsync(token).ConfigureAwait(false);
@@ -309,8 +381,10 @@ internal class QueryEventStore: IQueryEventStore, IReadOnlyEventStore
         var pageNumber = query.PageNumber <= 0 ? 1 : query.PageNumber;
         var offset = (pageNumber - 1) * query.PageSize;
 
+        // Sequence-ascending is contract (see IReadOnlyEventStore.QueryEventsAsync), and the paging
+        // walks that ordering.
         var events = await queryable
-            .OrderByDescending(e => e.Sequence)
+            .OrderBy(e => e.Sequence)
             .Skip(offset)
             .Take(query.PageSize)
             .ToListAsync(token)
@@ -323,6 +397,89 @@ internal class QueryEventStore: IQueryEventStore, IReadOnlyEventStore
             PageNumber = pageNumber,
             PageSize = query.PageSize
         };
+    }
+
+    /// <summary>
+    /// Translate the wire-form <see cref="EventTagQuerySpec"/> into a raw SQL fragment over the
+    /// event query's <c>d</c> alias (mt_events), OR'ing the conditions. Each condition takes the
+    /// same per-storage-mode shape as <c>HasTagParser</c>: a correlated tag-table subquery in
+    /// TagTables mode, hstore containment in HStore mode, with an optional <c>d.type</c> predicate
+    /// when the condition is scoped to an event type. IN-subqueries / containment are set
+    /// semantics, so an event matching several conditions still appears once.
+    /// </summary>
+    private (string sql, object[] parameters) buildTagConditionsFilter(EventTagQuerySpec spec)
+    {
+        var events = _store.Events;
+
+        // Resolve the wire descriptors back to CLR types against the registered tag/event graph.
+        var knownTypes = events.TagTypes.Select(x => x.TagType)
+            .Concat(events.AllKnownEventTypes().Select(x => x.EventType));
+        var tagQuery = spec.Resolve(EventTagQuerySpec.ResolverFor(knownTypes));
+
+        var conditions = tagQuery.Conditions;
+        if (conditions.Count == 0)
+        {
+            throw new ArgumentException("EventQuery.TagConditions must carry at least one condition.");
+        }
+
+        var schema = events.DatabaseSchemaName;
+        var isHStore = events.DcbStorageMode == DcbStorageMode.HStore;
+        var isConjoined = events.TenancyStyle == TenancyStyle.Conjoined;
+
+        var sb = new System.Text.StringBuilder();
+        var parameters = new List<object>();
+
+        sb.Append('(');
+        for (var i = 0; i < conditions.Count; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(" or ");
+            }
+
+            var condition = conditions[i];
+            var registration = events.FindTagType(condition.TagType)
+                               ?? throw new InvalidOperationException(
+                                   $"Tag type '{condition.TagType.Name}' is not registered. Call RegisterTagType<{condition.TagType.Name}>() first.");
+
+            sb.Append('(');
+            if (isHStore)
+            {
+                sb.Append("d.tags @> hstore(?, ?)");
+                parameters.Add(registration.TableSuffix);
+                parameters.Add(TagValueStringifier.Stringify(registration.ExtractValue(condition.TagValue)));
+            }
+            else
+            {
+                // Under conjoined tenancy seq_id is not unique across tenants (per-tenant
+                // sequences), so the correlated subquery must also match tenant_id; the outer
+                // event query is already tenant-scoped. Mirrors HasTagParser / #4645.
+                sb.Append("d.seq_id in (select seq_id from ");
+                sb.Append(schema);
+                sb.Append(".mt_event_tag_");
+                sb.Append(registration.TableSuffix);
+                sb.Append(" where value = ?");
+                if (isConjoined)
+                {
+                    sb.Append(" and tenant_id = d.tenant_id");
+                }
+
+                sb.Append(')');
+                parameters.Add(registration.ExtractValue(condition.TagValue));
+            }
+
+            if (condition.EventType != null)
+            {
+                sb.Append(" and d.type = ?");
+                parameters.Add(events.EventMappingFor(condition.EventType).EventTypeName);
+            }
+
+            sb.Append(')');
+        }
+
+        sb.Append(')');
+
+        return (sb.ToString(), parameters.ToArray());
     }
 
     private static JasperFx.Events.StreamState ToJasperFxStreamState(StreamState martenState)


### PR DESCRIPTION
Closes #5330

Downstream of [jasperfx#737](https://github.com/JasperFx/jasperfx/issues/737) (merged as jasperfx#738), riding the published **JasperFx 2.62.0** matched set (`JasperFx` / `JasperFx.Events` / `JasperFx.Events.ComplianceTests` / both source generators bumped together).

## What `QueryEventsAsync` now does

`QueryEventStore.QueryEventsAsync` implements the full broadened `EventQuery` contract:

- **Guard rail first:** `query.AssertFiltersAreSupported(...)` is the first statement, declaring `EventQueryFilters.All` minus any of the three metadata filters (`CorrelationId` / `CausationId` / `UserName`) whose capture column the store has not enabled. The LINQ member for a disabled column is never registered (`EventQueryMapping` gates on the same flag), so those filters genuinely cannot be honored — they are refused by name instead of declared and dropped.
- **Timestamp window** (`TimestampFrom` / `TimestampTo`): inclusive at both ends, `timestamp >= ? / <= ?`. An inverted window needs no special case — the ANDed bounds match nothing: empty page, `TotalCount` 0.
- **Sequence window** (`SequenceFloor` / `SequenceCeiling`): same shape over `seq_id`.
- **Multi-type:** consumes `CombinedEventTypeNames()` so the single/plural union semantics stay upstream; one name is `type = ?`, more translate via `IsOneOf` to `type = ANY(?)`.
- **Tag conditions:** the wire-form `EventTagQuerySpec` resolves back to a live `EventTagQuery` against the registered tag/event graph (`EventTagQuerySpec.ResolverFor`), then translates per storage mode with the same shapes `HasTagParser` / `BuildTagQuerySql` use — TagTables mode: `d.seq_id in (select seq_id from <schema>.mt_event_tag_<suffix> where value = ? [and tenant_id = d.tenant_id under conjoined tenancy, the #4645 correlation])`; HStore mode: `d.tags @> hstore(?, ?)`; either plus `and d.type = ?` for a condition scoped to an event type. Conditions OR together and the whole selection ANDs into the rest of the query via `MatchesSql`. IN-subqueries/containment are set semantics, so an event matching several conditions appears once.
- **Ordering:** flipped from sequence-descending to the contract's **sequence-ascending**, with paging walking that ordering and `TotalCount` reporting matches across all pages.

## ⚠️ Behavior change worth a release note

Filtering on a metadata column the store does not capture used to be **silently ignored** (unfiltered results that read as filtered — the exact failure mode jasperfx#737 refuses). It now throws `NotSupportedException` naming the field. The four DocumentDbTests that pinned the silent skip are rewritten to pin the refusal, including the mixed case where one disabled filter refuses the whole query rather than returning a partially-filtered answer.

## Compliance enrollment

- `EventQueryCompliance` enrolled as wave 11 (`src/EventSourcingTests/Compliance/marten_event_store_compliance_wave11.cs`).
- Both new fixture seams closed in `MartenComplianceFixture`: `SetUserName` → `session.LastModifiedBy`, and `ComplianceStoreConfig.EnableUserNameTracking` → `Events.MetadataConfig.UserNameEnabled` (opt-in, mirroring correlation tracking).
- New `event_query_tag_conditions_hstore_tests` pins the HStore branch of the tag translation, which the shared suite cannot reach (the storage mode is a Marten-only opt-in).

## CLI end-to-end coverage (maintainer-directed)

`event_query_command_end_to_end` (EventSourcingTests) is the first test anywhere to execute the new `event-query` CLI command against a real store — upstream carries only input-mapping unit tests. It drives `EventQueryCommand.Execute` with a real `EventQueryInput` whose `HostBuilder` wires Marten at the test database (the same handoff JasperFx.CommandLine performs), captures stdout, and parses the default JSON report: the happy path asserts exact expected events + payloads, sequence-ascending order, `totalCount` and paging echo through an `--event-type` + `--page-size` run; the honesty path runs `--user-name` against a host not capturing the column and asserts the named refusal with a failing return, carried in the same JSON report shape. 2/2 on net9.0 and net10.0.

## Test results (published 2.62.0)

| Suite | net9.0 | net10.0 |
|---|---|---|
| `EventQueryCompliance` (wave 11) | **41/41** | **41/41** |
| `ConjoinedEventTenancyCompliance` (gained 2 EventQuery facts on this bump) | **10/10** | **10/10** |
| `event_query_tag_conditions_hstore_tests` (new) | 3/3 | — |
| `event_diagnostics_metadata_filter_tests` (rewritten refusal pins) | 14/14 | — |
| `event_store_explorer_tests` | 18/18 | — |
| `read_query_deferred_items` (tenant-partitioned paging) | 2/2 | — |
| All compliance waves together | 372/372 | — |
| `EventSourcingTests.Dcb` | 139 passed / 2 pre-existing skips | — |
| `event_query_command_end_to_end` (new CLI e2e) | 2/2 | 2/2 |

Note for anyone re-running: run the compliance suites one TFM at a time — both TFMs concurrently share the `compliance_event_query` schema and contaminate each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
