### PR TITLE
Resolve `mt_dotnet_type` to a type that hasn't been registered yet

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_XXXX_dotnet_type_disambiguation_requires_registered_mapping.cs
+++ b/src/EventSourcingTests/Bugs/Bug_XXXX_dotnet_type_disambiguation_requires_registered_mapping.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using EventSourcingTests.Bugs.AliasCollisionAlpha;
+using EventSourcingTests.Bugs.AliasCollisionBeta;
+using JasperFx.Events;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Bugs
+{
+    /// <summary>
+    /// Marten derives an event's <c>mt_events.type</c> alias from the CLR type's simple name only, so two event
+    /// types that share a name but live in different namespaces collide on one alias. <c>mt_events.mt_dotnet_type</c>
+    /// exists to disambiguate them on read, and <c>EventDocumentStorage.ResolveAsync</c> does consult it — but only
+    /// via <c>EventGraph.TryGetRegisteredMappingForDotNetTypeName</c>, which is a linear scan over mappings that are
+    /// <em>already registered</em>. It never falls back to <c>TypeForDotNetName</c>.
+    ///
+    /// <para>
+    /// Nothing registers event types up front — not even projections — so the graph is populated lazily by whichever
+    /// code path touches a type first (an append, or a read whose alias lookup misses). A process that has only ever
+    /// touched one side of a collision therefore silently deserializes the other side's rows into the wrong CLR type.
+    /// It is silent whenever the two payloads are JSON-compatible, which same-named events in one domain usually are.
+    /// </para>
+    ///
+    /// <para>
+    /// Because registration is per-process and driven by runtime ordering, the same stored event resolves correctly
+    /// on one node and incorrectly on another, and a node self-heals as soon as it happens to append the missing
+    /// type. Reads never register it, so a read-only node can stay wrong indefinitely.
+    /// </para>
+    /// </summary>
+    public class Bug_XXXX_dotnet_type_disambiguation_requires_registered_mapping: BugIntegrationContext
+    {
+        [Fact]
+        public void dotnet_type_lookup_finds_a_type_that_has_not_been_registered_yet()
+        {
+            var options = new StoreOptions();
+            options.Events.AddEventType<AliasCollisionAlpha.ThingHappened>();
+
+            var beta = typeof(AliasCollisionBeta.ThingHappened);
+            var dotNetTypeName = $"{beta.FullName}, {beta.Assembly.GetName().Name}";
+
+            // This is what EventDocumentStorage.ResolveAsync leans on to correct a colliding alias. It is a scan
+            // over already-registered mappings, so an unregistered type yields null, the wrong mapping stands, and
+            // the bad deserialization below happens with no exception and nothing in the logs.
+            var mapping = options.EventGraph.TryGetRegisteredMappingForDotNetTypeName(dotNetTypeName);
+
+            mapping.ShouldNotBeNull();
+            mapping.DocumentType.ShouldBe(beta);
+        }
+
+        [Fact]
+        public async Task resolves_by_dotnet_type_when_the_colliding_type_is_not_registered()
+        {
+            // Both types are known here, so this store can append either one.
+            var writeStore = SeparateStore(opts =>
+            {
+                opts.Events.AddEventType<AliasCollisionAlpha.ThingHappened>();
+                opts.Events.AddEventType<AliasCollisionBeta.ThingHappened>();
+            });
+
+            await writeStore.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+
+            writeStore.Events.EventMappingFor<AliasCollisionAlpha.ThingHappened>().Alias
+                .ShouldBe(writeStore.Events.EventMappingFor<AliasCollisionBeta.ThingHappened>().Alias);
+
+            var streamId = Guid.NewGuid();
+            await using (var session = writeStore.LightweightSession())
+            {
+                session.Events.StartStream(streamId, new AliasCollisionBeta.ThingHappened(streamId, "beta", 42));
+                await session.SaveChangesAsync();
+            }
+
+            // A second store standing in for a process that has only ever touched the Alpha side — say a node whose
+            // projections reference Alpha and which has not handled a command that appends Beta. The alias resolves
+            // to Alpha, and the mt_dotnet_type correction finds nothing to swap to because Beta was never registered.
+            var readStore = SeparateStore(opts => opts.Events.AddEventType<AliasCollisionAlpha.ThingHappened>());
+
+            await using var query = readStore.QuerySession();
+            var events = await query.Events.FetchStreamAsync(streamId);
+
+            // Pre-fix this is an AliasCollisionAlpha.ThingHappened: the Beta payload deserializes into it cleanly,
+            // dropping Count, with no exception and nothing in the logs.
+            events.Single().Data.ShouldBeOfType<AliasCollisionBeta.ThingHappened>()
+                .Count.ShouldBe(42);
+        }
+    }
+}
+
+namespace EventSourcingTests.Bugs.AliasCollisionAlpha
+{
+    public record ThingHappened(Guid Id, string Name);
+}
+
+namespace EventSourcingTests.Bugs.AliasCollisionBeta
+{
+    // Deliberately JSON-compatible with the Alpha shape so a wrong-type read fails silently rather than throwing.
+    public record ThingHappened(Guid Id, string Name, int Count);
+}

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -920,7 +920,27 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
 
     internal EventMapping? TryGetRegisteredMappingForDotNetTypeName(string dotnetTypeName)
     {
-        return AllEvents().FirstOrDefault(x => x.DotNetTypeName == dotnetTypeName);
+        var registered = AllEvents().FirstOrDefault(x => x.DotNetTypeName == dotnetTypeName);
+        if (registered != null)
+        {
+            return registered;
+        }
+
+        // Nothing registers event types up front -- not even projections -- so the scan above misses whenever this
+        // process happens not to have touched the type yet. mt_dotnet_type is the unambiguous record of what was
+        // written, so resolve and register it rather than leaving the caller with a colliding alias's mapping and a
+        // silent deserialization into the wrong CLR type. Reads never registered a type before this, so which of two
+        // same-named types won an alias was decided per process by runtime ordering.
+        try
+        {
+            return EventMappingFor(TypeForDotNetName(dotnetTypeName));
+        }
+        catch (UnknownEventTypeException)
+        {
+            // The stored type isn't loadable here -- a genuinely foreign event, or an assembly this process doesn't
+            // reference. Fall back to the alias mapping, which is what the caller did before this resolution existed.
+            return null;
+        }
     }
 
     // Fetch additional event aliases that map to these types


### PR DESCRIPTION
## Problem

Two event types that share a simple name but live in different namespaces collide on a single
`mt_events.type` alias, because Marten derives the alias from `Type.Name` only. `mt_dotnet_type`
exists to disambiguate them on read, and `EventDocumentStorage.Resolve`/`ResolveAsync` does consult
it — but only through `EventGraph.TryGetRegisteredMappingForDotNetTypeName`, which was a linear scan
over mappings that are **already registered**:

Nothing registers event types up front. `StoreOptions.Scan` only registers types matched by an
explicit event-type matcher, `ApplySourceGeneratedManifest` needs a generated manifest, and
**projection registration does not register event types at all**. So, in a store that doesn't call
`AddEventType`, the graph is populated lazily by whichever code path touches a type first — an
append, or a read whose *alias* lookup misses.

A process that has only ever touched one side of a collision therefore gets `null` back from the
lookup above, leaves the wrong mapping in place, and deserializes the other side's rows into the
wrong CLR type. When the two payloads are JSON-compatible — which same-named events in one domain
usually are — this is completely silent: no exception, nothing logged, just an event whose missing
members are defaulted.

## Why it looks intermittent

Registration is per-process and driven by runtime ordering, so the same stored event resolves
correctly on one node and incorrectly on another. A node self-heals as soon as it happens to *append*
the missing type, because appends go through `EventMappingFor(Type)`. Reads never registered
anything, so a read-mostly node (an async daemon that isn't handling the command that writes the
other type) can stay wrong indefinitely — and restarting the projection agent doesn't help, because
the event graph is store-scoped, not agent-scoped.

## Fix

Fall back to `TypeForDotNetName` + `EventMappingFor(Type)` when the scan misses. `EventMappingFor`
self-registers, so the first read of a colliding type also repairs the graph for subsequent reads.

The `catch` preserves the old behavior for a stored type this process genuinely can't load — a
foreign event, or an assembly it doesn't reference — so the caller still falls back to the alias
mapping rather than throwing on read.

`Upcast` targets are unaffected: `EventDocumentStorage` already skips the swap entirely when
`mapping.IsUpcastTarget`, per #4680.

## Behavior change worth a maintainer's eye

`MapEventType` sets no equivalent of `IsUpcastTarget`, which leaves one scenario changed:

| Rename scenario | Before | After |
| --- | --- | --- |
| `MapEventType<Bar>("foo")`, old `Foo` type **deleted** | alias wins — `Foo` is unresolvable | unchanged; `TypeForDotNetName` throws and the `catch` returns null |
| `MapEventType<Bar>("foo")`, old `Foo` type **still in the assembly** | swaps to `Foo` *only if* `Foo` happens to be registered, otherwise alias wins | always swaps to `Foo` |

The ordinary rename (old type removed) is unaffected. The second row is a real change — though note
the existing behavior there is already ordering-dependent, so this makes it consistent rather than
introducing the inconsistency.

Whether "consistently prefer the stored `mt_dotnet_type`" is the right answer, or whether
`MapEventType` should get an `IsUpcastTarget`-style guard the way `Upcast` has, is a call I'd rather
leave to the maintainers.

## Tests

`Bug_XXXX_dotnet_type_disambiguation_requires_registered_mapping`, two facts at different levels:

- `dotnet_type_lookup_finds_a_type_that_has_not_been_registered_yet` — no database. Asserts the
  lookup resolves a type the graph hasn't seen. Fails on `master`, passes with the fix.
- `resolves_by_dotnet_type_when_the_colliding_type_is_not_registered` — end-to-end. A write store
  that knows both colliding types appends the Beta event; a read store that only knows Alpha reads it
  back and, pre-fix, gets an Alpha instance.

The two event types are deliberately JSON-compatible (Beta adds an `int Count`) so that a wrong-type
read fails silently rather than throwing — that's what makes the production failure invisible, so it
belongs in the repro.

## Notes for review

- Also considered, and deliberately **not** included here: `Cache.Fill` is first-wins, so an alias
  collision currently resolves arbitrarily with no warning at bootstrap. An assertion or a startup
  warning for duplicate aliases feels like a separate change.
