### PR TITLE
Implement IQueryable<StreamState> + the CompactedVersion watermark (jasperfx#740), enroll StreamStateQueryCompliance

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -406,16 +406,26 @@
          QueryEventStore.QueryEventsAsync (marten#5330), and the new EventQueryCompliance suite
          is enrolled as compliance wave 11. Two compile-breaking fixture seams landed with it:
          the abstract SetUserName on EventStoreComplianceFixture and
-         ComplianceStoreConfig.EnableUserNameTracking, both closed in MartenComplianceFixture. -->
-    <PackageVersion Include="JasperFx" Version="2.62.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.62.0" />
+         ComplianceStoreConfig.EnableUserNameTracking, both closed in MartenComplianceFixture.
+
+         JasperFx 2.63.0: jasperfx#740 (merged as jasperfx#741) — the streams table as a real
+         IQueryable<StreamState> (IReadOnlyEventStore.QueryStreamStates, abstract so the bump is a
+         deliberate compile break), executed through the shared IDocumentQueryExecutor hook, plus
+         StreamState.CompactedVersion — the stream-compaction watermark that makes the
+         (Version - CompactedVersion) growth measure of the Stream Compaction Policies expressible.
+         Marten's implementation is the dedicated provider in Marten.Events.Querying (marten#5333;
+         see StreamStateQueryable.cs for why it is not the general LINQ engine), the watermark is a
+         new mt_streams compacted_version column written by CompactStreamAsync, and the new
+         StreamStateQueryCompliance suite is enrolled as compliance wave 12. -->
+    <PackageVersion Include="JasperFx" Version="2.63.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.63.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.62.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.63.0" />
     <!--
       No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
       whole family moves together, and this note is kept for the history below. This package is
@@ -434,11 +444,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.62.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.63.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.62.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.63.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/CommandJsonOutput.cs
+++ b/src/EventSourcingTests/CommandJsonOutput.cs
@@ -1,0 +1,50 @@
+#nullable enable
+using System;
+using System.Text;
+using System.Text.Json;
+
+namespace EventSourcingTests;
+
+/// <summary>
+/// Shared stdout-parsing helper for the CLI end-to-end tests (<c>event-query</c> /
+/// <c>stream-query</c>). Console.Out is process-global, so while a test has it redirected an
+/// unrelated test running in parallel can interleave its own writes into the captured text —
+/// anchoring on "first '{' to end of output" then breaks the JSON parse (seen as a 1-in-a-full-run
+/// flake of event_query_command_end_to_end). This extracts the command's report robustly: try each
+/// '{' candidate, parse exactly ONE JSON value there (ignoring whatever follows), and accept the
+/// first object that carries the report signature.
+/// </summary>
+internal static class CommandJsonOutput
+{
+    public static JsonDocument ExtractReport(string consoleOutput)
+    {
+        var bytes = Encoding.UTF8.GetBytes(consoleOutput);
+
+        for (var i = Array.IndexOf(bytes, (byte)'{'); i >= 0; i = Array.IndexOf(bytes, (byte)'{', i + 1))
+        {
+            try
+            {
+                var reader = new Utf8JsonReader(bytes.AsSpan(i));
+                if (JsonDocument.TryParseValue(ref reader, out var document))
+                {
+                    // Both command reports always carry pageSize; a foreign JSON blob from another
+                    // test's output almost certainly does not.
+                    if (document.RootElement.ValueKind == JsonValueKind.Object &&
+                        document.RootElement.TryGetProperty("pageSize", out _))
+                    {
+                        return document;
+                    }
+
+                    document.Dispose();
+                }
+            }
+            catch (JsonException)
+            {
+                // Not a JSON value at this brace — keep scanning.
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Expected a JSON command report on stdout, but could not find one in: {consoleOutput}");
+    }
+}

--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave12.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave12.cs
@@ -1,0 +1,31 @@
+using JasperFx.Events.ComplianceTests;
+using Marten;
+using Marten.Testing.Harness;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * Wave 12 -- the streams table as a real IQueryable<StreamState>, shipped in JasperFx 2.63.0
+ * (jasperfx#740, merged as jasperfx#741). Same shape as the earlier enrollment files: an empty
+ * subclass closing the shared suite over Marten's session pair.
+ *
+ * The suite covers one Where() fact per public get member of StreamState -- including the new
+ * CompactedVersion watermark and the AggregateType == typeof(X) form, which is the Stream
+ * Compaction Policy's selector -- plus the compaction-policy predicate itself
+ * (AggregateType == typeof(X) && Version - CompactedVersion > N && !IsArchived), the stated
+ * OrderBy(Created).ThenBy(Id) ordering with Skip/Take paging, the shared async terminators, and
+ * truthful empty answers.
+ *
+ * Marten's implementation is the dedicated provider in Marten.Events.Querying (see
+ * StreamStateQueryable.cs for why it is not the general LINQ engine), and the watermark is
+ * written by CompactStreamAsync via RecordCompactionWatermarkOperation.
+ *
+ * The tenant-scoped overload (QueryStreamStates(tenantId)) is deliberately not exercised here --
+ * it lives with ConjoinedEventTenancyCompliance (wave 8 enrollment), which gained a fact for it
+ * on the same bump. The refusal shapes the shared suite deliberately cannot pin (an
+ * untranslatable member, a tenant scope on a tenantless store) are pinned in Marten's own
+ * EventSourcingTests/query_stream_states_refusals.cs.
+ */
+
+public class stream_state_query_compliance
+    : StreamStateQueryCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;

--- a/src/EventSourcingTests/event_query_command_end_to_end.cs
+++ b/src/EventSourcingTests/event_query_command_end_to_end.cs
@@ -32,6 +32,7 @@ public record CliCargoInspected(string Inspector);
 /// is captured and the default JSON report parsed, so the assertion covers the full path an
 /// operator or agent consumes: flags → EventQuery → QueryEventsAsync → JSON on stdout.
 /// </summary>
+[Collection("CliCommands")]
 public class event_query_command_end_to_end
 {
     private static IHostBuilder martenHostBuilder(string schemaName, bool enableUserName = false)
@@ -74,14 +75,9 @@ public class event_query_command_end_to_end
             Console.SetOut(original);
         }
 
-        var output = console.ToString();
-
-        // The report is the only JSON object on stdout; anchor on its first brace so an incidental
-        // plain-text line from the host bootstrap cannot break the parse.
-        var start = output.IndexOf('{');
-        start.ShouldBeGreaterThanOrEqualTo(0, $"expected a JSON report on stdout, but got: {output}");
-
-        return (success, JsonDocument.Parse(output[start..]));
+        // Console.Out is process-global, so parallel tests can interleave writes into the capture —
+        // extract the report robustly rather than anchoring on the first brace.
+        return (success, CommandJsonOutput.ExtractReport(console.ToString()));
     }
 
     [Fact]

--- a/src/EventSourcingTests/event_storage_stream_state_selector.cs
+++ b/src/EventSourcingTests/event_storage_stream_state_selector.cs
@@ -68,6 +68,7 @@ public class event_storage_stream_state_selector: IntegrationContext
         actual.LastTimestamp.ShouldBe(expected.LastTimestamp);
         actual.IsArchived.ShouldBe(expected.IsArchived);
         actual.AggregateType.ShouldBe(expected.AggregateType);
+        actual.CompactedVersion.ShouldBe(expected.CompactedVersion);
     }
 
     [Fact]
@@ -88,6 +89,8 @@ public class event_storage_stream_state_selector: IntegrationContext
         sql.ShouldContain("timestamp");
         sql.ShouldContain("created");
         sql.ShouldContain("is_archived");
+        // jasperfx#740: the compaction watermark rides the same SELECT/selector pair.
+        sql.ShouldContain("compacted_version");
         sql.ShouldContain("mt_streams");
         sql.ShouldStartWith("select ");
     }

--- a/src/EventSourcingTests/query_stream_states_refusals.cs
+++ b/src/EventSourcingTests/query_stream_states_refusals.cs
@@ -1,0 +1,154 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
+using JasperFx.Events;
+using JasperFx.Events.Documents;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+/// <summary>
+/// The refusal shapes of <c>IReadOnlyEventStore.QueryStreamStates()</c> (jasperfx#740 /
+/// marten#5333) that the shared <c>StreamStateQueryCompliance</c> suite deliberately cannot pin,
+/// because both current stores translate every <see cref="StreamState"/> member: an expression the
+/// provider cannot translate must FAIL naming the member or operator — never silently match all
+/// rows — and a tenant scope on a store with no tenant dimension must be refused, never answered
+/// with unscoped rows that read as tenant-scoped.
+/// </summary>
+public class query_stream_states_refusals: OneOffConfigurationsContext
+{
+    private IQueryable<StreamState> streams()
+        => ((IReadOnlyEventStore)theSession.Events).QueryStreamStates();
+
+    private async Task<Guid> seedOneStreamAsync()
+    {
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId, new AEvent(), new BEvent());
+        await theSession.SaveChangesAsync();
+        return streamId;
+    }
+
+    [Fact]
+    public void a_tenant_scope_on_a_tenantless_store_is_refused_by_name()
+    {
+        // The default store has no tenant dimension (TenancyStyle.Single), so a tenant-scoped
+        // stream query cannot be honored and must not quietly return every tenant's rows.
+        var ex = Should.Throw<NotSupportedException>(() =>
+            ((IReadOnlyEventStore)theSession.Events).QueryStreamStates("tenant-a"));
+
+        ex.Message.ShouldContain("tenant-a");
+        ex.Message.ShouldContain("tenant");
+    }
+
+    [Fact]
+    public async Task an_untranslatable_member_expression_is_refused_not_silently_matched()
+    {
+        await seedOneStreamAsync();
+
+        // A nested member the provider does not translate. The danger shape is returning ALL rows
+        // as if the predicate had matched — the seeded stream makes that detectable.
+        var query = streams().Where(x => x.Key!.Length > 0);
+
+        var ex = await Should.ThrowAsync<NotSupportedException>(
+            () => DocumentQueryableExtensions.ToListAsync(query, CancellationToken.None));
+
+        ex.Message.ShouldContain("QueryStreamStates");
+    }
+
+    [Fact]
+    public void a_projection_is_refused_at_composition_time()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => streams().Select(x => x.Version));
+
+        ex.Message.ShouldContain("Select");
+    }
+
+    [Fact]
+    public async Task an_unsupported_operator_is_refused_by_name()
+    {
+        var query = streams().Distinct();
+
+        var ex = await Should.ThrowAsync<NotSupportedException>(
+            () => DocumentQueryableExtensions.ToListAsync(query, CancellationToken.None));
+
+        ex.Message.ShouldContain("Distinct");
+    }
+
+    [Fact]
+    public async Task aggregate_type_supports_only_equality_comparison()
+    {
+        var query = streams().OrderBy(x => x.AggregateType);
+
+        var ex = await Should.ThrowAsync<NotSupportedException>(
+            () => DocumentQueryableExtensions.ToListAsync(query, CancellationToken.None));
+
+        ex.Message.ShouldContain(nameof(StreamState.AggregateType));
+    }
+
+    [Fact]
+    public void synchronous_execution_is_refused_with_guidance()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => streams().ToList());
+
+        ex.Message.ShouldContain("ToListAsync");
+    }
+}
+
+/// <summary>
+/// The compaction watermark on a STRING-identified store — the identity branch of
+/// <c>RecordCompactionWatermarkOperation</c> the shared compliance suite does not reach (its
+/// compaction facts run on the Guid-identified store; its string-store fact does not compact).
+/// </summary>
+public class compaction_watermark_on_string_identified_streams: OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task partial_then_full_compaction_move_the_watermark()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Add<LetterCountsByStringProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamKey = Guid.NewGuid().ToString();
+        theSession.Events.StartStream<LetterCountsByString>(streamKey,
+            new AEvent(), new BEvent(), new AEvent(), new CEvent(), new CEvent(),
+            new DEvent(), new DEvent(), new AEvent(), new AEvent());
+        await theSession.SaveChangesAsync();
+
+        // Partial: fold versions 1..5 into the snapshot — the watermark is the cutoff.
+        await theSession.Events.CompactStreamAsync<LetterCountsByString>(streamKey, x => x.Version = 5);
+        await theSession.SaveChangesAsync();
+
+        var partial = await theSession.Events.FetchStreamStateAsync(streamKey);
+        partial.Version.ShouldBe(9);
+        partial.CompactedVersion.ShouldBe(5);
+
+        // And the queryable agrees, including the growth arithmetic the compaction policies use.
+        var streams = ((IReadOnlyEventStore)theSession.Events).QueryStreamStates();
+        var matched = await DocumentQueryableExtensions.ToListAsync(
+            streams.Where(x => x.Key == streamKey && x.Version - x.CompactedVersion > 3),
+            CancellationToken.None);
+        matched.ShouldHaveSingleItem().CompactedVersion.ShouldBe(5);
+
+        // Full: the watermark advances to the stream version, so growth reads zero.
+        await theSession.Events.CompactStreamAsync<LetterCountsByString>(streamKey);
+        await theSession.SaveChangesAsync();
+
+        var full = await theSession.Events.FetchStreamStateAsync(streamKey);
+        full.Version.ShouldBe(9);
+        full.CompactedVersion.ShouldBe(9);
+
+        var grown = await DocumentQueryableExtensions.CountAsync(
+            streams.Where(x => x.Key == streamKey && x.Version - x.CompactedVersion > 0),
+            CancellationToken.None);
+        grown.ShouldBe(0);
+    }
+}

--- a/src/EventSourcingTests/stream_query_command_end_to_end.cs
+++ b/src/EventSourcingTests/stream_query_command_end_to_end.cs
@@ -1,0 +1,231 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.CommandLine;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+#region test events and aggregates
+
+public record CliFreighterLaunched(string Name);
+
+public record CliFreighterDocked(string Port);
+
+public partial class CliQueryFreighter
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Dockings { get; set; }
+
+    public static CliQueryFreighter Create(CliFreighterLaunched e) => new() { Name = e.Name };
+
+    public void Apply(CliFreighterDocked _) => Dockings++;
+}
+
+/// <summary>A second aggregate type over the same events, so the type filter has a decoy.</summary>
+public partial class CliQueryTugboat
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Dockings { get; set; }
+
+    public static CliQueryTugboat Create(CliFreighterLaunched e) => new() { Name = e.Name };
+
+    public void Apply(CliFreighterDocked _) => Dockings++;
+}
+
+#endregion
+
+/// <summary>
+/// End-to-end coverage for the <c>stream-query</c> CLI command (jasperfx#740 / marten#5333)
+/// against a real Marten store — the pattern the <c>event-query</c> wave established: drive
+/// <see cref="StreamQueryCommand.Execute"/> with a real <see cref="StreamQueryInput"/> whose
+/// <c>HostBuilder</c> wires Marten at the test database, capture stdout, parse the default JSON
+/// report, and assert exact expected streams — including the <c>versionsSinceCompaction</c>
+/// growth measure the Stream Compaction Policies threshold on.
+/// </summary>
+[Collection("CliCommands")]
+public class stream_query_command_end_to_end
+{
+    private static IHostBuilder martenHostBuilder(string schemaName)
+    {
+        return Host.CreateDefaultBuilder()
+            .ConfigureServices(services => services.AddMarten(opts =>
+            {
+                opts.Connection(ConnectionSource.ConnectionString);
+                opts.DatabaseSchemaName = schemaName;
+                opts.AutoCreateSchemaObjects = AutoCreate.All;
+                opts.DisableNpgsqlLogging = true;
+
+                opts.Events.AddEventType<CliFreighterLaunched>();
+                opts.Events.AddEventType<CliFreighterDocked>();
+
+                // Inline snapshots register both aggregate types store-side: what lets
+                // CompactStreamAsync find an aggregator, and what StartStream<T> stamps the
+                // stream's aggregate-type identity from.
+                opts.Projections.Snapshot<CliQueryFreighter>(SnapshotLifecycle.Inline);
+                opts.Projections.Snapshot<CliQueryTugboat>(SnapshotLifecycle.Inline);
+            }));
+    }
+
+    private static async Task<(bool Success, JsonDocument Report)> executeAsync(StreamQueryInput input)
+    {
+        var original = Console.Out;
+        var console = new StringWriter();
+        Console.SetOut(console);
+
+        bool success;
+        try
+        {
+            success = await new StreamQueryCommand().Execute(input);
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        return (success, CommandJsonOutput.ExtractReport(console.ToString()));
+    }
+
+    [Fact]
+    public async Task queries_stream_states_with_the_compaction_policy_filters()
+    {
+        const string schema = "stream_query_cli_e2e";
+
+        // Seed through an ordinary Marten host: two freighters — one compacted through version 3
+        // (growth 2), one never compacted (growth 5) — and a tugboat decoy that fails only the
+        // aggregate-type filter.
+        Guid compacted;
+        Guid overgrown;
+        using (var host = martenHostBuilder(schema).Build())
+        {
+            var store = host.Services.GetRequiredService<IDocumentStore>();
+            await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+            await using var session = store.LightweightSession();
+
+            // One save per stream with real wall-clock gaps: mt_streams.created defaults to the
+            // transaction timestamp, so same-save streams tie on Created and fall back to the Id
+            // tiebreak — real creation order needs distinct transactions.
+            compacted = Guid.NewGuid();
+            session.Events.StartStream<CliQueryFreighter>(compacted, new CliFreighterLaunched("Cargolux"),
+                new CliFreighterDocked("Kiel"), new CliFreighterDocked("Aarhus"),
+                new CliFreighterDocked("Gdansk"), new CliFreighterDocked("Riga"));
+            await session.SaveChangesAsync();
+            await Task.Delay(30);
+
+            overgrown = Guid.NewGuid();
+            session.Events.StartStream<CliQueryFreighter>(overgrown, new CliFreighterLaunched("Evergreen"),
+                new CliFreighterDocked("Kiel"), new CliFreighterDocked("Aarhus"),
+                new CliFreighterDocked("Gdansk"), new CliFreighterDocked("Riga"));
+            await session.SaveChangesAsync();
+            await Task.Delay(30);
+
+            session.Events.StartStream<CliQueryTugboat>(Guid.NewGuid(), new CliFreighterLaunched("Pushy"),
+                new CliFreighterDocked("Kiel"), new CliFreighterDocked("Aarhus"),
+                new CliFreighterDocked("Gdansk"), new CliFreighterDocked("Riga"));
+            await session.SaveChangesAsync();
+
+            await session.Events.CompactStreamAsync<CliQueryFreighter>(compacted, x => x.Version = 3);
+            await session.SaveChangesAsync();
+        }
+
+        // Run 1: the type filter alone — both freighters, creation order, exact watermarks.
+        var (success, report) = await executeAsync(new StreamQueryInput
+        {
+            HostBuilder = martenHostBuilder(schema),
+            AggregateTypeFlag = nameof(CliQueryFreighter),
+            PageSizeFlag = 10
+        });
+
+        success.ShouldBeTrue();
+
+        var root = report.RootElement;
+        root.TryGetProperty("error", out _).ShouldBeFalse();
+        root.GetProperty("totalCount").GetInt32().ShouldBe(2);
+
+        var streams = root.GetProperty("streams").EnumerateArray().ToList();
+        streams.Count.ShouldBe(2);
+
+        // Creation order, oldest first — the command's stated ordering.
+        streams.Select(x => x.GetProperty("streamId").GetString())
+            .ShouldBe([compacted.ToString(), overgrown.ToString()]);
+
+        var compactedRow = streams[0];
+        compactedRow.GetProperty("version").GetInt64().ShouldBe(5);
+        compactedRow.GetProperty("compactedVersion").GetInt64().ShouldBe(3);
+        compactedRow.GetProperty("versionsSinceCompaction").GetInt64().ShouldBe(2);
+        compactedRow.GetProperty("aggregateType").GetString().ShouldBe(typeof(CliQueryFreighter).FullName);
+
+        var overgrownRow = streams[1];
+        overgrownRow.GetProperty("version").GetInt64().ShouldBe(5);
+        overgrownRow.GetProperty("compactedVersion").GetInt64().ShouldBe(0);
+        overgrownRow.GetProperty("versionsSinceCompaction").GetInt64().ShouldBe(5);
+
+        // Run 2: the full compaction-policy shape — type AND growth threshold. The compacted
+        // freighter (raw version 5!) is the load-bearing decoy for thresholding on Version
+        // instead of growth; the tugboat for a dropped type filter.
+        var (policySuccess, policyReport) = await executeAsync(new StreamQueryInput
+        {
+            HostBuilder = martenHostBuilder(schema),
+            AggregateTypeFlag = nameof(CliQueryFreighter),
+            VersionAboveCompactedFlag = 3,
+            PageSizeFlag = 10
+        });
+
+        policySuccess.ShouldBeTrue();
+
+        var policyRoot = policyReport.RootElement;
+        policyRoot.GetProperty("totalCount").GetInt32().ShouldBe(1);
+        var match = policyRoot.GetProperty("streams").EnumerateArray().Single();
+        match.GetProperty("streamId").GetString().ShouldBe(overgrown.ToString());
+        match.GetProperty("versionsSinceCompaction").GetInt64().ShouldBe(5);
+    }
+
+    /// <summary>
+    /// The honesty path, end to end: a tenant scope against a store with no tenant dimension is
+    /// refused by name with a failing return — never answered with unscoped rows that read as
+    /// tenant-scoped — and the same JSON report shape carries the error.
+    /// </summary>
+    [Fact]
+    public async Task refuses_a_tenant_scope_on_a_tenantless_store()
+    {
+        const string schema = "stream_query_cli_refuse";
+
+        using (var host = martenHostBuilder(schema).Build())
+        {
+            var store = host.Services.GetRequiredService<IDocumentStore>();
+            await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+            await using var session = store.LightweightSession();
+            session.Events.StartStream<CliQueryFreighter>(Guid.NewGuid(), new CliFreighterLaunched("Solo"));
+            await session.SaveChangesAsync();
+        }
+
+        var (success, report) = await executeAsync(new StreamQueryInput
+        {
+            HostBuilder = martenHostBuilder(schema),
+            TenantFlag = "tenant-a"
+        });
+
+        success.ShouldBeFalse();
+
+        var root = report.RootElement;
+        root.GetProperty("error").GetString().ShouldNotBeNull();
+        root.GetProperty("error").GetString()!.ShouldContain("tenant-a");
+        root.GetProperty("totalCount").GetInt32().ShouldBe(0);
+        root.GetProperty("streams").GetArrayLength().ShouldBe(0);
+    }
+}

--- a/src/Marten/EventStorage/StreamStateSql.cs
+++ b/src/Marten/EventStorage/StreamStateSql.cs
@@ -14,5 +14,5 @@ namespace Marten.EventStorage;
 internal static class StreamStateSql
 {
     public static string Build(EventGraph graph) =>
-        $"select id, version, type, timestamp, created, is_archived from {graph.DatabaseSchemaName}.mt_streams";
+        $"select id, version, type, timestamp, created, is_archived, compacted_version from {graph.DatabaseSchemaName}.mt_streams";
 }

--- a/src/Marten/Events/EventDocumentStorage.cs
+++ b/src/Marten/Events/EventDocumentStorage.cs
@@ -284,6 +284,13 @@ public abstract class EventDocumentStorage: IEventStorage, ILinqDocumentStorage
         state.Created = reader.GetFieldValue<DateTimeOffset>(4);
         state.IsArchived = reader.GetFieldValue<bool>(5);
 
+        // jasperfx#740: the compaction watermark. The column is NOT NULL DEFAULT 0, but guard the
+        // null read anyway for a database mid-migration.
+        if (!reader.IsDBNull(6))
+        {
+            state.CompactedVersion = reader.GetFieldValue<long>(6);
+        }
+
         return state;
     }
 
@@ -313,6 +320,13 @@ public abstract class EventDocumentStorage: IEventStorage, ILinqDocumentStorage
         state.LastTimestamp = await reader.GetFieldValueAsync<DateTimeOffset>(3, token).ConfigureAwait(false);
         state.Created = await reader.GetFieldValueAsync<DateTimeOffset>(4, token).ConfigureAwait(false);
         state.IsArchived = await reader.GetFieldValueAsync<bool>(5, token).ConfigureAwait(false);
+
+        // jasperfx#740: the compaction watermark. The column is NOT NULL DEFAULT 0, but guard the
+        // null read anyway for a database mid-migration.
+        if (!await reader.IsDBNullAsync(6, token).ConfigureAwait(false))
+        {
+            state.CompactedVersion = await reader.GetFieldValueAsync<long>(6, token).ConfigureAwait(false);
+        }
 
         return state;
     }

--- a/src/Marten/Events/EventStore.StreamCompacting.cs
+++ b/src/Marten/Events/EventStore.StreamCompacting.cs
@@ -143,6 +143,14 @@ internal static class StreamCompactingExecution
         session.Events.CompletelyReplaceEvent(request.Sequence, compacted);
 
         session.QueueOperation(new DeleteEventsOperation(sequences));
+
+        // jasperfx#740 (marten#5333): record the compaction watermark on mt_streams so
+        // StreamState.CompactedVersion — and the (Version - CompactedVersion) growth measure the
+        // Stream Compaction Policies are built on — reads truthfully. request.Version is the
+        // version of the last event folded into the Compacted<T> snapshot: the caller's cutoff for
+        // a partial compaction, the stream's current version for a full one.
+        session.QueueOperation(new RecordCompactionWatermarkOperation(
+            ((IMartenSession)session).Options.EventGraph, request.StreamId, request.StreamKey, request.Version));
     }
 
     private static IAggregator<T, IQuerySession> FindAggregator<T>(DocumentSessionBase session) where T : class
@@ -198,6 +206,59 @@ public sealed class SampleArchiverDocumentation : IEventsArchiver<IDocumentOpera
 }
 
 #endregion
+
+/// <summary>
+///     jasperfx#740 (marten#5333): stamp the stream-compaction watermark onto
+///     <c>mt_streams.compacted_version</c> as part of the same unit of work that writes the
+///     <c>Compacted&lt;T&gt;</c> snapshot and deletes the folded events. <c>greatest()</c> keeps the
+///     watermark monotonic — a replayed or lower-cutoff compaction request can never move it
+///     backwards, which would make a stream's un-compacted growth read larger than it is.
+/// </summary>
+internal class RecordCompactionWatermarkOperation: IStorageOperation, NoDataReturnedCall
+{
+    private readonly EventGraph _events;
+    private readonly Guid? _streamId;
+    private readonly string? _streamKey;
+    private readonly long _version;
+
+    public RecordCompactionWatermarkOperation(EventGraph events, Guid? streamId, string? streamKey, long version)
+    {
+        _events = events;
+        _streamId = streamId;
+        _streamKey = streamKey;
+        _version = version;
+    }
+
+    public void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        builder.Append(
+            $"update {_events.DatabaseSchemaName}.{Schema.StreamsTable.TableName} set {Schema.StreamsTable.CompactedVersionColumn} = greatest({Schema.StreamsTable.CompactedVersionColumn}, ");
+        builder.AppendParameter(_version);
+        builder.Append(") where id = ");
+
+        if (_events.StreamIdentity == StreamIdentity.AsGuid)
+        {
+            builder.AppendParameter(_streamId!.Value);
+        }
+        else
+        {
+            builder.AppendParameter(_streamKey!);
+        }
+
+        // Same #5234 discipline as the sibling compaction operations: under conjoined tenancy the
+        // same stream id exists in every tenant, and only the calling tenant's watermark may move.
+        builder.AppendConjoinedTenantFilter(session);
+    }
+
+    public Type DocumentType => typeof(IEvent);
+
+    public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
+
+    public OperationRole Role() => OperationRole.Events;
+}
 
 internal class DeleteEventsOperation: IStorageOperation, NoDataReturnedCall
 {

--- a/src/Marten/Events/QueryEventStore.cs
+++ b/src/Marten/Events/QueryEventStore.cs
@@ -492,7 +492,28 @@ internal class QueryEventStore: IQueryEventStore, IReadOnlyEventStore
             AggregateType = martenState.AggregateType,
             LastTimestamp = martenState.LastTimestamp,
             Created = martenState.Created,
-            IsArchived = martenState.IsArchived
+            IsArchived = martenState.IsArchived,
+            CompactedVersion = martenState.CompactedVersion
         };
+    }
+
+    /// <summary>
+    /// jasperfx#740 (marten#5333): the streams table as a real <see cref="IQueryable{T}"/> of
+    /// <see cref="StreamState"/>, translated against <c>mt_streams</c> and executed through the
+    /// shared <see cref="JasperFx.Events.Documents.IDocumentQueryExecutor"/> hook. See
+    /// <see cref="StreamStateQueryProvider"/> for the translatable set and the refusal rules.
+    /// </summary>
+    public IQueryable<StreamState> QueryStreamStates(string? tenantId = null)
+    {
+        // A tenant scope against a store with no tenant dimension must be refused, never quietly
+        // answered with unscoped rows that read as tenant-scoped — the jasperfx#737 rule applied
+        // to the tenant filter.
+        if (tenantId != null && _store.Events.TenancyStyle != TenancyStyle.Conjoined)
+        {
+            throw new NotSupportedException(
+                $"This event store does not have a tenant dimension (TenancyStyle.{_store.Events.TenancyStyle}), so QueryStreamStates cannot scope to tenant '{tenantId}'. Omit the tenantId argument, or configure conjoined multi-tenancy.");
+        }
+
+        return new StreamStateQueryProvider(_session, _store, _tenant, tenantId).CreateRoot();
     }
 }

--- a/src/Marten/Events/Querying/StreamStateQueryable.cs
+++ b/src/Marten/Events/Querying/StreamStateQueryable.cs
@@ -1,0 +1,712 @@
+#nullable enable
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Documents;
+using Marten.Events.Schema;
+using Marten.Internal;
+using Marten.Internal.Sessions;
+using Marten.Linq.QueryHandlers;
+using Marten.Linq.Selectors;
+using Marten.Storage;
+using Weasel.Postgresql;
+
+namespace Marten.Events.Querying;
+
+/*
+ * jasperfx#740 (marten#5333): IReadOnlyEventStore.QueryStreamStates() — the streams table as a real
+ * IQueryable<StreamState>, executed through the shared IDocumentQueryExecutor hook.
+ *
+ * This is a DEDICATED provider rather than a StreamState mapping over Marten's full LINQ engine,
+ * deliberately. The contract's minimum translatable set includes two shapes the general engine does
+ * not translate: member-to-member arithmetic in a comparison (Version - CompactedVersion > N, the
+ * compaction-policy predicate — SimpleExpression only reduces constant arithmetic) and equality of
+ * a Type-valued member against a typeof constant (AggregateType == typeof(X), which must resolve to
+ * the stored aggregate alias). A purpose-built translator over one seven-column table keeps both
+ * exact, and keeps the contract's refusal rule enforceable: anything outside the translatable set
+ * throws naming the member or operator — never a silent match-all.
+ */
+
+/// <summary>
+/// The <see cref="IQueryable{T}"/> face of <c>QueryStreamStates()</c>. Composition (Where/OrderBy/
+/// ThenBy/Skip/Take) builds expression trees as usual; execution goes through the shared
+/// asynchronous terminators in <see cref="DocumentQueryableExtensions"/>, dispatching to
+/// <see cref="StreamStateQueryProvider"/>'s <see cref="IDocumentQueryExecutor"/> implementation.
+/// </summary>
+internal class StreamStateQueryable: IOrderedQueryable<StreamState>
+{
+    public StreamStateQueryable(StreamStateQueryProvider provider, Expression expression)
+    {
+        Provider = provider;
+        Expression = expression;
+    }
+
+    public Type ElementType => typeof(StreamState);
+    public Expression Expression { get; }
+    public IQueryProvider Provider { get; }
+
+    public IEnumerator<StreamState> GetEnumerator() =>
+        throw StreamStateQueryProvider.SynchronousExecutionRefused();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+/// <summary>
+/// LINQ provider + shared async execution hook for <see cref="StreamStateQueryable"/>. Translates
+/// the supported operator set to SQL over <c>mt_streams</c> and executes through the owning
+/// session, hydrating rows with the same <see cref="ISelector{T}"/> the fetch path uses so the two
+/// surfaces can never disagree about a column.
+/// </summary>
+internal class StreamStateQueryProvider: IQueryProvider, IDocumentQueryExecutor
+{
+    private readonly QuerySession _session;
+    private readonly DocumentStore _store;
+    private readonly Tenant _tenant;
+    private readonly string? _tenantIdOverride;
+
+    public StreamStateQueryProvider(QuerySession session, DocumentStore store, Tenant tenant,
+        string? tenantIdOverride)
+    {
+        _session = session;
+        _store = store;
+        _tenant = tenant;
+        _tenantIdOverride = tenantIdOverride;
+    }
+
+    private string effectiveTenantId => _tenantIdOverride ?? _tenant.TenantId;
+
+    public IQueryable<StreamState> CreateRoot() =>
+        new StreamStateQueryable(this, Expression.Constant(new StreamStateQueryable(this, null!), typeof(IQueryable<StreamState>)));
+
+    public IQueryable CreateQuery(Expression expression) => CreateQuery<StreamState>(expression);
+
+    public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+    {
+        if (typeof(TElement) != typeof(StreamState))
+        {
+            throw new NotSupportedException(
+                $"IReadOnlyEventStore.QueryStreamStates() cannot project to '{typeof(TElement).Name}' — the queryable supports Where, OrderBy/OrderByDescending/ThenBy/ThenByDescending, Skip and Take over StreamState only, not Select projections.");
+        }
+
+        return (IQueryable<TElement>)(object)new StreamStateQueryable(this, expression);
+    }
+
+    public object? Execute(Expression expression) => throw SynchronousExecutionRefused();
+
+    public TResult Execute<TResult>(Expression expression) => throw SynchronousExecutionRefused();
+
+    internal static NotSupportedException SynchronousExecutionRefused() =>
+        new(
+            "Synchronous LINQ execution is not supported by IReadOnlyEventStore.QueryStreamStates(). Execute with the asynchronous terminators in JasperFx.Events.Documents.DocumentQueryableExtensions — ToListAsync, CountAsync, AnyAsync or FirstOrDefaultAsync.");
+
+    // ---- IDocumentQueryExecutor ----
+
+    public async Task<IReadOnlyList<T>> ExecuteToListAsync<T>(IQueryable<T> queryable, CancellationToken token)
+    {
+        var states = await executeListAsync(translate(queryable.Expression), token).ConfigureAwait(false);
+        return (IReadOnlyList<T>)states;
+    }
+
+    public async Task<T?> ExecuteFirstOrDefaultAsync<T>(IQueryable<T> queryable, CancellationToken token)
+    {
+        var plan = translate(queryable.Expression);
+        plan.Take = plan.Take.HasValue ? Math.Min(plan.Take.Value, 1) : 1;
+
+        var states = await executeListAsync(plan, token).ConfigureAwait(false);
+        return (T?)(object?)states.FirstOrDefault();
+    }
+
+    public async Task<int> ExecuteCountAsync<T>(IQueryable<T> queryable, CancellationToken token)
+    {
+        var plan = translate(queryable.Expression);
+        await ensureStorageAsync(token).ConfigureAwait(false);
+
+        var handler = new ScalarQueryHandler<long>(builder => writeCountSql(builder, plan));
+        var count = await _session.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+        return (int)count;
+    }
+
+    public async Task<bool> ExecuteAnyAsync<T>(IQueryable<T> queryable, CancellationToken token)
+    {
+        var plan = translate(queryable.Expression);
+        await ensureStorageAsync(token).ConfigureAwait(false);
+
+        var handler = new ScalarQueryHandler<bool>(builder => writeAnySql(builder, plan));
+        return await _session.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+    }
+
+    // ---- execution ----
+
+    private async Task ensureStorageAsync(CancellationToken token) =>
+        await _tenant.Database.EnsureStorageExistsAsync(typeof(StreamAction), token).ConfigureAwait(false);
+
+    private async Task<IReadOnlyList<StreamState>> executeListAsync(StreamStateQueryPlan plan,
+        CancellationToken token)
+    {
+        await ensureStorageAsync(token).ConfigureAwait(false);
+
+        var handler = new StreamStateListQueryHandler(builder => writeSelectSql(builder, plan));
+        return await _session.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+    }
+
+    private StreamStateQueryPlan translate(Expression expression) =>
+        new StreamStateQueryTranslator(_store.Events).Translate(expression);
+
+    // ---- SQL emission ----
+
+    private void writeParts(ICommandBuilder builder, IReadOnlyList<object> parts)
+    {
+        foreach (var part in parts)
+        {
+            if (part is SqlParam p)
+            {
+                builder.AppendParameter(p.Value);
+            }
+            else
+            {
+                builder.Append((string)part);
+            }
+        }
+    }
+
+    private void writeFromAndWhere(ICommandBuilder builder, StreamStateQueryPlan plan)
+    {
+        builder.Append($"from {_store.Events.DatabaseSchemaName}.{StreamsTable.TableName} where tenant_id = ");
+        builder.AppendParameter(effectiveTenantId);
+
+        foreach (var predicate in plan.Predicates)
+        {
+            builder.Append(" and (");
+            writeParts(builder, predicate);
+            builder.Append(')');
+        }
+    }
+
+    private void writeOrderingAndPaging(ICommandBuilder builder, StreamStateQueryPlan plan)
+    {
+        var orderings = plan.Orderings.Where(x => x.Parts.Count > 0).ToList();
+        if (orderings.Count > 0)
+        {
+            builder.Append(" order by ");
+            for (var i = 0; i < orderings.Count; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(", ");
+                }
+
+                writeParts(builder, orderings[i].Parts);
+                builder.Append(orderings[i].Descending ? " desc" : " asc");
+            }
+        }
+
+        if (plan.Skip is { } skip)
+        {
+            builder.Append(" offset ");
+            builder.AppendParameter((long)skip);
+        }
+
+        if (plan.Take is { } take)
+        {
+            builder.Append(" limit ");
+            builder.AppendParameter((long)take);
+        }
+    }
+
+    private void writeSelectSql(ICommandBuilder builder, StreamStateQueryPlan plan)
+    {
+        // The column list and ordering are owned by StreamStateSql/ISelector<StreamState> — the
+        // same row shape the fetch path reads, so the two surfaces cannot drift apart.
+        builder.Append(
+            $"select id, version, type, timestamp, created, is_archived, {StreamsTable.CompactedVersionColumn} ");
+        writeFromAndWhere(builder, plan);
+        writeOrderingAndPaging(builder, plan);
+    }
+
+    private void writeCountSql(ICommandBuilder builder, StreamStateQueryPlan plan)
+    {
+        if (plan.Skip is null && plan.Take is null)
+        {
+            builder.Append("select count(*) ");
+            writeFromAndWhere(builder, plan);
+            return;
+        }
+
+        // A count after Skip/Take counts the page, so wrap the paged selection.
+        builder.Append("select count(*) from (select 1 ");
+        writeFromAndWhere(builder, plan);
+        writeOrderingAndPaging(builder, plan);
+        builder.Append(") as paged");
+    }
+
+    private void writeAnySql(ICommandBuilder builder, StreamStateQueryPlan plan)
+    {
+        builder.Append("select exists(select 1 ");
+        writeFromAndWhere(builder, plan);
+
+        // Ordering cannot change existence; Skip/Take can.
+        var ordered = plan.Orderings;
+        plan.Orderings = new List<StreamStateOrdering>();
+        writeOrderingAndPaging(builder, plan);
+        plan.Orderings = ordered;
+
+        builder.Append(')');
+    }
+}
+
+/// <summary>One SQL parameter value inside a translated fragment.</summary>
+internal readonly record struct SqlParam(object Value);
+
+internal class StreamStateOrdering
+{
+    public StreamStateOrdering(IReadOnlyList<object> parts, bool descending)
+    {
+        Parts = parts;
+        Descending = descending;
+    }
+
+    /// <summary>Empty when the ordering term is a stable constant (the inapplicable identity member) and can be skipped.</summary>
+    public IReadOnlyList<object> Parts { get; }
+
+    public bool Descending { get; }
+}
+
+internal class StreamStateQueryPlan
+{
+    public List<IReadOnlyList<object>> Predicates { get; } = new();
+    public List<StreamStateOrdering> Orderings { get; set; } = new();
+    public int? Skip { get; set; }
+    public int? Take { get; set; }
+}
+
+/// <summary>
+/// Translates the supported LINQ operator set over <see cref="StreamState"/> into SQL fragments
+/// against <c>mt_streams</c>. Anything outside the contract's translatable set throws
+/// <see cref="NotSupportedException"/> naming the member or operator — the jasperfx#737/#740 rule:
+/// a predicate that cannot be honored must be refused, never silently dropped.
+/// </summary>
+internal class StreamStateQueryTranslator
+{
+    private readonly EventGraph _events;
+
+    public StreamStateQueryTranslator(EventGraph events)
+    {
+        _events = events;
+    }
+
+    public StreamStateQueryPlan Translate(Expression expression)
+    {
+        var plan = new StreamStateQueryPlan();
+
+        // Unwind the operator chain source-first.
+        var calls = new List<MethodCallExpression>();
+        var current = expression;
+        while (current is MethodCallExpression mc)
+        {
+            calls.Insert(0, mc);
+            current = mc.Arguments[0];
+        }
+
+        foreach (var call in calls)
+        {
+            switch (call.Method.Name)
+            {
+                case nameof(Queryable.Where):
+                    plan.Predicates.Add(translatePredicate(unquoteLambda(call.Arguments[1])));
+                    break;
+
+                case nameof(Queryable.OrderBy):
+                    plan.Orderings = new List<StreamStateOrdering> { ordering(call, descending: false) };
+                    break;
+
+                case nameof(Queryable.OrderByDescending):
+                    plan.Orderings = new List<StreamStateOrdering> { ordering(call, descending: true) };
+                    break;
+
+                case nameof(Queryable.ThenBy):
+                    plan.Orderings.Add(ordering(call, descending: false));
+                    break;
+
+                case nameof(Queryable.ThenByDescending):
+                    plan.Orderings.Add(ordering(call, descending: true));
+                    break;
+
+                case nameof(Queryable.Skip):
+                    plan.Skip = (plan.Skip ?? 0) + evaluateInt(call.Arguments[1]);
+                    break;
+
+                case nameof(Queryable.Take):
+                    var take = evaluateInt(call.Arguments[1]);
+                    plan.Take = plan.Take.HasValue ? Math.Min(plan.Take.Value, take) : take;
+                    break;
+
+                default:
+                    throw new NotSupportedException(
+                        $"The LINQ operator '{call.Method.Name}' is not supported by IReadOnlyEventStore.QueryStreamStates(). " +
+                        "Supported: Where, OrderBy/OrderByDescending/ThenBy/ThenByDescending, Skip, Take, and the asynchronous terminators in JasperFx.Events.Documents.DocumentQueryableExtensions.");
+            }
+        }
+
+        return plan;
+    }
+
+    private StreamStateOrdering ordering(MethodCallExpression call, bool descending)
+    {
+        var lambda = unquoteLambda(call.Arguments[1]);
+        var body = stripConvert(lambda.Body);
+
+        if (body is MemberExpression { Expression: ParameterExpression } member)
+        {
+            // The identity member that does not apply to the store's identity style holds its
+            // default on every row — a stable constant, skipped rather than emitted.
+            if (isInapplicableIdentity(member.Member.Name))
+            {
+                return new StreamStateOrdering(Array.Empty<object>(), descending);
+            }
+
+            return new StreamStateOrdering(new object[] { columnFor(member.Member.Name) }, descending);
+        }
+
+        throw new NotSupportedException(
+            $"QueryStreamStates() can only order by a direct StreamState member, not '{body}'.");
+    }
+
+    private static LambdaExpression unquoteLambda(Expression e)
+    {
+        if (e is UnaryExpression { NodeType: ExpressionType.Quote } quote)
+        {
+            e = quote.Operand;
+        }
+
+        var lambda = (LambdaExpression)e;
+        if (lambda.Parameters.Count != 1)
+        {
+            throw new NotSupportedException(
+                "The indexed Where/OrderBy overloads are not supported by QueryStreamStates().");
+        }
+
+        return lambda;
+    }
+
+    private static int evaluateInt(Expression e) => (int)evaluate(e)!;
+
+    private List<object> translatePredicate(LambdaExpression lambda) => translateBoolean(lambda.Body);
+
+    private List<object> translateBoolean(Expression e)
+    {
+        e = stripConvert(e);
+
+        switch (e)
+        {
+            case BinaryExpression { NodeType: ExpressionType.AndAlso or ExpressionType.And } and:
+            {
+                var parts = new List<object> { "(" };
+                parts.AddRange(translateBoolean(and.Left));
+                parts.Add(" and ");
+                parts.AddRange(translateBoolean(and.Right));
+                parts.Add(")");
+                return parts;
+            }
+
+            case BinaryExpression { NodeType: ExpressionType.OrElse or ExpressionType.Or } or:
+            {
+                var parts = new List<object> { "(" };
+                parts.AddRange(translateBoolean(or.Left));
+                parts.Add(" or ");
+                parts.AddRange(translateBoolean(or.Right));
+                parts.Add(")");
+                return parts;
+            }
+
+            case UnaryExpression { NodeType: ExpressionType.Not } not:
+            {
+                var parts = new List<object> { "NOT (" };
+                parts.AddRange(translateBoolean(not.Operand));
+                parts.Add(")");
+                return parts;
+            }
+
+            case BinaryExpression binary when comparisonOperator(binary.NodeType) != null:
+                return translateComparison(binary);
+
+            case MemberExpression { Expression: ParameterExpression } member when member.Type == typeof(bool):
+                return new List<object> { columnSqlOrParam(member.Member.Name), " = TRUE" };
+
+            case ConstantExpression { Value: bool b }:
+                return new List<object> { b ? "TRUE" : "FALSE" };
+
+            default:
+                if (!ReferencesParameter.Test(e) && e.Type == typeof(bool))
+                {
+                    return new List<object> { (bool)evaluate(e)! ? "TRUE" : "FALSE" };
+                }
+
+                throw new NotSupportedException(
+                    $"QueryStreamStates() cannot translate the predicate expression '{e}'.");
+        }
+    }
+
+    private static string? comparisonOperator(ExpressionType type) => type switch
+    {
+        ExpressionType.Equal => "=",
+        ExpressionType.NotEqual => "<>",
+        ExpressionType.GreaterThan => ">",
+        ExpressionType.GreaterThanOrEqual => ">=",
+        ExpressionType.LessThan => "<",
+        ExpressionType.LessThanOrEqual => "<=",
+        _ => null
+    };
+
+    private List<object> translateComparison(BinaryExpression binary)
+    {
+        var op = comparisonOperator(binary.NodeType)!;
+        var left = stripConvert(binary.Left);
+        var right = stripConvert(binary.Right);
+
+        // AggregateType == typeof(X) / != typeof(X) / == null — the compaction-policy selector.
+        // Resolved against the stored aggregate alias, exactly what StartStream<T> writes.
+        if (isAggregateTypeMember(left) || isAggregateTypeMember(right))
+        {
+            var other = isAggregateTypeMember(left) ? right : left;
+
+            if (op is not ("=" or "<>"))
+            {
+                throw new NotSupportedException(
+                    "StreamState.AggregateType only supports equality comparison against a Type value in QueryStreamStates().");
+            }
+
+            if (ReferencesParameter.Test(other))
+            {
+                throw new NotSupportedException(
+                    $"QueryStreamStates() cannot translate the AggregateType comparison '{binary}'.");
+            }
+
+            var typeValue = (Type?)evaluate(other);
+            if (typeValue == null)
+            {
+                return new List<object> { op == "=" ? "type is null" : "type is not null" };
+            }
+
+            var alias = _events.AggregateAliasFor(typeValue);
+            return op == "="
+                ? new List<object> { "type = ", new SqlParam(alias) }
+                // IS DISTINCT FROM so a stream started with no aggregate type still counts as
+                // "not X", matching the C# semantics of a null Type against a typeof constant.
+                : new List<object> { "type is distinct from ", new SqlParam(alias) };
+        }
+
+        // Null comparisons become IS [NOT] NULL on the other operand.
+        if (isNullConstant(left) || isNullConstant(right))
+        {
+            var operand = isNullConstant(left) ? right : left;
+            var parts = translateOperand(operand);
+            parts.Add(op == "=" ? " is null" : " is not null");
+            return parts;
+        }
+
+        var result = translateOperand(left);
+        if (op == "<>")
+        {
+            // IS DISTINCT FROM matches C# inequality when the column is null (Key on rows that
+            // never had one, an untyped stream's type column).
+            result.Add(" is distinct from ");
+        }
+        else
+        {
+            result.Add($" {op} ");
+        }
+
+        result.AddRange(translateOperand(right));
+        return result;
+    }
+
+    private List<object> translateOperand(Expression e)
+    {
+        e = stripConvert(e);
+
+        if (!ReferencesParameter.Test(e))
+        {
+            return new List<object> { new SqlParam(evaluate(e) ?? DBNull.Value) };
+        }
+
+        switch (e)
+        {
+            case MemberExpression { Expression: ParameterExpression } member:
+                return new List<object> { columnSqlOrParam(member.Member.Name) };
+
+            case BinaryExpression binary when binary.NodeType is ExpressionType.Add or ExpressionType.Subtract
+                or ExpressionType.Multiply or ExpressionType.Divide:
+            {
+                var op = binary.NodeType switch
+                {
+                    ExpressionType.Add => " + ",
+                    ExpressionType.Subtract => " - ",
+                    ExpressionType.Multiply => " * ",
+                    _ => " / "
+                };
+
+                var parts = new List<object> { "(" };
+                parts.AddRange(translateOperand(binary.Left));
+                parts.Add(op);
+                parts.AddRange(translateOperand(binary.Right));
+                parts.Add(")");
+                return parts;
+            }
+
+            default:
+                throw new NotSupportedException(
+                    $"QueryStreamStates() cannot translate the expression '{e}'.");
+        }
+    }
+
+    private static bool isAggregateTypeMember(Expression e) =>
+        stripConvert(e) is MemberExpression { Expression: ParameterExpression } m &&
+        m.Member.Name == nameof(StreamState.AggregateType);
+
+    private static bool isNullConstant(Expression e) =>
+        stripConvert(e) is ConstantExpression { Value: null };
+
+    private static Expression stripConvert(Expression e)
+    {
+        while (e is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } u)
+        {
+            e = u.Operand;
+        }
+
+        return e;
+    }
+
+    private static object? evaluate(Expression e)
+    {
+        if (e is ConstantExpression c)
+        {
+            return c.Value;
+        }
+
+        return Expression.Lambda(e).Compile().DynamicInvoke();
+    }
+
+    private bool isInapplicableIdentity(string memberName) =>
+        (memberName == nameof(StreamState.Id) && _events.StreamIdentity == StreamIdentity.AsString) ||
+        (memberName == nameof(StreamState.Key) && _events.StreamIdentity == StreamIdentity.AsGuid);
+
+    /// <summary>
+    /// The member-to-column map — the whole translatable member surface. An inapplicable identity
+    /// member holds its CLR default on every row, so it translates to that constant; everything
+    /// unknown is refused by name.
+    /// </summary>
+    private object columnSqlOrParam(string memberName)
+    {
+        if (memberName == nameof(StreamState.Id) && _events.StreamIdentity == StreamIdentity.AsString)
+        {
+            return new SqlParam(Guid.Empty);
+        }
+
+        if (memberName == nameof(StreamState.Key) && _events.StreamIdentity == StreamIdentity.AsGuid)
+        {
+            return "null::varchar";
+        }
+
+        return columnFor(memberName);
+    }
+
+    private string columnFor(string memberName) => memberName switch
+    {
+        nameof(StreamState.Id) => "id",
+        nameof(StreamState.Key) => "id",
+        nameof(StreamState.Version) => "version",
+        nameof(StreamState.LastTimestamp) => "timestamp",
+        nameof(StreamState.Created) => "created",
+        nameof(StreamState.IsArchived) => "is_archived",
+        nameof(StreamState.CompactedVersion) => StreamsTable.CompactedVersionColumn,
+        nameof(StreamState.AggregateType) => throw new NotSupportedException(
+            "StreamState.AggregateType only supports equality comparison against a Type value in QueryStreamStates()."),
+        _ => throw new NotSupportedException(
+            $"QueryStreamStates() cannot translate the member 'StreamState.{memberName}'.")
+    };
+
+    /// <summary>Does the expression reference the lambda parameter anywhere?</summary>
+    private class ReferencesParameter: ExpressionVisitor
+    {
+        private bool _found;
+
+        public static bool Test(Expression e)
+        {
+            var visitor = new ReferencesParameter();
+            visitor.Visit(e);
+            return visitor._found;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            _found = true;
+            return base.VisitParameter(node);
+        }
+    }
+}
+
+/// <summary>
+/// Reads a page of <c>mt_streams</c> rows through the SAME <see cref="ISelector{T}"/> the fetch
+/// path uses (<c>IEventStorage</c>'s <c>ISelector&lt;StreamState&gt;</c>), so the queryable and
+/// <c>FetchStreamStateAsync</c> can never disagree about column ordering or hydration.
+/// </summary>
+internal class StreamStateListQueryHandler: IQueryHandler<IReadOnlyList<StreamState>>
+{
+    private readonly Action<ICommandBuilder> _configure;
+
+    public StreamStateListQueryHandler(Action<ICommandBuilder> configure)
+    {
+        _configure = configure;
+    }
+
+    public void ConfigureCommand(ICommandBuilder builder, IStorageSession session) => _configure(builder);
+
+    public async Task<IReadOnlyList<StreamState>> HandleAsync(DbDataReader reader, IStorageSession session,
+        CancellationToken token)
+    {
+        var selector = (ISelector<StreamState>)((IMartenSession)session).EventStorage();
+
+        var states = new List<StreamState>();
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            states.Add(await selector.ResolveAsync(reader, token).ConfigureAwait(false));
+        }
+
+        return states;
+    }
+
+    public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token) =>
+        throw new NotSupportedException();
+}
+
+internal class ScalarQueryHandler<T>: IQueryHandler<T>
+{
+    private readonly Action<ICommandBuilder> _configure;
+
+    public ScalarQueryHandler(Action<ICommandBuilder> configure)
+    {
+        _configure = configure;
+    }
+
+    public void ConfigureCommand(ICommandBuilder builder, IStorageSession session) => _configure(builder);
+
+    public async Task<T> HandleAsync(DbDataReader reader, IStorageSession session, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            return default!;
+        }
+
+        return await reader.GetFieldValueAsync<T>(0, token).ConfigureAwait(false);
+    }
+
+    public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token) =>
+        throw new NotSupportedException();
+}

--- a/src/Marten/Events/Schema/StreamsTable.cs
+++ b/src/Marten/Events/Schema/StreamsTable.cs
@@ -20,6 +20,18 @@ internal class StreamsTable: Table
 {
     public const string TableName = "mt_streams";
 
+    /// <summary>
+    ///     jasperfx#740 (marten#5333): the stream-compaction watermark — the stream version through
+    ///     which events have been folded into a <c>Compacted&lt;T&gt;</c> snapshot. 0 means never
+    ///     compacted. Written by <c>CompactStreamAsync</c> (see
+    ///     <c>RecordCompactionWatermarkOperation</c>), surfaced on <c>StreamState.CompactedVersion</c>
+    ///     by both the fetch path and <c>QueryStreamStates</c>. Deliberately NOT an
+    ///     <see cref="IStreamTableColumn"/>: the append/insert paths enumerate
+    ///     <c>Columns.OfType&lt;IStreamTableColumn&gt;().Where(x => x.Writes)</c>, and this column is
+    ///     only ever written by the compaction operation — new streams get the 0 default.
+    /// </summary>
+    public const string CompactedVersionColumn = "compacted_version";
+
     public StreamsTable(EventGraph events): base(new PostgresqlObjectName(events.DatabaseSchemaName, TableName))
     {
         foreach (var index in events.IgnoredIndexes)
@@ -60,6 +72,8 @@ internal class StreamsTable: Table
         {
             AddColumn<TenantIdColumn>();
         }
+
+        AddColumn<long>(CompactedVersionColumn).NotNull().DefaultValueByExpression("0");
 
         var archiving = AddColumn<IsArchivedColumn>();
         if (events.UseArchivedStreamPartitioning)


### PR DESCRIPTION
Closes #5333

Downstream of [jasperfx#740](https://github.com/JasperFx/jasperfx/issues/740) (merged as jasperfx#741), riding the published **JasperFx 2.63.0** matched set. Sibling of the merged EventQuery wave (#5331), part of the CritterWatch 1.1 Stream Compaction Policies chain.

## The dedicated provider (and why it is not the general LINQ engine)

`QueryEventStore.QueryStreamStates(tenantId)` returns a purpose-built `IQueryable<StreamState>` over `mt_streams` (`src/Marten/Events/Querying/StreamStateQueryable.cs`) rather than a mapping through Marten's LINQ engine, because the contract's minimum translatable set contains two shapes the engine does not translate:

- **member-to-member arithmetic in a comparison** — `x.Version - x.CompactedVersion > N`, the compaction-policy predicate (`SimpleExpression` only reduces constant arithmetic);
- **`x.AggregateType == typeof(X)`** — a Type-valued member resolved to the stored aggregate alias (`EventGraph.AggregateAliasFor`) in the `type` column.

The provider translates `Where` over every public get member of `StreamState`, `OrderBy`/`OrderByDescending`/`ThenBy`/`ThenByDescending`, `Skip`/`Take`, and implements the shared `IDocumentQueryExecutor` hook so the `JasperFx.Events.Documents` terminators (`ToListAsync`/`CountAsync`/`AnyAsync`/`FirstOrDefaultAsync`) dispatch against it. Rows hydrate through the **same** `ISelector<StreamState>` the fetch path uses, so the two surfaces cannot drift. Semantics worth noting:

- `!=` emits `IS DISTINCT FROM`, so a null cell (an untyped stream's `type`, the absent identity member) matches C# inequality semantics.
- The identity member that does not apply to the store's identity style (`Key` on a Guid store, `Id` on a string store) translates as its constant CLR default in `Where`, and is skipped as an ordering term (a stable constant) — the contract's stated behavior.
- **Everything else is refused by name**, never silently matched: an untranslatable member (`x.Key.Length`), an unsupported operator (`Distinct`, …), `Select` projections (at composition time), synchronous execution (with guidance to the async terminators), `AggregateType` outside equality, and a **tenant scope on a store with no tenant dimension**. On conjoined stores the query scopes to the given tenant, otherwise to the session's own.

## Schema delta + the watermark write

- `mt_streams` gains **`compacted_version bigint NOT NULL DEFAULT 0`** — a migration delta on existing schemas; deliberately not an `IStreamTableColumn`, so the append/insert paths ignore it and new streams read 0.
- `CompactStreamAsync` now queues `RecordCompactionWatermarkOperation` in the same unit of work as the `Compacted<T>` snapshot: `set compacted_version = greatest(compacted_version, @cutoff)` — **`greatest()` keeps the watermark monotonic** (a replayed or lower-cutoff compaction can never move it backwards, which would inflate a stream's apparent un-compacted growth), with the #5234 conjoined-tenant filter. Partial compaction records the cutoff version, full compaction the stream version (growth 0), never-compacted reads 0.
- The shared `StreamStateSql`/selector pair carries the new column, so `FetchStreamStateAsync` and the queryable agree — pinned by the extended `event_storage_stream_state_selector` tests.

## Compliance + tests

- `StreamStateQueryCompliance` enrolled as **wave 12** — includes the compaction-policy shape itself (`AggregateType == typeof(X) && Version - CompactedVersion > 3 && !IsArchived`, where the freshly-compacted stream with raw Version 9 is the load-bearing decoy), the `OrderBy(Created).ThenBy(Id)` paging contract, and per-member decoys.
- `ConjoinedEventTenancyCompliance` gains the tenant-scoped `QueryStreamStates` fact.
- The refusal shapes the shared suite deliberately cannot pin (both stores translate everything) live in `query_stream_states_refusals.cs`, beside a string-identity watermark test for the identity branch the shared suite does not reach.
- **CLI e2e from the start:** `stream_query_command_end_to_end` drives `StreamQueryCommand.Execute` against a real host — exact expected streams including `versionsSinceCompaction` (2 for the partially-compacted freighter, 5 for the never-compacted one), a second run with the full compaction-policy filters isolating the overgrown stream, and the tenant-refusal honesty path in the same JSON report shape.

## Two findings for reviewers

1. **First local run after pulling this will migrate every existing test schema's `mt_streams`.** In a full parallel `EventSourcingTests` run, that one-time first-touch migration collided across collections in this branch's testing (a burst of failures, then permanently green once patched). Real upgrades do this once per schema; just expect the first full local run to be noisy and the second clean.
2. **CS0121 note:** user code with both `using Marten;` and `using JasperFx.Events.Documents;` gets an ambiguous-call error on extension-style `.ToListAsync()`/`.CountAsync()` over the stream queryable, because `Marten.QueryableExtensions` declares identical-shape extensions. The compliance suite and the CLI call the JasperFx extensions explicitly; may deserve an upstream naming thought.

Also fixed in passing: the wave-1 `event_query_command_end_to_end` had a 1-in-a-full-run flake (Console.Out is process-global; a parallel test's write corrupted the captured stdout). Both CLI e2e classes now share an xUnit collection and a robust single-JSON-value report extractor (`CommandJsonOutput`).

## Test results (published 2.63.0, verified from nuget.org after cache eviction)

| Suite | net9.0 | net10.0 |
|---|---|---|
| `StreamStateQueryCompliance` (wave 12) | **15/15** | **15/15** |
| `ConjoinedEventTenancyCompliance` (incl. the new fact) | **11/11** | **11/11** |
| `query_stream_states_refusals` + string-identity watermark + selector pins | 9/9 | 12/12* |
| Both CLI e2e classes (`stream-query` + `event-query`) | 4/4 | (in *) |
| `Aggregation.stream_compacting` neighbors | 20/20 | — |
| Full compliance namespace (39 suites) | **388/388** | **388/388** |
| Full `EventSourcingTests` | 2075 passed / 7 pre-existing skips / 0 failed | same |

\* net10.0 re-ran the refusals, watermark and CLI classes as one 12-test filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)