### PR TITLE
Enroll CompositeProjectionCompliance + SingleTenantedEventSlicingCompliance (compliance wave 13)

### DIFF
--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave13.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave13.cs
@@ -1,0 +1,32 @@
+using JasperFx.Events.ComplianceTests;
+using Marten;
+using Marten.Testing.Harness;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * Wave 13 (#5335) -- the last two shipped suites Marten did not enroll, both arriving in the
+ * JasperFx 2.59.0 line. Same shape as the earlier enrollment files: empty subclasses closing the
+ * shared suites over Marten's session pair.
+ *
+ * CompositeProjectionCompliance (jasperfx#725) is opt-in through the registrar's
+ * AddCompositeProjection seam member, implemented in MartenComplianceFixture on this wave as the
+ * documented forward-plus-adapter over Projections.CompositeProjectionFor. The suite pins the
+ * shared composite contract: every stage materializes from one async pass, a rebuild tears the
+ * members down rather than replaying over their surviving rows (the Bug 5175 class of failure),
+ * and the composite presents itself as exactly one shard. Marten's own coverage of the same
+ * ground lives in src/DaemonTests/Composites/.
+ *
+ * SingleTenantedEventSlicingCompliance (jasperfx#724) pins marten#4085: events whose tenant_id
+ * values disagree on a single-tenanted store still fold into ONE async aggregate rather than
+ * being sliced per tenant into partial documents. Per jasperfx#727 the suite's precondition is
+ * only constructible on Marten -- Polecat and Fisher normalize the stamped tenant ids away and
+ * hit the suite's honest-skip guard -- which is exactly why Marten, where the bug was reported
+ * and fixed, is the store that should be holding the contract while that issue is settled.
+ */
+
+public class composite_projection_compliance
+    : CompositeProjectionCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+public class single_tenanted_event_slicing_compliance
+    : SingleTenantedEventSlicingCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;

--- a/src/Marten.Testing/Harness/MartenComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenComplianceFixture.cs
@@ -283,6 +283,29 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
 
         public void AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle)
             => _options.Projections.Add((IProjectionSource<IDocumentOperations, IQuerySession>)projection, lifecycle);
+
+        /// <summary>
+        ///     jasperfx#725 (#5335) — exactly the forward-plus-adapter the seam documents: the calls are
+        ///     identical across the products but the composite type is Marten's own, so the adapter's only
+        ///     job is to drop the DocumentMappingExpression return value that Marten's Snapshot has and the
+        ///     void-returning shared member deliberately does not.
+        /// </summary>
+        public void AddCompositeProjection(string name, Action<IComplianceCompositeBuilder> configure)
+            => _options.Projections.CompositeProjectionFor(name,
+                composite => configure(new MartenCompositeBuilder(composite)));
+
+        private sealed class MartenCompositeBuilder: IComplianceCompositeBuilder
+        {
+            private readonly Marten.Events.Projections.CompositeProjection _composite;
+
+            public MartenCompositeBuilder(Marten.Events.Projections.CompositeProjection composite)
+            {
+                _composite = composite;
+            }
+
+            public void Snapshot<TDoc>(int stageNumber) where TDoc : notnull
+                => _composite.Snapshot<TDoc>(stageNumber);
+        }
     }
 
     internal class MartenComplianceBatch: IComplianceBatch


### PR DESCRIPTION
Closes #5335. Enrolls the last two unenrolled suites from `JasperFx.Events.ComplianceTests` 2.63.0, taking Marten from 37 of 39 shipped suites to 39 of 39. Tracked by Stoat plan `event-compliance-wave-13`, node `marten-enroll-composite`.

## What changed

- **`MartenComplianceFixture.MartenComplianceRegistrar`** now implements the opt-in `AddCompositeProjection` seam member (jasperfx#725) — the forward-plus-adapter the seam's own docs describe, over `Projections.CompositeProjectionFor(name, configure)`. The private adapter exists only to drop the `DocumentMappingExpression<T>` return value that Marten's `CompositeProjection.Snapshot<T>(stage)` has and the void-returning `IComplianceCompositeBuilder.Snapshot<TDoc>(int)` deliberately does not.
- **`src/EventSourcingTests/Compliance/marten_event_store_compliance_wave13.cs`** — the usual two empty enrollment subclasses closing the suites over `MartenComplianceFixture, IDocumentOperations, IQuerySession`.

Enrollment runs against the pinned published package (2.63.0 already ships both suites); no `ComplianceSourceDir` swap or JasperFx bump needed.

## Test results (PostgreSQL 17, net10.0)

```
total: 4, failed: 0, succeeded: 3, skipped: 1
```

- **`composite_projection_compliance`** — all three facts pass: every stage materializes from one async pass, rebuild tears members down rather than replaying over them, and the composite presents itself as exactly one shard.
- **`single_tenanted_event_slicing_compliance`** — enrolls and compiles, and its honest-skip guard fires at runtime: *"This event store normalized the appended tenant ids down to 1 distinct value(s) on a single-tenanted store."* This is a **measurement, not a behavior gap**: Marten's append path stamps `IEvent.TenantId` from the session exactly like Polecat and Fisher do (jasperfx#727 had left Marten as the one store where the precondition was "plausibly" constructible — measured here, it is not). The marten#4085 behavior itself remains covered by `Bug_4085_async_projection_with_mixed_tenant_ids`, which seeds the disagreeing rows by SQL UPDATE for precisely this reason and already cites jasperfx#727. Nothing here was weakened to get green; the skip is the suite reporting the truth, and this run is a data point for settling jasperfx#727 (it strengthens option 1 there — retire the suite in favor of the store-local regression tests).

## Local tests that are now candidates for retirement (NOT removed here — separate wave-13 node)

With the composite suite enrolled, these `src/DaemonTests/Composites/` tests overlap the shared facts and are worth assessing for retirement in the dedicated retirement node:

- `Bug_5175_composite_member_teardown.cs` — same class of failure as the suite's rebuild-teardown fact (the suite's own docs name this test as the local guard it replaces).
- The single-pass/staged-materialization portions of `multi_stage_projections.cs` and `composite_single_pass_rebuild.cs` — overlap the every-stage-from-one-async-pass and rebuild facts, though both files also cover Marten-specific ground (fan-out, side-effect suppression) the shared suite deliberately does not.

The remaining composite tests (`Bug_4093`, `Bug_4329`, `Feature_4284`, service-provider attachment, `end_to_end_with_composite_projection`) cover Marten-specific behavior outside the shared contract and should stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)