### PR TITLE
Retire leftover duplicates of types lifted to shared packages

### DIFF
--- a/src/CoreTests/Exceptions/ApplyEventExceptionTests.cs
+++ b/src/CoreTests/Exceptions/ApplyEventExceptionTests.cs
@@ -6,6 +6,11 @@ using Xunit;
 
 namespace CoreTests.Exceptions;
 
+// #5337: Marten.Exceptions.ApplyEventException is [Obsolete] (superseded by
+// JasperFx.Events.Daemon.ApplyEventException) but stays through 9.x for compat;
+// this test pins the no-event-data message shape for as long as the type exists.
+#pragma warning disable CS0618
+
 public class ApplyEventExceptionTests
 {
     public class FakeEventThatContainsSecretInformation

--- a/src/Marten/Exceptions/ApplyEventException.cs
+++ b/src/Marten/Exceptions/ApplyEventException.cs
@@ -4,6 +4,12 @@ using Marten.Events;
 
 namespace Marten.Exceptions;
 
+// #5337: dead compat type. Since the async daemon moved to JasperFx.Events, apply
+// failures throw JasperFx.Events.Daemon.ApplyEventException — nothing in Marten
+// throws this type any longer. It stays (as [Obsolete]) so existing catch blocks
+// keep compiling through 9.x; catch the JasperFx.Events.Daemon type instead.
+[Obsolete(
+    "Marten no longer throws this type. Catch JasperFx.Events.Daemon.ApplyEventException instead. This duplicate will be removed in Marten 10.")]
 public class ApplyEventException: MartenException
 {
     public ApplyEventException(IEvent @event, Exception innerException): base(

--- a/src/Marten/Internal/WalkReferencedAssemblies.cs
+++ b/src/Marten/Internal/WalkReferencedAssemblies.cs
@@ -1,32 +1,18 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 
 namespace Marten.Internal;
 
+// #5337: this used to be a byte-identical local copy of what is now
+// JasperFx.Core.Reflection.WalkReferencedAssemblies. Nothing in the Marten solution
+// uses it any longer; the shell stays (delegating, [Obsolete]) only because the type
+// is public and a third-party consumer could reference it.
+[Obsolete("Use JasperFx.Core.Reflection.WalkReferencedAssemblies instead. This duplicate will be removed in Marten 10.")]
 public static class WalkReferencedAssemblies
 {
     public static IEnumerable<Assembly> ForTypes(params Type[] types)
     {
-        var stack = new Stack<Type>();
-
-        foreach (var type in types)
-        {
-            stack.Push(type);
-
-            while (stack.Count > 0)
-            {
-                var current = stack.Pop();
-                yield return current.Assembly;
-
-                if (!current.IsGenericType || current.IsGenericTypeDefinition)
-                {
-                    continue;
-                }
-
-                var typeArguments = current.GetGenericArguments();
-                foreach (var typeArgument in typeArguments) stack.Push(typeArgument);
-            }
-        }
+        return JasperFx.Core.Reflection.WalkReferencedAssemblies.ForTypes(types);
     }
 }


### PR DESCRIPTION
Closes #5337. Stoat plan `internals-lifting-2026-09`, node `marten-shared-leftovers`.

Sweep of master for local duplicates of types lifted into the shared packages (Weasel.Core / Weasel.Storage / JasperFx / JasperFx.Events) consumed by Polecat and Fisher.

## Verified already handled on master (no change needed)

The 8.0-branch analysis items were stale: `HiloSequence` already subclasses `Weasel.Core.Sequences.HiloSequenceBase` with the support types aliased in `src/Shared/DedupeAliases.cs`; `BulkInsertMode.cs` and `OperationRole.cs` are gone (relocations documented in `docs/migration-guide.md`); `IStorageOperation` is a deliberate bridge over `Weasel.Storage.IStorageOperation`, not a duplicate. Full inventory of same-named-but-intentional types is in #5337.

## Changes

* **`Marten.Internal.WalkReferencedAssemblies`** — was a byte-identical duplicate of `JasperFx.Core.Reflection.WalkReferencedAssemblies`, unused anywhere in the solution. Now delegates to the JasperFx copy and is `[Obsolete]` (kept because the type is public).
* **`Marten.Exceptions.ApplyEventException`** — dead public type; the daemon has thrown `JasperFx.Events.Daemon.ApplyEventException` since the JasperFx.Events consumption. Now `[Obsolete]` pointing at the JasperFx.Events type; still compiles for existing catch blocks through 9.x. The message-shape test keeps pinning the no-event-data behavior under `#pragma warning disable CS0618`.

Nothing here breaks a compiling Marten 9 consumer — both types keep their name, namespace, and members; the only change visible to consumers is an obsolescence warning.

## Deferred (see #5337)

* `Marten.CollectionStorage` duplicates `Weasel.Core.CollectionStorage` (weasel#286) but is the declared type of public `SerializerOptions.CollectionStorage` and used by `Marten.Newtonsoft` — retiring it mid-9.x breaks source compat; Marten 10 item.
* Internal `SubscriptionWrapper` / `ScopedSubscriptionServiceWrapper` parallel same-named internal generics in JasperFx.Events, which Marten cannot consume while they are `internal`.

## Testing

* `src/Marten` builds clean (0 errors).
* CoreTests: 599 passed / 4 failed / 7 skipped — the 4 failures ("Unable to attain a global lock in time order to apply database changes") reproduce identically on unmodified `origin/master` under the same parallel run against the shared Postgres, and each passes in isolation; environmental, not from this change.
* HiLo/identity areas: DocumentDbTests `Writing.Identity.Sequences` 28/28 passed; CoreTests `Storage.Identification` + `ApplyEventException` 93/93 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
