### PR TITLE
Flat-table Increment(column) counts the creating event

### DIFF
--- a/src/Marten/Events/Projections/Flattened/IncrementMap.cs
+++ b/src/Marten/Events/Projections/Flattened/IncrementMap.cs
@@ -29,7 +29,9 @@ internal class IncrementMap: IColumnMap
 
     public string ToInsertExpression(Table table)
     {
-        return "0";
+        // The creating event counts: after one event the column reads 1, not 0. Polecat, Fisher and
+        // the lifted Weasel.Storage DSL all insert 1; Marten's 0 was an off-by-one (marten#5341).
+        return "1";
     }
 
 }


### PR DESCRIPTION
`IncrementMap.ToInsertExpression` returned `0`, so the event that created the row was never counted — the column read N-1 after N events. Polecat, Fisher and the lifted `Weasel.Storage.Flattened` DSL all insert `1`.

Maintainer ruling on #5341: **1 is correct, Marten was wrong.**

**Behaviour change.** A flat table's incremented column will read one higher for rows created after this ships; existing rows are untouched. Anyone whose downstream reporting compensated for the old value should be told — worth a release note.

Note the 34 existing `Flattened` tests pass both before and after this change, because none of them appends an increment event to a stream that has no row yet. The shared `FlatTableProjectionCompliance` suite names that exact edge in its remarks but does not test it either — a companion PR in JasperFx adds the missing fact, which is what will keep the three stores honest going forward.

Local runs are the gate per the September policy; org Actions runners are stalled. `EventSourcingTests` `~Flattened` filter: 34 passed, 0 failed (net10.0, PostgreSQL 17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)