### PR TITLE
Adopt JasperFx 2.64.0 and enroll the wave-14 compliance suites

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -416,16 +416,47 @@
          Marten's implementation is the dedicated provider in Marten.Events.Querying (marten#5333;
          see StreamStateQueryable.cs for why it is not the general LINQ engine), the watermark is a
          new mt_streams compacted_version column written by CompactStreamAsync, and the new
-         StreamStateQueryCompliance suite is enrolled as compliance wave 12. -->
-    <PackageVersion Include="JasperFx" Version="2.63.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.63.0" />
+         StreamStateQueryCompliance suite is enrolled as compliance wave 12.
+
+         JasperFx 2.64.0 (marten#5343): the largest compliance wave yet, and the first one where
+         Marten's enrollment is the ONLY runtime validation the suites have ever had — the JasperFx
+         repo enrolls the document suites but no event store, so everything below shipped
+         compile-checked and design-reasoned only. Nothing outside JasperFx.Events.ComplianceTests
+         changed behaviourally for Marten except jasperfx#756 (the per-store event exception types
+         lifted into JasperFx.Events) and jasperfx#753 (CompositeIProjectionSource moved into
+         JasperFx.Events.Projections.Composite), both of which Marten already consumes through the
+         shared namespaces.
+
+         New suites, and what each one needs from the fixture:
+         jasperfx#764/#765 (+#772) NaturalKeyCompliance => SupportsNaturalKeys, no seam member.
+         jasperfx#754/#758 AggregateTo{Many,LinqOperator} => AggregateEventsTo{,Many}Async.
+         jasperfx#755/#759 DcbHasTagLinqCompliance => QueryRawEventsAsync + HasTagFilter.
+         jasperfx#763/#767 ProjectionSideEffectCompliance => IComplianceStoreRegistrar.UseMessageOutbox
+                                                              plus the RecordingMessageOutbox partials.
+         jasperfx#762/#766 AlwaysEnforceConsistency => no seam member.
+                           StreamQueryPlanCompliance => Fetch{StreamState,Stream}ByPlanAsync.
+         jasperfx#769/#771 ProjectionScenarioCompliance => Run/CreateProjectionScenario.
+         jasperfx#732/#760 ProjectionCoordinatorCompliance => StartCoordinatorHostAsync. Deliberately
+                                                              ungated: it is the suite that would have
+                                                              caught fisher#138, so a store that enrolls
+                                                              it without the seam FAILS rather than skips.
+         jasperfx#757 UpcastingCompliance => SupportsUpcasting + registrar Upcast.
+
+         Deepened suites Marten already enrolls, which gain facts on this bump with no new seam:
+         jasperfx#768/#770 SubscriptionCompliance grows rewind, event filters, session writes and a
+         listener; jasperfx#762 adds facts to FetchLatestCompliance, StreamArchivingCompliance,
+         EventDataMaskingCompliance and StrongTypedIdentityCompliance; jasperfx#774/#775 add the two
+         FlatTableProjectionCompliance facts that pin Increment/Decrement onto a row that does not
+         exist yet => the increment half is marten#5342, already fixed on this branch's base. -->
+    <PackageVersion Include="JasperFx" Version="2.64.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.64.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.63.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.64.0" />
     <!--
       No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
       whole family moves together, and this note is kept for the history below. This package is
@@ -444,11 +475,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.63.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.64.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.63.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.64.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave14.cs
+++ b/src/EventSourcingTests/Compliance/marten_event_store_compliance_wave14.cs
@@ -1,0 +1,113 @@
+using JasperFx.Events.ComplianceTests;
+using Marten;
+using Marten.Testing.Harness;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * Wave 14 (#5343) -- the JasperFx 2.64.0 compliance wave, and the largest single enrollment so far.
+ *
+ * What makes this wave different from every one before it: NONE of these suites had ever been
+ * executed against a real event store. The JasperFx repo enrolls the document suites but no event
+ * store, so all of the below shipped compile-checked and design-reasoned only, and Marten running
+ * them here is their first runtime validation. That is the point of the exercise rather than a
+ * caveat on it -- see the PR for what the first run actually found.
+ *
+ * Same shape as the earlier enrollment files: empty subclasses closing the shared suites over
+ * Marten's session pair. What is NOT empty is MartenComplianceFixture, which grows a seam member
+ * for most of these; each suite gates on a Supports... flag defaulting false plus a seam with a
+ * throwing default, so enrolling means implementing the Marten half. The flags Marten leaves false
+ * are documented at their declaration in the fixture rather than here.
+ */
+
+/// <summary>
+///     jasperfx#764/#765 (+#772). Marten's [NaturalKey] storage half -- the mt_natural_key_X lookup
+///     table maintained by the auto-registered NaturalKeyProjection (#4788) -- resolving the shared
+///     FetchForWriting / FetchForExclusiveWriting / FetchLatest triple through it, including the
+///     uniqueness ruling that a second claimant of a live key is refused.
+/// </summary>
+public class natural_key_compliance
+    : NaturalKeyCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+/// <summary>
+///     jasperfx#754. The AggregateToAsync half: folding an ad hoc raw-event query into a single
+///     aggregate over Marten's derived live aggregator, with identity stamped from the stream.
+/// </summary>
+public class aggregate_to_linq_operator_compliance
+    : AggregateToLinqOperatorCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+/// <summary>
+///     jasperfx#754. The AggregateToManyAsync half, and the more demanding of the pair: the operator
+///     has to drive the REGISTERED multi-stream projection -- identity routing, a session-reading
+///     custom grouper, ShouldDelete -- rather than reimplementing the fold inline. The projections
+///     are registered Async with the daemon never started, so every aggregate the suite asserts on
+///     can only have come from the live fold.
+/// </summary>
+public class aggregate_to_many_compliance
+    : AggregateToManyCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+/// <summary>
+///     jasperfx#755. HasTag&lt;TTag&gt; predicates inside an event LINQ query, composed with ordinary
+///     event predicates in ONE predicate tree -- which is why the fixture seam applies its filter in
+///     a single Where() rather than chaining.
+/// </summary>
+public class dcb_has_tag_linq_compliance
+    : DcbHasTagLinqCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+/// <summary>
+///     jasperfx#763. RaiseSideEffects: raised events, published messages, and their suppression
+///     during a rebuild. The expensive one to enroll (a projection base alias, a registrar member and
+///     two consumer partials on RecordingMessageOutbox/RecordingMessageBatch), and worth it -- the
+///     half underneath the shared raise seam is each store's own, and has shipped STUBBED EMPTY
+///     twice (fisher#61, polecat#420), dropping every raised event with no error and no log. A store
+///     that did that passes every other suite in the library.
+/// </summary>
+public class projection_side_effect_compliance
+    : ProjectionSideEffectCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+/// <summary>
+///     jasperfx#762. AlwaysEnforceConsistency -- the store-wide opt-in that makes every append
+///     assert the stream version it was handed.
+/// </summary>
+public class always_enforce_consistency_compliance
+    : AlwaysEnforceConsistencyCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+/// <summary>
+///     jasperfx#762. Marten's FetchStreamStatePlan / FetchStreamPlan, run BOTH standalone and inside
+///     a batched query -- the two paths compose their SQL separately, so a plan that is right one way
+///     and wrong the other is exactly what this suite is looking for.
+/// </summary>
+public class stream_query_plan_compliance
+    : StreamQueryPlanCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+/// <summary>
+///     jasperfx#769. The shared ProjectionScenario harness (lifted into JasperFx.Events.TestSupport
+///     in 2.38.0) reached through Marten's own documented entry point,
+///     Advanced.EventProjectionScenario -- the route is under test as much as the harness, so the
+///     fixture seam forwards to it rather than reimplementing its three lines.
+/// </summary>
+public class projection_scenario_compliance
+    : ProjectionScenarioCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+/// <summary>
+///     jasperfx#732/#760. The one suite here with NO capability gate and no skip, deliberately: it
+///     asserts that Marten's DOCUMENTED DI registration -- AddMarten(...).AddAsyncDaemon(...) --
+///     produces a reachable IProjectionCoordinator. Every other daemon suite drives a daemon the
+///     fixture built by hand, which can never observe that; fisher#138 shipped exactly that gap and
+///     passed all 37 suites while it did. A store that enrolls this without implementing
+///     StartCoordinatorHostAsync fails every fact rather than skipping, because a skippable
+///     registration check recreates the silent gap the suite exists to close.
+/// </summary>
+public class projection_coordinator_compliance
+    : ProjectionCoordinatorCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;
+
+/// <summary>
+///     jasperfx#752/#757. Enrolled but SKIPPING wholesale, and deliberately so rather than as
+///     unfinished work here: this is the first suite in the library written ahead of any store
+///     implementing the behavior. Marten has had upcasting since v5, but it is Marten's own
+///     implementation rather than the shared JasperFx.Events.Upcasting registry the suite asserts on
+///     -- see the SupportsUpcasting comment on MartenComplianceFixture for the detail. Enrolling it
+///     now means it compiles and runs from the moment the flag flips, instead of being remembered.
+/// </summary>
+public class upcasting_compliance
+    : UpcastingCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;

--- a/src/EventSourcingTests/EventSourcingTests.csproj
+++ b/src/EventSourcingTests/EventSourcingTests.csproj
@@ -85,6 +85,9 @@
         <Compile Include="..\Marten.Testing\Harness\ComplianceSubscription.Marten.cs">
             <Link>Harness\ComplianceSubscription.Marten.cs</Link>
         </Compile>
+        <Compile Include="..\Marten.Testing\Harness\RecordingMessageOutbox.Marten.cs">
+            <Link>Harness\RecordingMessageOutbox.Marten.cs</Link>
+        </Compile>
         <Compile Include="..\Marten.Testing\Harness\MartenComplianceFixture.cs">
             <Link>Harness\MartenComplianceFixture.cs</Link>
         </Compile>

--- a/src/Marten.Testing/Harness/ComplianceQuerySessionAlias.cs
+++ b/src/Marten.Testing/Harness/ComplianceQuerySessionAlias.cs
@@ -21,3 +21,22 @@ global using ComplianceStringPartyProjectionBase =
 global using ComplianceMultiStreamProjectionBase =
     Marten.Events.Projections.MultiStreamProjection<
         JasperFx.Events.ComplianceTests.ComplianceDepartment, string>;
+
+// jasperfx#754 (marten#5343). AggregateToManyCompliance's whole point is that the operator drives
+// the REGISTERED projection -- identity routing, a session-reading custom grouper, ShouldDelete --
+// rather than reimplementing the fold inline, so its two multi-stream projections are real
+// registrations declared at file scope, and need the same closed-generic alias as the department
+// projection above.
+global using ComplianceBalanceProjectionBase =
+    Marten.Events.Projections.MultiStreamProjection<
+        JasperFx.Events.ComplianceTests.ComplianceBalance, System.Guid>;
+global using ComplianceMemberLoyaltyProjectionBase =
+    Marten.Events.Projections.MultiStreamProjection<
+        JasperFx.Events.ComplianceTests.ComplianceMemberLoyalty, System.Guid>;
+
+// jasperfx#763 (marten#5343). ProjectionSideEffectCompliance's projection has to OVERRIDE
+// RaiseSideEffects, so it must derive from Marten's own SingleStreamProjection<TDoc, TId> rather
+// than anything the suite could name itself.
+global using ComplianceWatchtowerProjectionBase =
+    Marten.Events.Aggregation.SingleStreamProjection<
+        JasperFx.Events.ComplianceTests.ComplianceWatchtower, System.Guid>;

--- a/src/Marten.Testing/Harness/ComplianceSubscription.Marten.cs
+++ b/src/Marten.Testing/Harness/ComplianceSubscription.Marten.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten;
+using Marten.Services;
 using Marten.Subscriptions;
 
 namespace JasperFx.Events.ComplianceTests;
@@ -16,8 +17,21 @@ namespace JasperFx.Events.ComplianceTests;
  * IDocumentOperations, CancellationToken) -- but IChangeListener is a per-product type, so the
  * signature cannot be written once in the shared source.
  *
- * NullChangeListener.Instance is the documented "I do not need to be signalled" return on both
- * products; it is spelled the same in each, but on each product's own type.
+ * jasperfx#768 (marten#5343) deepened the suite past mere delivery, and the two guarantees it
+ * added both land in this partial rather than in the library:
+ *
+ *  - Writes through the SUPPLIED session must be committed with the batch. The library builds the
+ *    notes (NotesFor) and asserts on them; the operations.Store call has to happen here because
+ *    the session type is Marten's.
+ *  - The IChangeListener returned from ProcessEventsAsync must actually be called after the commit.
+ *    This used to return NullChangeListener.Instance -- the documented "I do not need to be
+ *    signalled" return -- which is exactly what the new facts exist to catch: a store that drops
+ *    the listener, or hands out a session it never commits, passes every delivery fact in the suite
+ *    while doing neither. Neither fact is gated, for that reason.
+ *
+ * IChangeListener is a per-product type, so the listener is declared here rather than shared; the
+ * library exposes RecordCommitAsync as a public member precisely so a consumer can call it from a
+ * nested type like this one.
  *
  * Lives beside MartenComplianceFixture rather than in EventSourcingTests because both assemblies
  * reference the source-only compliance package and therefore both compile the library's half of
@@ -30,8 +44,29 @@ public partial class ComplianceSubscription: ISubscription
     {
         Record(page.Events);
 
-        return Task.FromResult(NullChangeListener.Instance);
+        foreach (var note in NotesFor(page))
+        {
+            operations.Store(note);
+        }
+
+        return Task.FromResult<IChangeListener>(new Listener(this));
     }
 
     public ValueTask DisposeAsync() => default;
+
+    private sealed class Listener: IChangeListener
+    {
+        private readonly ComplianceSubscription _subscription;
+
+        public Listener(ComplianceSubscription subscription)
+        {
+            _subscription = subscription;
+        }
+
+        public Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+            => _subscription.RecordCommitAsync();
+
+        public Task BeforeCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+            => Task.CompletedTask;
+    }
 }

--- a/src/Marten.Testing/Harness/MartenComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenComplianceFixture.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx;
@@ -10,6 +12,9 @@ using JasperFx.Events.Projections;
 using JasperFx.Events.Tags;
 using Marten.Events;
 using Marten.Services.BatchQuerying;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 
 namespace Marten.Testing.Harness;
@@ -66,6 +71,15 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
         if (config.ConjoinedEventTenancy)
         {
             options.Events.TenancyStyle = JasperFx.MultiTenancy.TenancyStyle.Conjoined;
+
+            // #5343: conjoined EVENTS are not enough on their own once the configuration also
+            // registers a snapshot. Marten refuses to build a store whose events are Conjoined but
+            // whose projected aggregate document is Single ("Tenancy storage style mismatch"), and
+            // that is Marten telling the truth rather than being fussy -- a per-tenant event slice
+            // folded into a single-tenanted document would silently merge tenants in the read model.
+            // Every earlier conjoined suite registered no projection, so this pairing first appears
+            // with NaturalKeyCompliance's tenanted configuration.
+            options.Policies.AllDocumentsAreMultiTenanted();
         }
 
         config.ApplyTo(new MartenComplianceRegistrar(options));
@@ -197,6 +211,290 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
         Action<JasperFx.Events.Protected.IEventDataMasking> configure, CancellationToken token)
         => _store.Advanced.ApplyEventDataMasking(configure, token);
 
+    // ---------------------------------------------------------------------------------------
+    // JasperFx 2.64.0 compliance wave (marten#5343). Everything below is either a seam member
+    // with a throwing default in the shared fixture, or the capability flag that gates it.
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    ///     jasperfx#755. Marten translates the HasTag marker by matching the declaring type in its LINQ
+    ///     parser, so the predicate has to be built here where Marten's own extension is in scope; a
+    ///     lambda written in the shared source would carry the wrong MethodInfo and never be recognized.
+    ///     Deliberately does not validate the tag type -- an unregistered tag must throw at query
+    ///     translation, which is the behavior the suite pins.
+    /// </summary>
+    public override Expression<Func<IEvent, bool>> HasTagFilter<TTag>(TTag value)
+        => e => e.HasTag(value);
+
+    /// <summary>
+    ///     The single-Where contract is load-bearing rather than incidental: the HasTag facts assert
+    ///     that a tag predicate composes with ordinary event predicates inside ONE predicate tree,
+    ///     which two chained Where() calls would not exercise.
+    /// </summary>
+    public override async Task<IReadOnlyList<IEvent>> QueryRawEventsAsync(IQuerySession session,
+        Expression<Func<IEvent, bool>> filter, CancellationToken token)
+        => await session.Events.QueryAllRawEvents().Where(filter).ToListAsync(token).ConfigureAwait(false);
+
+    public override bool SupportsHasTagLinqPredicates => true;
+
+    /// <summary>
+    ///     jasperfx#754. Marten's AggregateToAsync / AggregateToManyAsync ride on QueryAllRawEvents(),
+    ///     which returns IMartenQueryable and so is deliberately outside the shared IQueryEventStore
+    ///     contract -- hence the seam. Both members apply the optional predicate in a single Where()
+    ///     and then hand off to Marten's own terminator; no ordering and no paging, so this cannot
+    ///     grow into pinning Marten's operator set.
+    /// </summary>
+    public override Task<T?> AggregateEventsToAsync<T>(IQuerySession session,
+        Expression<Func<IEvent, bool>>? filter, T? initialState, CancellationToken token)
+        where T : class
+    {
+        var queryable = session.Events.QueryAllRawEvents();
+
+        return filter == null
+            ? queryable.AggregateToAsync(initialState, token)
+            : queryable.Where(filter).AggregateToAsync(initialState, token);
+    }
+
+    /// <inheritdoc cref="AggregateEventsToAsync{T}" />
+    public override Task<IReadOnlyList<T>> AggregateEventsToManyAsync<T>(IQuerySession session,
+        Expression<Func<IEvent, bool>>? filter, CancellationToken token)
+        where T : class
+    {
+        var queryable = session.Events.QueryAllRawEvents();
+
+        return filter == null
+            ? queryable.AggregateToManyAsync<T>(token)
+            : queryable.Where(filter).AggregateToManyAsync<T>(token);
+    }
+
+    public override bool SupportsAggregateToLinqOperators => true;
+
+    /// <summary>
+    ///     jasperfx#764 (#4788). Marten maintains an mt_natural_key_X lookup table per aggregate
+    ///     carrying a [NaturalKey], written by the auto-registered NaturalKeyProjection, and resolves
+    ///     the FetchForWriting / FetchForExclusiveWriting / FetchLatest triple through it.
+    /// </summary>
+    public override bool SupportsNaturalKeys => true;
+
+    /// <summary>
+    ///     jasperfx#762. Both plan types ship on Marten (Marten.FetchStreamStatePlan /
+    ///     Marten.FetchStreamPlan), each implementing IQueryPlan&lt;T&gt; and IBatchQueryPlan&lt;T&gt;
+    ///     so the same instance can run standalone or inside a batch.
+    /// </summary>
+    public override bool SupportsStreamQueryPlans => true;
+
+    public override async Task<StreamState?> FetchStreamStateByPlanAsync(
+        IQuerySession session, object streamIdentity, bool batched, CancellationToken token)
+    {
+        var plan = streamIdentity switch
+        {
+            Guid streamId => new FetchStreamStatePlan(streamId),
+            string streamKey => new FetchStreamStatePlan(streamKey),
+            _ => throw new ArgumentOutOfRangeException(nameof(streamIdentity),
+                $"Marten streams are identified by Guid or string, not {streamIdentity.GetType().FullName}")
+        };
+
+        if (!batched)
+        {
+            return await session.QueryByPlanAsync(plan, token).ConfigureAwait(false);
+        }
+
+        // The batched path composes its SQL separately from the standalone one, which is exactly
+        // why the suite runs every fact both ways.
+        var batch = session.CreateBatchQuery();
+        var result = batch.QueryByPlan(plan);
+        await batch.Execute(token).ConfigureAwait(false);
+
+        return await result.ConfigureAwait(false);
+    }
+
+    /// <inheritdoc cref="FetchStreamStateByPlanAsync" />
+    public override async Task<IReadOnlyList<IEvent>> FetchStreamByPlanAsync(
+        IQuerySession session, object streamIdentity, long version, bool batched, CancellationToken token)
+    {
+        var plan = streamIdentity switch
+        {
+            Guid streamId => new FetchStreamPlan(streamId, version),
+            string streamKey => new FetchStreamPlan(streamKey, version),
+            _ => throw new ArgumentOutOfRangeException(nameof(streamIdentity),
+                $"Marten streams are identified by Guid or string, not {streamIdentity.GetType().FullName}")
+        };
+
+        if (!batched)
+        {
+            return await session.QueryByPlanAsync(plan, token).ConfigureAwait(false);
+        }
+
+        var batch = session.CreateBatchQuery();
+        var result = batch.QueryByPlan(plan);
+        await batch.Execute(token).ConfigureAwait(false);
+
+        return await result.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     jasperfx#769. A forward, never a re-implementation -- the suite is testing Marten's own
+    ///     advertised entry point as much as the shared harness behind it, so inlining the three
+    ///     lines Advanced.EventProjectionScenario runs would pass every fact while that entry point
+    ///     was missing or wired to the wrong store.
+    /// </summary>
+    public override Task RunProjectionScenarioAsync(
+        Action<JasperFx.Events.TestSupport.ProjectionScenario<IDocumentOperations, IQuerySession>> configure,
+        CancellationToken token)
+        => _store.Advanced.EventProjectionScenario(scenario => configure(scenario), token);
+
+    /// <summary>
+    ///     For the one fact the run entry point structurally cannot reach: a scenario's steps are
+    ///     consumed by its first run, so proving a second run fails loudly rather than passing as a
+    ///     silent no-op needs a handle on the instance, and the entry point above constructs one and
+    ///     throws it away.
+    /// </summary>
+    public override JasperFx.Events.TestSupport.ProjectionScenario<IDocumentOperations, IQuerySession>
+        CreateProjectionScenario()
+        => new Marten.Events.TestSupport.ProjectionScenario(_store);
+
+    public override bool SupportsProjectionScenario => true;
+
+    /// <summary>
+    ///     PostgreSQL is an MVCC snapshot reader: a second connection reading a row the first
+    ///     connection's open transaction is mid-write sees the pre-write snapshot and returns
+    ///     immediately rather than blocking on a lock. That is precisely the property this flag is
+    ///     asking about, so the before-commit probe cannot deadlock against the hook holding the
+    ///     commit open.
+    /// </summary>
+    public override bool SupportsCommitVisibilityProbe => true;
+
+    public override bool SupportsSubscriptionEventFilters => true;
+
+    /// <summary>
+    ///     jasperfx#763. Marten has a real message outbox seam -- Events.MessageOutbox, defaulted to
+    ///     NulloMessageOutbox and replaced by the Wolverine integration -- and routes a projection's
+    ///     published side effects through it, so the outbox facts run rather than skip.
+    /// </summary>
+    public override bool SupportsMessageOutbox => true;
+
+    /// <summary>
+    ///     jasperfx#732. Marten's documented registration -- AddMarten(...).AddAsyncDaemon(...) --
+    ///     is what has to be under test here, not a hand-built daemon, because the gap this suite
+    ///     exists to close (fisher#138) was a store that produced no reachable IProjectionCoordinator
+    ///     from its documented DI registration while passing all 37 other suites.
+    /// </summary>
+    public override bool SupportsAncillaryCoordinators => true;
+
+    /// <summary>
+    ///     Resolves MARTEN's IProjectionCoordinator&lt;T&gt;, not the shared one. AddMartenStore&lt;T&gt;
+    ///     registers the singleton against Marten.Events.Daemon.Coordination.IProjectionCoordinator&lt;T&gt;
+    ///     only; that interface derives from the JasperFx one, so the shared seam is satisfied, and
+    ///     resolving the product's own marker-typed service is exactly the per-product asymmetry this
+    ///     seam exists to absorb.
+    /// </summary>
+    public override IProjectionCoordinator AncillaryCoordinatorFrom(IServiceProvider services)
+        => services
+            .GetRequiredService<Marten.Events.Daemon.Coordination.IProjectionCoordinator<IComplianceAncillaryStore>>();
+
+    protected override async Task<IComplianceCoordinatorHost<IDocumentOperations>> StartCoordinatorHostAsync(
+        ComplianceStoreConfig config, bool includeAncillaryStore)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+
+        var schemaName = (config.SchemaName ?? "compliance").ToLowerInvariant();
+
+        builder.Services.AddMarten(options =>
+            {
+                options.Connection(connectionStringFor(config));
+                options.AutoCreateSchemaObjects = AutoCreate.All;
+                options.DisableNpgsqlLogging = true;
+                options.NameDataLength = 100;
+
+                // The same database AND the same schema as the fixture's own store, so the
+                // per-test CleanEventDataAsync isolation covers the hosted store too.
+                options.DatabaseSchemaName = schemaName;
+
+                if (config.StreamIdentity.HasValue)
+                {
+                    options.Events.StreamIdentity = config.StreamIdentity.Value;
+                }
+
+                config.ApplyTo(new MartenComplianceRegistrar(options));
+            })
+            .AddAsyncDaemon(DaemonMode.Solo);
+
+        if (includeAncillaryStore)
+        {
+            // Only ever registered for the one ancillary fact. Load-bearing that it is NOT
+            // registered otherwise: the suite asserts the hosted-service walk finds EXACTLY one
+            // coordinator, so a second store on the default host would fail every core fact.
+            builder.Services.AddMartenStore<IComplianceAncillaryStore>(options =>
+                {
+                    options.Connection(connectionStringFor(config));
+                    options.AutoCreateSchemaObjects = AutoCreate.All;
+                    options.DisableNpgsqlLogging = true;
+                    options.NameDataLength = 100;
+                    options.DatabaseSchemaName = schemaName + "_ancillary";
+                })
+                .AddAsyncDaemon(DaemonMode.Solo);
+        }
+
+        var host = builder.Build();
+        await host.StartAsync().ConfigureAwait(false);
+
+        return new MartenCoordinatorHost(host);
+    }
+
+    /// <summary>
+    ///     The marker type for the ancillary store in the coordinator suite. A fixture-local type
+    ///     because every product constrains ancillary markers to its own store interface, so only
+    ///     the fixture can name one.
+    /// </summary>
+    public interface IComplianceAncillaryStore: IDocumentStore;
+
+    private sealed class MartenCoordinatorHost: IComplianceCoordinatorHost<IDocumentOperations>
+    {
+        private readonly IHost _host;
+
+        public MartenCoordinatorHost(IHost host)
+        {
+            _host = host;
+        }
+
+        public IServiceProvider Services => _host.Services;
+
+        public IDocumentOperations OpenSession()
+            => _host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+
+        public async ValueTask DisposeAsync()
+        {
+            // IHost.Dispose alone does not call StopAsync, and an abandoned daemon host leaks
+            // agents into the next test.
+            await _host.StopAsync().ConfigureAwait(false);
+            _host.Dispose();
+        }
+    }
+
+    /// <summary>
+    ///     jasperfx#752/#757. Left FALSE deliberately, and this is a real divergence rather than
+    ///     unfinished work on this branch. Marten has had event upcasting since v5, but it is
+    ///     Marten's OWN implementation: registrations hang off IEventStoreOptions.Upcast and the read
+    ///     path routes through EventMapping.IsUpcastTarget, not through the shared
+    ///     JasperFx.Events.Upcasting.EventRegistry.Upcasters registry the suite asserts on, and
+    ///     Marten implements neither IUpcastPayload nor anything else in that namespace. The shared
+    ///     contract was deliberately specified ahead of any store implementing it, so the suite is
+    ///     enrolled here skipping wholesale -- which keeps it compiling and running -- and the flag
+    ///     flips in the node that moves Marten's read path onto the shared registry.
+    /// </summary>
+    public override bool SupportsUpcasting => false;
+
+    /// <summary>
+    ///     Left FALSE because the operation genuinely does not exist in Marten. ArchiveStream is on
+    ///     the shared IEventStoreOptions surface but its reverse is not: Polecat declares
+    ///     UnArchiveStream on its own IEventOperations and Marten has no equivalent at all (nothing
+    ///     in src/Marten matches "UnArchive"), which is why the shared fixture gates it rather than
+    ///     putting it on IEventStoreOperations. The unarchive facts of StreamArchivingCompliance skip;
+    ///     every archiving fact around them still runs.
+    /// </summary>
+    public override bool SupportsUnarchiveStream => false;
+
     public override async ValueTask DisposeAsync()
     {
         foreach (var disposable in _disposables)
@@ -277,9 +575,33 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
         public void AddMaskingRule<TEvent>(Func<TEvent, TEvent> rule) where TEvent : notnull
             => _options.Events.AddMaskingRuleForProtectedInformation(rule);
 
+        /// <summary>
+        ///     The name is pinned because progression is keyed on it and the products disagree on what
+        ///     an unnamed subscription defaults to.
+        ///
+        ///     jasperfx#768 (#5343) adds the filter replay. A list declared on the shared subscription
+        ///     object reaches nothing on its own: Marten wraps a bare ISubscription in its own
+        ///     SubscriptionWrapper, and it is the WRAPPER the daemon reads filters from. Replaying each
+        ///     declared type onto the wrapper's IncludeType is the whole of what
+        ///     SupportsSubscriptionEventFilters gates.
+        /// </summary>
         public void Subscribe(ComplianceSubscription subscription)
-            => _options.Projections.Subscribe(subscription,
-                x => x.Name = ComplianceSubscription.SubscriptionName);
+            => _options.Projections.Subscribe(subscription, x =>
+            {
+                x.Name = ComplianceSubscription.SubscriptionName;
+
+                foreach (var eventType in subscription.IncludedEventTypes)
+                {
+                    x.IncludeType(eventType);
+                }
+            });
+
+        /// <summary>
+        ///     jasperfx#763 (#5343). Every store spells this the same way; the seam exists because
+        ///     IMessageOutbox is a per-product type, so the shared config cannot declare the property.
+        /// </summary>
+        public void UseMessageOutbox(RecordingMessageOutbox outbox)
+            => _options.Events.MessageOutbox = outbox;
 
         public void AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle)
             => _options.Projections.Add((IProjectionSource<IDocumentOperations, IQuerySession>)projection, lifecycle);

--- a/src/Marten.Testing/Harness/RecordingMessageOutbox.Marten.cs
+++ b/src/Marten.Testing/Harness/RecordingMessageOutbox.Marten.cs
@@ -1,0 +1,45 @@
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Internal.Sessions;
+using Marten.Services;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/*
+ * Marten's half of the shared recording message outbox (jasperfx#763, marten#5343).
+ *
+ * Same division of labour as ComplianceSubscription.Marten.cs beside it: the compliance library
+ * owns the recording, the ordering, the commit probe and the locking, and this partial supplies
+ * only the interface implementations that genuinely cannot be written once. IMessageOutbox and
+ * IMessageBatch are per-product types whose members differ -- Marten declares
+ * IMessageBatch : IMessageSink, IChangeListener, so its commit hooks take
+ * (IDocumentSession, IChangeSet, CancellationToken), while Polecat's and Fisher's take a bare
+ * CancellationToken -- and Marten's CreateBatch takes the internal DocumentSessionBase rather than
+ * any shared session type.
+ *
+ * The IMessageSink half -- PublishAsync<T>(T, string) -- is shared and stays in the library, so
+ * nothing here records anything itself; each member is a one-line forward onto the library's
+ * protected recorder.
+ *
+ * Lives beside MartenComplianceFixture rather than in EventSourcingTests for the reason
+ * ComplianceSubscription.Marten.cs documents: both assemblies reference the source-only compliance
+ * package and therefore both compile the library's half of these partials, so both need this half
+ * to satisfy them.
+ */
+public partial class RecordingMessageOutbox: IMessageOutbox
+{
+    public ValueTask<IMessageBatch> CreateBatch(DocumentSessionBase session)
+        => new(NewBatch());
+}
+
+public partial class RecordingMessageBatch: IMessageBatch
+{
+    public Task BeforeCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+        => RecordBeforeCommitAsync();
+
+    public Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+        => RecordAfterCommitAsync();
+}

--- a/src/Marten/GlobalUsings.cs
+++ b/src/Marten/GlobalUsings.cs
@@ -9,3 +9,18 @@ global using ICommandBuilder = Weasel.Postgresql.ICommandBuilder;
 global using ISqlFragment = Weasel.Postgresql.SqlGeneration.ISqlFragment;
 global using ICompoundFragment = Weasel.Postgresql.SqlGeneration.ICompoundFragment;
 
+// jasperfx#756 (marten#5343): JasperFx.Events 2.64.0 adds canonical versions of the six event
+// exception types that until now were declared once per store, so every file importing both
+// JasperFx.Events and Marten.Exceptions sees an ambiguous simple name. Marten's own copies are
+// public API that callers catch by name, and the lift commit is explicit that "stores will
+// subclass or type-forward in a later node" -- so the resolution here is deliberately the
+// API-preserving one: alias the simple names to Marten's types assembly-wide, exactly as the
+// Weasel aliases above do, and leave the consolidation to the node that owns it. Code that wants
+// the shared type fully-qualifies it, which overrides these aliases.
+global using UnknownEventTypeException = Marten.Exceptions.UnknownEventTypeException;
+global using NonExistentStreamException = Marten.Exceptions.NonExistentStreamException;
+global using ExistingStreamIdCollisionException = Marten.Exceptions.ExistingStreamIdCollisionException;
+global using EventDeserializationFailureException = Marten.Exceptions.EventDeserializationFailureException;
+global using StreamLockedException = Marten.Exceptions.StreamLockedException;
+global using DefaultTenantUsageDisabledException = Marten.Exceptions.DefaultTenantUsageDisabledException;
+

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
@@ -57,6 +57,23 @@ public abstract partial class DocumentSessionBase
             await listener.BeforeSaveChangesAsync(this, token).ConfigureAwait(false);
         }
 
+        // #5343: Marten declares IMessageBatch : IMessageSink, IChangeListener -- so it promises BOTH
+        // commit hooks -- but only ever called AfterCommitAsync below. The before hook is the half a
+        // transactional outbox actually needs, because it is the only point at which an outbox can
+        // queue its own operations and have them land in the SAME UpdateBatch, and therefore the same
+        // transaction, as the events that produced the messages. Hence the placement: immediately
+        // after the session listeners' BeforeSaveChangesAsync and before the UpdateBatch is built
+        // from _workTracker, which is exactly the contract those listeners already get.
+        //
+        // Found by the jasperfx#763 ProjectionSideEffectCompliance suite, whose commit-boundary facts
+        // observe what the rest of the database can see at each hook rather than merely that the
+        // hooks ran. Wolverine's MartenToWolverineMessageBatch.BeforeCommitAsync is currently a
+        // no-op, so nothing downstream changes behaviour on this fix today.
+        if (_messageBatch != null)
+        {
+            await _messageBatch.BeforeCommitAsync(this, _workTracker, token).ConfigureAwait(false);
+        }
+
         var batch = new UpdateBatch(_workTracker.AllOperations);
 
         await ExecuteBatchAsync(batch, token).ConfigureAwait(false);

--- a/src/Tests.props
+++ b/src/Tests.props
@@ -58,4 +58,25 @@
         <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     </PropertyGroup>
 
+    <!-- jasperfx#756 (marten#5343). JasperFx.Events 2.64.0 added canonical versions of the six
+         event exception types that were previously declared once per store, so any file importing
+         both JasperFx.Events and Marten.Exceptions now sees an ambiguous simple name (CS0104).
+         Six suites hit it: EventSourcingTests, TenantPartitionedEventsTests, MultiTenancyTests,
+         DaemonTests, DocumentDbTests and CoreTests.
+
+         These aliases are the test-side half of the same API-preserving choice made in
+         src/Marten/GlobalUsings.cs: Marten's own exception types stay the ones Marten's tests
+         assert on, because that is what Marten's callers catch, and the lift commit is explicit
+         that "stores will subclass or type-forward in a later node". When that node lands and
+         Marten's copies become subclasses or type-forwards of the shared ones, both alias blocks
+         go away together. A test that specifically wants the shared type fully-qualifies it. -->
+    <ItemGroup>
+        <Using Include="Marten.Exceptions.UnknownEventTypeException" Alias="UnknownEventTypeException" />
+        <Using Include="Marten.Exceptions.NonExistentStreamException" Alias="NonExistentStreamException" />
+        <Using Include="Marten.Exceptions.ExistingStreamIdCollisionException" Alias="ExistingStreamIdCollisionException" />
+        <Using Include="Marten.Exceptions.EventDeserializationFailureException" Alias="EventDeserializationFailureException" />
+        <Using Include="Marten.Exceptions.StreamLockedException" Alias="StreamLockedException" />
+        <Using Include="Marten.Exceptions.DefaultTenantUsageDisabledException" Alias="DefaultTenantUsageDisabledException" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Closes #5343. Stoat plan node `marten-adopt-wave13`.

Bumps `JasperFx*` to **2.64.0** and enrolls the ten new/deepened event-store compliance suites it ships.

**What makes this wave different:** none of these suites had ever been executed against a real event store. The JasperFx repo enrolls the document suites but no event store, so all ten shipped compile-checked and design-reasoned only. This run is their first runtime validation, and it found **nine genuine bugs** across three repos. That is the deliverable, not a caveat on it.

## Enrolled

`src/EventSourcingTests/Compliance/marten_event_store_compliance_wave14.cs` (wave 13 was taken by #5336):

| Suite | jasperfx | Fixture cost |
|---|---|---|
| `NaturalKeyCompliance` | #764/#765/#772 | flag only |
| `AggregateToLinqOperatorCompliance` | #754 | `AggregateEventsToAsync` |
| `AggregateToManyCompliance` | #754 | `AggregateEventsToManyAsync` + 2 projection aliases |
| `DcbHasTagLinqCompliance` | #755 | `QueryRawEventsAsync` + `HasTagFilter` |
| `ProjectionSideEffectCompliance` | #763 | registrar member, 2 consumer partials, 1 alias |
| `AlwaysEnforceConsistencyCompliance` | #762 | none |
| `StreamQueryPlanCompliance` | #762 | `Fetch{StreamState,Stream}ByPlanAsync` |
| `ProjectionScenarioCompliance` | #769 | `Run`/`CreateProjectionScenario` |
| `ProjectionCoordinatorCompliance` | #732/#760 | `StartCoordinatorHostAsync` — **ungated** |
| `UpcastingCompliance` | #752/#757 | enrolled, skipping (see below) |

Plus the deepened facts on suites already enrolled: `SubscriptionCompliance` (#768), `FetchLatest`/`StreamArchiving`/`EventDataMasking`/`StrongTypedIdentity` (#762), and the two `FlatTableProjectionCompliance` facts pinning increment/decrement onto a row that does not exist yet (#774/#775) — **both pass**, the increment half thanks to #5342 on this branch's base.

`ProjectionCoordinatorCompliance` has no capability gate by design: it asserts that Marten's *documented* DI registration produces a reachable `IProjectionCoordinator`, which every other daemon suite structurally cannot see because they drive a hand-built daemon. fisher#138 shipped exactly that gap and passed all 37 suites while it did.

## Capability flags left false

Both documented where they are declared, the way Fisher documents its slicing skip.

- **`SupportsUpcasting`** — a real divergence, not unfinished work here. Marten has had upcasting since v5, but it is Marten's own: registrations hang off `IEventStoreOptions.Upcast` and the read path routes through `EventMapping.IsUpcastTarget`, not the shared `JasperFx.Events.Upcasting` registry the suite asserts on (Marten implements no part of that namespace). The contract was deliberately specified ahead of any store implementing it. Enrolled and skipping, so it runs the moment the flag flips.
- **`SupportsUnarchiveStream`** — the operation does not exist in Marten. Nothing under `src/Marten` matches `UnArchive`; Polecat declares it on its own `IEventOperations`. Five unarchive facts skip; every archiving fact around them runs.

## Marten fix in this PR

**`IMessageBatch.BeforeCommitAsync` was never called.** Marten declares `IMessageBatch : IMessageSink, IChangeListener` — promising both commit hooks — but `SaveChangesAsync` only ever called the after hook. The before hook is the half a transactional outbox actually needs, because it is the only point at which an outbox can queue its own operations and have them land in the *same* `UpdateBatch`, and therefore the same transaction, as the events that produced the messages. It now runs immediately after the session listeners' `BeforeSaveChangesAsync` and before the batch is built, which is exactly the contract those listeners already get.

Found by the #763 commit-boundary facts, which observe what the rest of the database can see at each hook rather than merely that the hooks ran. Wolverine's `MartenToWolverineMessageBatch.BeforeCommitAsync` is currently a no-op, so nothing downstream changes behaviour today.

## The jasperfx#756 collision

2.64.0 lifted six per-store event exception types into `JasperFx.Events`, making every simple name ambiguous (CS0104) in Marten and six test projects. Resolved the **API-preserving** way — global-using aliases onto Marten's own types, in `src/Marten/GlobalUsings.cs` and `src/Tests.props`, following the Weasel alias precedent already in `GlobalUsings.cs`. Marten's copies are public API that callers catch by name, and the lift commit is explicit that "stores will subclass or type-forward in a later node". Both alias blocks are deleted by #5346.

## Every failure, and how it was classified

Nine, from 517 compliance facts. **None was made green by weakening a suite.**

**Fixed here (2)** — my own enrolment gaps, found by the deepened `SubscriptionCompliance`:
1. `writes_through_the_supplied_session_are_committed_with_the_batch` and `the_listener_returned_by_the_subscription_runs_after_the_commit` — Marten's `ComplianceSubscription` partial stored nothing and returned `NullChangeListener.Instance`. That is precisely what #768 added these ungated facts to catch: a store that hands out a session it never commits, or drops the listener, passes every delivery fact in the suite.
2. Two more fixture bugs of mine: the conjoined-tenancy config needed `AllDocumentsAreMultiTenanted()` once a snapshot was also registered (`NaturalKeyCompliance` is the first suite to combine them), and `AncillaryCoordinatorFrom` must resolve **Marten's** `IProjectionCoordinator<T>`, which derives from the shared one.

**Genuine Marten bug, fixed here (1)** — the missing `BeforeCommitAsync` above, which turned `both_commit_hooks_fire_in_order` and `the_before_hook_runs_inside_the_transaction_and_the_after_hook_outside_it` green.

**Product bug in shared JasperFx code — fixed in jasperfx#780, merged (1)**

`stream_archiving_compliance.capturing_an_archived_event_archives_a_string_identified_stream`. An `Archived` event appended to a snapshotted stream **with no other handled event in the same batch** left `transformed` null in `JasperFxSingleStreamProjectionBase.ApplyInline`, so an early `continue` skipped `maybeArchiveStream` and the stream stayed live.

Stream identity turned out to be irrelevant — I reproduced it under both Guid and string; the string fact is simply the only one of the four archiving facts that appends the marker alone. The tell that it was a bug: `ownsStream: snapshot != null || transformed != null` had a **dead disjunct**, since the only way past the `continue` was `transformed != null`. That disjunct documents the intent the `continue` defeated.

Worth recording: **every one** of Marten's local tests in `archiving_events.cs` appends `new DEvent()` next to `new Archived(...)`. Not one covered the lone-marker case. This is the compliance library doing exactly what it exists for.

**Suite bugs — fixed in jasperfx#780, merged (2)**

- `projection_side_effect_compliance.{side_effects_are_suppressed_during_a_rebuild, no_messages_are_published_during_a_rebuild}` — both asked the daemon for `nameof(ComplianceWatchtowerProjection)`, assuming a store names a projection after the *projection* type. Marten names it after the aggregated *document* type. Neither convention is wrong, so the suite now pins the projection's `Name`.
- `aggregate_to_linq_operator_compliance.can_aggregate_with_initial_state_asynchronously` — its two assertions could not both hold. `ComplianceTrail` has `Create(TrailStarted)` and no `Apply`, so over supplied state a store either skips the creator (`Name` empty, `Miles` 110) or runs it and its `new()` discards the seed (`Name` set, `Miles` 10). The over-tight `Name` assertion was dropped; the miles assertion alone proves what the fact is for.

**Filed, not fixed (3 issues, 4 facts)**

- **#5344** — three natural-key gaps: no uniqueness enforcement on a live key (the #772 ruling; needs a schema change), the lookup row surviving `ArchiveStream`, and a primitive-`string` natural key colliding with the Guid stream-identity guard in `FindFetchPlan`. Behaviour changes to the natural-key design, not enrolment defects.
- **#5345** — `AlwaysEnforceConsistency` on a never-created stream throws `expected 0 but was 0`. Root-caused to `Weasel.Storage`'s `AssertStreamVersionOperation.PostprocessAsync`, which treats "no row" as an unconditional conflict when a missing stream's version is in fact 0. The issue carries the exact patch. Fix belongs in Weasel, which this node cannot release.
- **#5346** — `a_unit_of_work_that_fails_publishes_nothing` asserts the shared `ExistingStreamIdCollisionException`; Marten throws its own unrelated type. This *is* the jasperfx#756 consolidation node.
- **#5347** — tracks consuming the release carrying jasperfx#780, which closes the three facts above that are already fixed upstream.

So `master` carries **9 red compliance facts**, every one classified, filed, and either already fixed upstream or blocked on a package release this node was told not to make.

## Retired: nothing

#5336 listed three candidates. Assessed, and all three cover ground the shared suites deliberately do not reach:

- `Bug_5175_composite_member_teardown.cs` — `every_member_reports_its_own_teardown_rules` asserts Marten's internal `AsyncOptions.CleanUps` wiring, which no shared fact reaches. And `rebuilding_deletes_every_members_documents_first` uses an **orphan-row** technique that catches a strictly larger failure set than the suite's additive-doubling one: a member with missing teardown but idempotent writes passes the doubling check and fails the orphan check.
- `composite_single_pass_rebuild.cs` — asserts the daemon spawned no per-member rebuild agents by inspecting progression rows after a rebuild. The suite's `a_composite_presents_itself_as_exactly_one_shard` is a static shard count, not a post-rebuild runtime check.
- `multi_stage_projections.cs` — a tenancy-style theory and a cache-limit fact, neither in the shared suite.

Retiring any of them would have been a net loss of coverage.

## Testing

- `src/EventSourcingTests` (Release, net10.0): **2182 passed, 9 failed, 20 skipped** — the 9 are exactly the classified compliance failures above, with no regression anywhere in the other 2200 tests.
- `src/DaemonTests` (Release, net10.0): run because this PR touches `DocumentSessionBase.SaveChanges`. **319 passed, 0 failed**.
- `JasperFx` `EventTests` for the companion PR: 1049 passed on net9.0 and net10.0.

No NuGet package was published from this node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
