### PR TITLE
Close the three natural-key compliance gaps (#5344)

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4788_natrual_key_table_not_populated_on_rebuild.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4788_natrual_key_table_not_populated_on_rebuild.cs
@@ -89,6 +89,12 @@ public class Bug_4788_natrual_key_table_not_populated_on_rebuild: OneOffConfigur
         StoreOptions(ConfigureStore);
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 
+        // #5344: this test pins its own schema and never cleaned it, so every run left another live
+        // stream behind claiming order number "12345". That was invisible while a second claimant
+        // silently repointed the lookup row; now that a live key is refused, the second run of the
+        // test fails on its own leftovers rather than on anything it is trying to assert.
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+
         var streamId = Guid.NewGuid();
         await using var session = theStore.LightweightSession();
         session.Events.StartStream<Order>(streamId, new OrderPlaced(streamId, "12345"));

--- a/src/EventSourcingTests/FetchForWriting/natural_key_uniqueness.cs
+++ b/src/EventSourcingTests/FetchForWriting/natural_key_uniqueness.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.FetchForWriting;
+
+/// <summary>
+/// #5344 / the jasperfx#764 ruling: a natural key already mapped to a live stream is refused to a
+/// second claimant rather than repointed at it.
+/// </summary>
+/// <remarks>
+/// The behaviour itself is pinned by <c>NaturalKeyCompliance.a_second_stream_cannot_claim_a_live_natural_key</c>.
+/// What is local here is the batch shape that fact does not reach: the refusal is enforced by a
+/// storage operation that reads a <c>RETURNING</c> row back in <c>PostprocessAsync</c>, so several
+/// claims committed in ONE <c>SaveChangesAsync</c> have to stay aligned with their own result sets.
+/// A single-claim fact cannot tell a correct implementation from one that reads the wrong row.
+/// </remarks>
+public class natural_key_uniqueness: OneOffConfigurationsContext
+{
+    public record InvoiceNumber(string Value);
+
+    public record InvoiceRaised(string Number, string Customer);
+
+    public record InvoiceRenumbered(string Number);
+
+    public class UniquenessInvoice
+    {
+        public Guid Id { get; set; }
+
+        [NaturalKey]
+        public InvoiceNumber Number { get; set; } = null!;
+
+        public string Customer { get; set; } = string.Empty;
+
+        [NaturalKeySource]
+        public static UniquenessInvoice Create(IEvent<InvoiceRaised> e) =>
+            new() { Id = e.StreamId, Number = new InvoiceNumber(e.Data.Number), Customer = e.Data.Customer };
+
+        [NaturalKeySource]
+        public void Apply(InvoiceRenumbered e) => Number = new InvoiceNumber(e.Number);
+    }
+
+    private async Task configure()
+    {
+        StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "natural_key_uniqueness";
+            opts.RegisterValueType(typeof(InvoiceNumber));
+            opts.Projections.Snapshot<UniquenessInvoice>(SnapshotLifecycle.Inline);
+        });
+
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+    }
+
+    [Fact]
+    public async Task several_streams_claiming_distinct_keys_in_one_batch_all_commit()
+    {
+        await configure();
+
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var third = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<UniquenessInvoice>(first, new InvoiceRaised("INV-1", "Alice"));
+            session.Events.StartStream<UniquenessInvoice>(second, new InvoiceRaised("INV-2", "Bob"));
+            // Two claims for one stream inside the same batch: the create, then a rename that
+            // retires it. The last one has to win.
+            session.Events.StartStream<UniquenessInvoice>(third, new InvoiceRaised("INV-3", "Carol"),
+                new InvoiceRenumbered("INV-3-REVISED"));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = theStore.LightweightSession();
+
+        (await query.Events.FetchLatest<UniquenessInvoice, InvoiceNumber>(new InvoiceNumber("INV-1")))
+            .ShouldNotBeNull().Id.ShouldBe(first);
+        (await query.Events.FetchLatest<UniquenessInvoice, InvoiceNumber>(new InvoiceNumber("INV-2")))
+            .ShouldNotBeNull().Id.ShouldBe(second);
+        (await query.Events.FetchLatest<UniquenessInvoice, InvoiceNumber>(new InvoiceNumber("INV-3-REVISED")))
+            .ShouldNotBeNull().Id.ShouldBe(third);
+
+        // The superseded key is retired, not left pointing at the stream that gave it up.
+        (await query.Events.FetchLatest<UniquenessInvoice, InvoiceNumber>(new InvoiceNumber("INV-3")))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task a_duplicate_inside_a_multi_claim_batch_is_refused_and_names_both_streams()
+    {
+        await configure();
+
+        var original = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<UniquenessInvoice>(original, new InvoiceRaised("INV-DUP", "Alice"));
+            await session.SaveChangesAsync();
+        }
+
+        var claimant = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            // A legitimate claim and a duplicate in the same batch: the duplicate has to be the one
+            // that raises, which only holds if each claim is matched to its own returned row.
+            session.Events.StartStream<UniquenessInvoice>(Guid.NewGuid(), new InvoiceRaised("INV-OK", "Bob"));
+            session.Events.StartStream<UniquenessInvoice>(claimant, new InvoiceRaised("INV-DUP", "Mallory"));
+
+            var ex = await Should.ThrowAsync<DuplicateNaturalKeyException>(() => session.SaveChangesAsync());
+
+            ex.Key.ShouldBe("INV-DUP");
+            ex.AggregateType.ShouldBe(typeof(UniquenessInvoice));
+            ex.ExistingStreamId.ShouldBe(original);
+            ex.ClaimingStreamId.ShouldBe(claimant);
+        }
+
+        // The whole unit of work rolled back, so the legitimate claim in that batch is gone too and
+        // the original mapping is untouched.
+        await using var query = theStore.LightweightSession();
+
+        var invoice = await query.Events.FetchLatest<UniquenessInvoice, InvoiceNumber>(new InvoiceNumber("INV-DUP"));
+        invoice.ShouldNotBeNull();
+        invoice.Id.ShouldBe(original);
+        invoice.Customer.ShouldBe("Alice");
+
+        (await query.Events.FetchLatest<UniquenessInvoice, InvoiceNumber>(new InvoiceNumber("INV-OK")))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task an_archived_streams_key_can_be_claimed_by_a_new_stream()
+    {
+        await configure();
+
+        var original = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<UniquenessInvoice>(original, new InvoiceRaised("INV-RECYCLED", "Alice"));
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.ArchiveStream(original);
+            await session.SaveChangesAsync();
+        }
+
+        // The ruling refuses a claim on a *live* key. Once the holder is archived the identifier is
+        // free again, which is the half that would be lost by refusing on the lookup row alone.
+        var replacement = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<UniquenessInvoice>(replacement, new InvoiceRaised("INV-RECYCLED", "Bob"));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = theStore.LightweightSession();
+
+        var invoice = await query.Events.FetchLatest<UniquenessInvoice, InvoiceNumber>(new InvoiceNumber("INV-RECYCLED"));
+        invoice.ShouldNotBeNull();
+        invoice.Id.ShouldBe(replacement);
+        invoice.Customer.ShouldBe("Bob");
+    }
+}

--- a/src/Marten/Events/EventStore.FetchForWriting.cs
+++ b/src/Marten/Events/EventStore.FetchForWriting.cs
@@ -259,15 +259,26 @@ internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityS
 
     internal IAggregateFetchPlan<TDoc, TId> FindFetchPlan<TDoc, TId>() where TDoc : class where TId : notnull
     {
-        if (typeof(TId) == typeof(Guid))
+        var options = ((IMartenSession)_session).Options;
+
+        // #5344: only assert the store's stream identity when TId is actually being used to address
+        // a *stream*. A [NaturalKey] whose type happens to be Guid or string is not a stream id, and
+        // asserting here refused a primitive `string` natural key on a Guid-identity store outright
+        // ("This Marten event store is configured to identify streams with Guids") before any
+        // planner got a look at it. A wrapped natural key never hit this because it is neither Guid
+        // nor string, which is why only the primitive case was broken.
+        if (!IsNaturalKeyIdentity<TDoc, TId>(options))
         {
-            ((IMartenSession)_session).Options.EventGraph.EnsureAsGuidStorage(_session);
+            if (typeof(TId) == typeof(Guid))
+            {
+                options.EventGraph.EnsureAsGuidStorage(_session);
+            }
+            else if (typeof(TId) == typeof(string))
+            {
+                options.EventGraph.EnsureAsStringStorage(_session);
+            }
+            // else: natural key type — event storage initialization deferred to the plan
         }
-        else if (typeof(TId) == typeof(string))
-        {
-            ((IMartenSession)_session).Options.EventGraph.EnsureAsStringStorage(_session);
-        }
-        // else: natural key type — event storage initialization deferred to the plan
 
         // Use (TDoc, TId) as cache key to support both stream id and natural key lookups
         var cacheKey = new AggregateFetchKey(typeof(TDoc), typeof(TId));
@@ -276,7 +287,7 @@ internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityS
             return (IAggregateFetchPlan<TDoc, TId>)stored;
         }
 
-        var plan = determineFetchPlan<TDoc, TId>(((IMartenSession)_session).Options);
+        var plan = determineFetchPlan<TDoc, TId>(options);
 
         _fetchStrategies = _fetchStrategies.AddOrUpdate(cacheKey, plan);
 
@@ -285,9 +296,12 @@ internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityS
 
     private IAggregateFetchPlan<TDoc, TId> determineFetchPlan<TDoc, TId>(StoreOptions options) where TDoc : class where TId : notnull
     {
-        // For natural key types (not Guid/string), try natural key planners first
-        // before attempting the cast to IEventIdentityStrategy<TId>
-        if (typeof(TId) != typeof(Guid) && typeof(TId) != typeof(string))
+        // For natural key types, try natural key planners first before attempting the cast to
+        // IEventIdentityStrategy<TId>. #5344: a natural key is usually a wrapper (neither Guid nor
+        // string), but it can also be a primitive `string` on a Guid-identity store — in which case
+        // it still is not a stream identifier, so it belongs on this branch too.
+        if (IsNaturalKeyIdentity<TDoc, TId>(options) ||
+            (typeof(TId) != typeof(Guid) && typeof(TId) != typeof(string)))
         {
             // Auto-discover natural key from [NaturalKey] attribute on the aggregate type
             // BEFORE iterating planners, so the projection is registered and available
@@ -351,6 +365,45 @@ internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityS
     }
 
     /// <summary>
+    /// #5344: is <typeparamref name="TId"/> the aggregate's <em>natural</em> key rather than its
+    /// stream identifier?
+    /// </summary>
+    /// <remarks>
+    /// The store's own stream identity always wins, so on a string-identity store
+    /// <c>FetchLatest&lt;T, string&gt;(value)</c> addresses the stream and never the natural key,
+    /// exactly as it did before. What this adds is the other half: on a Guid-identity store a
+    /// <c>string</c> cannot possibly name a stream, so a <c>[NaturalKey] string</c> is the only
+    /// thing it can mean. Falls back to probing the attribute directly because the natural key
+    /// projection may not be registered yet — <see cref="tryAutoRegisterNaturalKeyProjection{TDoc,TId}"/>
+    /// runs later, inside <see cref="determineFetchPlan{TDoc,TId}"/>.
+    /// </remarks>
+    internal static bool IsNaturalKeyIdentity<TDoc, TId>(StoreOptions options)
+        where TDoc : class where TId : notnull
+    {
+        var streamIdentityType = options.EventGraph.StreamIdentity == StreamIdentity.AsGuid
+            ? typeof(Guid)
+            : typeof(string);
+
+        if (typeof(TId) == streamIdentityType)
+        {
+            return false;
+        }
+
+        if (options.Projections.TryFindAggregate(typeof(TDoc), out var projection))
+        {
+            return projection.NaturalKeyDefinition?.OuterType == typeof(TId);
+        }
+
+        return FindNaturalKeyProperty<TDoc>()?.PropertyType == typeof(TId);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
+        Justification = "Aggregate types reaching the fetch planners are preserved at the projection-registration boundary.")]
+    private static PropertyInfo? FindNaturalKeyProperty<TDoc>() =>
+        typeof(TDoc).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(p => p.GetCustomAttribute<NaturalKeyAttribute>() != null);
+
+    /// <summary>
     /// Auto-discovers a natural key from [NaturalKey] attribute on the aggregate type
     /// and registers an Inline snapshot projection if no projection exists yet.
     /// This enables FetchForWriting with natural keys on self-aggregating types
@@ -366,8 +419,7 @@ internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityS
             return false;
         }
 
-        var naturalKeyProp = typeof(TDoc).GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .FirstOrDefault(p => p.GetCustomAttribute<NaturalKeyAttribute>() != null);
+        var naturalKeyProp = FindNaturalKeyProperty<TDoc>();
 
         if (naturalKeyProp == null || naturalKeyProp.PropertyType != typeof(TId))
         {

--- a/src/Marten/Events/Fetching/FetchNaturalKeyPlan.cs
+++ b/src/Marten/Events/Fetching/FetchNaturalKeyPlan.cs
@@ -303,6 +303,16 @@ internal class FetchNaturalKeyPlan<TDoc, TNaturalKey>: IAggregateFetchPlan<TDoc,
         builder.AppendParameter(innerValue);
         builder.Append(" and nk.is_archived = false");
 
+        // #5344: archival is a property of the *stream*, and nothing on the write side copies it
+        // onto the lookup row -- ArchiveStream() and the Archived event both go through
+        // mt_archive_stream, which has never touched mt_natural_key_X. Reading the flag off the
+        // stream we are already joined to is what Fisher does, and it needs no schema change, no
+        // migration of existing lookup tables, and covers every route into the archive (the explicit
+        // call, the Archived marker event, and the daemon) with one predicate. nk.is_archived above
+        // is kept because it is genuinely maintained under UseArchivedStreamPartitioning, where the
+        // cascading FK moves the lookup row along with its stream.
+        builder.Append(" and s.is_archived = false");
+
         if (_isConjoined && !_isGlobal)
         {
             builder.Append(" and s.tenant_id = ");

--- a/src/Marten/Events/Fetching/NaturalKeyFetchPlanner.cs
+++ b/src/Marten/Events/Fetching/NaturalKeyFetchPlanner.cs
@@ -23,19 +23,23 @@ internal class NaturalKeyFetchPlanner: IFetchPlanner
         if (options.Projections.TryFindAggregate(typeof(TDoc), out var projection))
         {
             var naturalKey = projection.NaturalKeyDefinition;
-            if (naturalKey != null && naturalKey.OuterType == typeof(TId))
+
+            // #5344: this used to exclude Guid and string outright, on the reasoning that both are
+            // stream identity types handled by the built-in planners. Only one of them is, though —
+            // whichever the store actually uses. On a Guid-identity store a primitive `string`
+            // natural key was refused here and then died on EnsureAsStringStorage's "configured to
+            // identify streams with Guids". EventStore.IsNaturalKeyIdentity narrows the exclusion to
+            // the store's own stream identity type, which keeps the ambiguous case (a string key on
+            // a string-identity store) resolving to the stream as it always has.
+            if (naturalKey != null && naturalKey.OuterType == typeof(TId) &&
+                EventStore.IsNaturalKeyIdentity<TDoc, TId>(options))
             {
-                // Only match if TId is NOT already a stream identity type (Guid/string)
-                // Those are handled by the existing planners
-                if (typeof(TId) != typeof(Guid) && typeof(TId) != typeof(string))
-                {
-                    plan = new FetchNaturalKeyPlan<TDoc, TId>(
-                        options.EventGraph,
-                        naturalKey,
-                        projection.Lifecycle,
-                        options);
-                    return true;
-                }
+                plan = new FetchNaturalKeyPlan<TDoc, TId>(
+                    options.EventGraph,
+                    naturalKey,
+                    projection.Lifecycle,
+                    options);
+                return true;
             }
         }
 

--- a/src/Marten/Events/Operations/NaturalKeyClaimOperation.cs
+++ b/src/Marten/Events/Operations/NaturalKeyClaimOperation.cs
@@ -1,0 +1,163 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten.Storage;
+using Weasel.Postgresql;
+using Weasel.Storage;
+
+namespace Marten.Events.Operations;
+
+/// <summary>
+/// Claims a natural key for one stream, refusing the claim when the key is already mapped to a
+/// different <em>live</em> stream (#5344, ruling in jasperfx#764/#772).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Replaces the plain <c>ON CONFLICT ... DO UPDATE SET stream_id = excluded.stream_id</c> that the
+/// append path used to queue through <c>QueueSqlCommand</c>. That form repointed the row at the
+/// newcomer and reported nothing, which left the original stream in place but unreachable by the
+/// identifier it was created with. Of the two failure modes the silent one is worse, so a natural
+/// key already mapped to a live stream is now refused rather than moved.
+/// </para>
+/// <para>
+/// <b>The refusal is the SQL, not a pre-flight read.</b> A probing SELECT before the write would
+/// race: two sessions could both find the key free and both proceed, and the loser's upsert would
+/// repoint the row exactly as before. Instead the <c>DO UPDATE</c> keeps firing unconditionally but
+/// its <c>SET</c> is a <c>CASE</c> that writes the incoming stream only when the claim is legitimate
+/// and otherwise rewrites the row's existing value — so the row is never repointed, and the
+/// row-level lock ON CONFLICT already takes is what serializes concurrent claimants. Because the
+/// update always fires, <c>RETURNING</c> always yields exactly one row carrying the key's
+/// <em>current</em> owner, which is what <see cref="PostprocessAsync" /> compares against the
+/// claimant. That is also where both ids in
+/// <see cref="DuplicateNaturalKeyException.ExistingStreamId" /> /
+/// <see cref="DuplicateNaturalKeyException.ClaimingStreamId" /> come from, with no extra round trip.
+/// </para>
+/// <para>
+/// A claim is legitimate in three cases: the key is unmapped (no conflict at all), the same stream
+/// is re-asserting its own mapping (idempotent by design — every event carrying the key rewrites the
+/// row), or the stream currently holding it has been archived. That last one is read off
+/// <c>mt_streams</c> rather than the lookup row's own <c>is_archived</c>, for the same reason
+/// <c>FetchNaturalKeyPlan</c> joins the streams table: nothing on the write side copies the flag
+/// across, so the lookup column is only maintained under <c>UseArchivedStreamPartitioning</c>. The
+/// ruling refuses a claim on a <em>live</em> key, so an archived stream's key is free to take.
+/// </para>
+/// <para>
+/// Renaming is not a duplicate either, and needs no special handling here: the projection queues a
+/// DELETE of this stream's superseded rows ahead of the claim, which retires the old key and frees
+/// that identifier for a later stream.
+/// </para>
+/// </remarks>
+internal class NaturalKeyClaimOperation: IStorageOperation
+{
+    private readonly Type _aggregateType;
+    private readonly string _tableName;
+    private readonly string _streamsTableName;
+    private readonly string _streamColumn;
+    private readonly object _streamIdValue;
+    private readonly string _tenantId;
+    private readonly object _innerValue;
+    private readonly bool _isConjoined;
+    private readonly bool _useArchivedPartitioning;
+
+    public NaturalKeyClaimOperation(Type aggregateType, string tableName, string streamsTableName,
+        string streamColumn, object streamIdValue, string tenantId, object innerValue, bool isConjoined,
+        bool useArchivedPartitioning)
+    {
+        _aggregateType = aggregateType;
+        _tableName = tableName;
+        _streamsTableName = streamsTableName;
+        _streamColumn = streamColumn;
+        _streamIdValue = streamIdValue;
+        _tenantId = tenantId;
+        _innerValue = innerValue;
+        _isConjoined = isConjoined;
+        _useArchivedPartitioning = useArchivedPartitioning;
+    }
+
+    public void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        builder.Append("insert into ");
+        builder.Append(_tableName);
+        builder.Append(" as nk (natural_key_value, ");
+        builder.Append(_streamColumn);
+        builder.Append(_isConjoined ? ", tenant_id, is_archived) values (" : ", is_archived) values (");
+        builder.AppendParameter(_innerValue);
+        builder.Append(", ");
+        builder.AppendParameter(_streamIdValue);
+
+        if (_isConjoined)
+        {
+            builder.Append(", ");
+            builder.AppendParameter(_tenantId);
+        }
+
+        builder.Append(", false) on conflict (natural_key_value");
+
+        if (_isConjoined)
+        {
+            builder.Append(", tenant_id");
+        }
+
+        if (_useArchivedPartitioning)
+        {
+            builder.Append(", is_archived");
+        }
+
+        builder.Append(") do update set ");
+        builder.Append(_streamColumn);
+        builder.Append(" = case when nk.");
+        builder.Append(_streamColumn);
+        builder.Append(" = excluded.");
+        builder.Append(_streamColumn);
+        builder.Append(" or nk.is_archived or exists (select 1 from ");
+        builder.Append(_streamsTableName);
+        builder.Append(" s where s.id = nk.");
+        builder.Append(_streamColumn);
+        builder.Append(" and s.is_archived");
+
+        if (_isConjoined)
+        {
+            builder.Append(" and s.tenant_id = nk.tenant_id");
+        }
+
+        builder.Append(") then excluded.");
+        builder.Append(_streamColumn);
+        builder.Append(" else nk.");
+        builder.Append(_streamColumn);
+        builder.Append(" end");
+
+        // is_archived is part of the conflict target under archived partitioning, so a conflicting
+        // row necessarily already carries the value being inserted. Everywhere else the existing
+        // upsert reset it, and a refused claim leaves it at the false it already held.
+        if (!_useArchivedPartitioning)
+        {
+            builder.Append(", is_archived = false");
+        }
+
+        builder.Append(" returning ");
+        builder.Append(_streamColumn);
+    }
+
+    public Type DocumentType => typeof(StorageFeatures);
+
+    public async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        var owner = await reader.GetFieldValueAsync<object>(0, token).ConfigureAwait(false);
+
+        if (!owner.Equals(_streamIdValue))
+        {
+            exceptions.Add(new DuplicateNaturalKeyException(_aggregateType, _innerValue, owner, _streamIdValue));
+        }
+    }
+
+    public OperationRole Role() => OperationRole.Other;
+}

--- a/src/Marten/Events/Projections/NaturalKeyProjection.cs
+++ b/src/Marten/Events/Projections/NaturalKeyProjection.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Events;
 using JasperFx.Events.Projections;
+using Marten.Events.Operations;
 using Marten.Events.Schema;
 using Marten.Storage;
 using Weasel.Core;
@@ -11,16 +12,24 @@ using Weasel.Core;
 namespace Marten.Events.Projections;
 
 /// <summary>
-/// Auto-registered inline projection that maintains natural key to stream id/key mappings
-/// in a dedicated table. This projection upserts the natural key value when matching events
-/// are appended and marks entries as archived when streams are archived.
+/// Auto-registered inline projection that maintains natural key to stream id/key mappings in a
+/// dedicated table, writing the natural key value when a matching event is appended.
 /// </summary>
+/// <remarks>
+/// It does <em>not</em> mark entries archived when a stream is archived, which this comment used to
+/// claim (#5344). Nothing on the write side ever did: archival runs through
+/// <c>mt_archive_stream</c>, which has never touched <c>mt_natural_key_X</c>, so the row's own
+/// <c>is_archived</c> column is only maintained under <c>UseArchivedStreamPartitioning</c>, where
+/// the cascading foreign key moves it along with its stream. Readers get the flag off
+/// <c>mt_streams</c> instead — see <c>FetchNaturalKeyPlan.BuildNaturalKeyToStreamQuery</c>.
+/// </remarks>
 internal class NaturalKeyProjection: IInlineProjection<IDocumentOperations>, IProjectionSchemaSource
 {
     private readonly EventGraph _events;
     private readonly NaturalKeyDefinition _naturalKey;
     private readonly NaturalKeyTable _table;
     private readonly string _tableName;
+    private readonly string _streamsTableName;
     private readonly bool _isConjoined;
     private readonly bool _isGuid;
     private readonly bool _useArchivedPartitioning;
@@ -31,6 +40,7 @@ internal class NaturalKeyProjection: IInlineProjection<IDocumentOperations>, IPr
         _naturalKey = naturalKey;
         _table = new NaturalKeyTable(events, naturalKey);
         _tableName = _table.Identifier.QualifiedName;
+        _streamsTableName = $"{events.DatabaseSchemaName}.{StreamsTable.TableName}";
         _useArchivedPartitioning = events.UseArchivedStreamPartitioning;
         _isConjoined = events.TenancyStyle == TenancyStyle.Conjoined;
         _isGuid = events.StreamIdentity == StreamIdentity.AsGuid;
@@ -52,7 +62,7 @@ internal class NaturalKeyProjection: IInlineProjection<IDocumentOperations>, IPr
                         var innerValue = _naturalKey.Unwrap(rawValue);
                         if (innerValue != null)
                         {
-                            queueUpsertSql(operations, stream.Id, stream.Key, stream.TenantId, innerValue);
+                            queueClaim(operations, stream.Id, stream.Key, stream.TenantId, innerValue);
                         }
                     }
                 }
@@ -92,20 +102,18 @@ internal class NaturalKeyProjection: IInlineProjection<IDocumentOperations>, IPr
         }
     }
 
-    private void queueUpsertSql(IDocumentOperations operations, Guid streamId, string? streamKey,
-        string tenantId, object innerValue)
+    /// <summary>
+    /// #5041: a stream has exactly one <em>current</em> natural key value, but the writes below only
+    /// ever insert. When an event changes the key, the row carrying the previous value stays behind
+    /// pointing at the same stream, so the table accumulates one dead row per rename and the retired
+    /// key keeps occupying its slot in the primary key. Retire those rows first — scoped to this
+    /// stream (and tenant, when conjoined) so a key legitimately owned by some other stream is never
+    /// touched. Queued ahead of the write, and the batch preserves order, so a Create-then-rename
+    /// inside a single batch still lands on the newest value.
+    /// </summary>
+    private void queueRetirementOfSupersededKeys(IDocumentOperations operations, string streamCol,
+        object streamIdValue, string tenantId, object innerValue)
     {
-        var streamCol = _isGuid ? "stream_id" : "stream_key";
-        object streamIdValue = _isGuid ? (object)streamId : streamKey!;
-
-        // #5041: a stream has exactly one *current* natural key value, but the upsert below only
-        // ever inserts. When an event changes the key, the row carrying the previous value stays
-        // behind pointing at the same stream, so the table accumulates one dead row per rename and
-        // the retired key keeps occupying its slot in the primary key. Retire those rows first —
-        // scoped to this stream (and tenant, when conjoined) so a key legitimately owned by some
-        // other stream is never touched. Queued ahead of the upsert, and QueueSqlCommand preserves
-        // order within the batch, so a Create-then-rename inside a single batch still lands on the
-        // newest value.
         if (_isConjoined)
         {
             operations.QueueSqlCommand(
@@ -118,6 +126,51 @@ internal class NaturalKeyProjection: IInlineProjection<IDocumentOperations>, IPr
                 $"DELETE FROM {_tableName} WHERE {streamCol} = ? AND natural_key_value <> ?",
                 streamIdValue, innerValue);
         }
+    }
+
+    /// <summary>
+    /// #5344: the append-path claim, which refuses a key already mapped to a different live stream
+    /// rather than repointing the row at the newcomer. The retiring DELETE below is shared with the
+    /// rebuild path; only the write itself differs.
+    /// </summary>
+    private void queueClaim(IDocumentOperations operations, Guid streamId, string? streamKey,
+        string tenantId, object innerValue)
+    {
+        var streamCol = _isGuid ? "stream_id" : "stream_key";
+        object streamIdValue = _isGuid ? (object)streamId : streamKey!;
+
+        queueRetirementOfSupersededKeys(operations, streamCol, streamIdValue, tenantId, innerValue);
+
+        operations.QueueOperation(new NaturalKeyClaimOperation(
+            _naturalKey.AggregateType,
+            _tableName,
+            _streamsTableName,
+            streamCol,
+            streamIdValue,
+            tenantId,
+            innerValue,
+            _isConjoined,
+            _useArchivedPartitioning));
+    }
+
+    /// <summary>
+    /// The rebuild-path write, which stays last-writer-wins.
+    /// </summary>
+    /// <remarks>
+    /// A rebuild replays events that were already accepted at append time, where the claim above is
+    /// what enforces uniqueness. Re-adjudicating them here would turn a pre-existing data condition
+    /// — two live streams sharing a key, which older Marten permitted precisely because the upsert
+    /// repointed — into an unrecoverable daemon failure, with no caller present to correct the key
+    /// derivation the ruling blames. Replay order also preserves renames: a stream's superseded rows
+    /// are retired before the next claim, so the run ends on the same mapping the append path built.
+    /// </remarks>
+    private void queueUpsertSql(IDocumentOperations operations, Guid streamId, string? streamKey,
+        string tenantId, object innerValue)
+    {
+        var streamCol = _isGuid ? "stream_id" : "stream_key";
+        object streamIdValue = _isGuid ? (object)streamId : streamKey!;
+
+        queueRetirementOfSupersededKeys(operations, streamCol, streamIdValue, tenantId, innerValue);
 
         // When UseArchivedStreamPartitioning is on, is_archived is part of the PK
         // and must be included in the ON CONFLICT clause


### PR DESCRIPTION
Closes #5344.

All three facts `NaturalKeyCompliance` left red on `master` are **genuine Marten bugs**. None is a suite defect, none is a legitimate divergence, and none was made green by weakening a suite — the suite is untouched, and no companion PR was needed in JasperFx.

Validated against **JasperFx 2.64.0**, the pin on this branch's base. (2.65.0 was not on nuget.org when this branch was cut; the bump is #5347, and I re-validate this work on top of it there.)

## 1. `a_second_stream_cannot_claim_a_live_natural_key` — genuine Marten bug

The append path wrote `ON CONFLICT (natural_key_value) DO UPDATE SET stream_id = excluded.stream_id`, which repointed the key at the newcomer and reported nothing. Per the ruling in jasperfx#764/#772 a live key is now **refused** with the shared `JasperFx.Events.DuplicateNaturalKeyException`.

**The refusal is in the SQL, not a pre-flight read.** A probing `SELECT` before the write would race — two sessions could both find the key free, and the loser's upsert would repoint the row exactly as before. Instead the `DO UPDATE` keeps firing unconditionally, but its `SET` is a `CASE` that rewrites the row's *existing* value on an illegitimate claim. Three consequences, all wanted:

- the row is **never** repointed, so the mapping the fact reads back afterwards is intact even if the throw were somehow missed;
- the row-level lock `ON CONFLICT` already takes is what serializes concurrent claimants, so there is no window to lose;
- because the update always fires, `RETURNING` always yields exactly one row carrying the key's *current* owner. Comparing that to the claimant is what raises, and it hands both `ExistingStreamId` and `ClaimingStreamId` to the exception with no extra round trip — the nullable superset jasperfx#772 added for precisely a store that has both ids at the throw site.

A claim stays legitimate in three cases: the key is unmapped, the same stream re-asserts its own mapping (idempotent by design), or **the stream holding it has been archived**. That last one matters — the ruling refuses a claim on a *live* key — and it is read off `mt_streams` rather than the lookup row's own `is_archived`, for the same reason as gap 2 below.

**The rebuild path deliberately stays last-writer-wins.** A rebuild replays events the append path already adjudicated; re-adjudicating them would turn a pre-existing data condition — two live streams sharing a key, which older Marten permitted *because* the upsert repointed — into an unrecoverable daemon failure, with no caller present to correct the key derivation the ruling blames. Replay order preserves renames on its own, so a rebuild still lands on the mapping the append path built.

## 2. `an_archived_stream_no_longer_resolves_by_natural_key` — genuine Marten bug

`ArchiveStream` left the lookup row intact, so an archived stream stayed resolvable by its natural key indefinitely.

Fixed the way Fisher does it: read `is_archived` off the `mt_streams` row the lookup query **already joins**, rather than copying the flag onto the lookup table. `BuildNaturalKeyToStreamQuery` is the single choke point for all four fetch paths, so this is one predicate, and it needs no schema change, no migration of existing lookup tables, and it covers every route into the archive — the explicit call, the `Archived` marker event, and the daemon. The row's own `is_archived` check is kept alongside it because it *is* genuinely maintained under `UseArchivedStreamPartitioning`, where the cascading FK moves the lookup row with its stream.

The class comment on `NaturalKeyProjection` claimed it "marks entries as archived when streams are archived". That was never true — `mt_archive_stream` has never touched `mt_natural_key_X` — and it is the reason this gap reads as handled at a glance. Corrected in place.

## 3. `natural_key_with_a_primitive_string_key` — genuine Marten bug

`FindFetchPlan<TDoc, TId>` asserted string *stream* storage for any `string` TId, so a `[NaturalKey] string` on a Guid-identity store died on `"This Marten event store is configured to identify streams with Guids"` before any planner saw it. `NaturalKeyFetchPlanner` had the mirror-image guard, excluding Guid **and** string outright.

Both guards now narrow to the store's **own** stream identity type (`EventStore.IsNaturalKeyIdentity`). Only one of Guid/string can address a stream in a given store; a `string` cannot name a stream on a Guid-identity store, so it can only be the natural key. The ambiguous case is unchanged by design: on a string-identity store `FetchLatest<T, string>(value)` still addresses the **stream**, never the natural key. A store with no natural key at all also still gets the old, clearer `EnsureAs*Storage` message rather than falling through to "unable to determine a fetch plan".

## Fallout worth naming

`Bug_4788_natrual_key_table_not_populated_on_rebuild` pinned its own schema and never cleaned it, so **every run left another live stream behind claiming order number "12345"**. That was invisible while a second claimant silently repointed the row; with the refusal in place the test's second run fails on its own leftovers. It now cleans event data first. Three such streams had accumulated in my local database — the test had been passing on the strength of the bug it sits next to.

## Testing

- `natural_key_compliance` — **17 passed, 0 failed** (was 14/3).
- `src/EventSourcingTests` (net10.0) — **2185 passed, 6 failed, 20 skipped**, up from 2182/9/20 on `master`. The 6 are exactly the other classified failures, unchanged; no regression anywhere.
- `src/DaemonTests` (net10.0) — **319 passed, 0 failed**. Run because the rebuild path shares the retiring DELETE with the append path.
- New `natural_key_uniqueness` (3 tests) covers the batch shape no compliance fact reaches: every fact commits a single claim, but the refusal reads a `RETURNING` row back in `PostprocessAsync`, so several claims in one `SaveChangesAsync` have to stay aligned with their own result sets. A single-claim fact cannot tell that apart from an implementation reading the wrong row.

**Nine red facts on `master` → six.** The three closed are exactly this issue's. The remainder: three waiting on the JasperFx release (#5347), one on Weasel (#5345), and one on the exception consolidation (#5346).

No NuGet package was published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
