### PR TITLE
Rebuild teardown clears the EF Core table, not mt_doc (#5329)

### DIFF
--- a/docs/events/projections/efcore.md
+++ b/docs/events/projections/efcore.md
@@ -396,6 +396,21 @@ public class MyProjection
 }
 ```
 
+## Rebuilding
+
+`IProjectionDaemon.RebuildProjectionAsync` works normally for EF Core projections. Because the
+projection's data lives in the `DbContext`-mapped table rather than in a Marten document table, the
+rebuild's teardown step clears **that** table -- Marten's conventional `mt_doc_<tdoc>` table is
+neither created nor truncated for an EF Core-backed aggregate.
+
+This matters when you build your schema with a separate migration and run with
+`AutoCreateSchemaObjects = AutoCreate.None`: there is no `mt_doc_<tdoc>` table to find, and the
+rebuild does not go looking for one.
+
+If you need to suppress the teardown entirely -- for instance when the entity table is shared with
+data Marten did not write -- set `Options.TeardownDataOnRebuild = false` in your projection's
+constructor and clear the table yourself.
+
 ## How It Works
 
 Under the hood, EF Core projections:
@@ -404,3 +419,4 @@ Under the hood, EF Core projections:
 2. **Register a transaction participant** so the DbContext's `SaveChangesAsync` is called within Marten's transaction, ensuring atomicity
 3. **Migrate entity tables** through Weasel alongside Marten's own schema objects, so `dotnet ef` migrations are not needed
 4. **Use EF Core change tracking** for insert vs. update detection (detached entities are added; unchanged entities are marked as modified)
+5. **Register the entity table as the rebuild teardown target**, so a rebuild clears the rows EF Core actually wrote

--- a/docs/events/projections/efcore.md
+++ b/docs/events/projections/efcore.md
@@ -411,6 +411,21 @@ If you need to suppress the teardown entirely -- for instance when the entity ta
 data Marten did not write -- set `Options.TeardownDataOnRebuild = false` in your projection's
 constructor and clear the table yourself.
 
+::: warning
+A **per-tenant** rebuild (`RebuildProjectionAsync` scoped to one tenant) scopes the wipe with
+`delete from <entity table> where tenant_id = ?`. That column name is not read from your EF Core
+model, so it only matches a `DbContext` that maps the tenant property to a snake_case `tenant_id`
+column -- as the conjoined multi-tenancy example above does. Under EF Core's default naming the
+column is `TenantId` and the rebuild fails with `42703: column "tenant_id" does not exist`. Map the
+column explicitly:
+
+```csharp
+entity.Property(e => e.TenantId).HasColumnName("tenant_id");
+```
+
+See [#5351](https://github.com/JasperFx/marten/issues/5351). A store-wide rebuild is unaffected.
+:::
+
 ## How It Works
 
 Under the hood, EF Core projections:

--- a/src/DaemonTests/Internals/AsyncOptionsTests.cs
+++ b/src/DaemonTests/Internals/AsyncOptionsTests.cs
@@ -1,9 +1,12 @@
+using System.Collections.Generic;
+using System.Linq;
 using JasperFx.Events.Projections;
 using Marten;
 using Marten.Events.Daemon;
 using Marten.Internal.Operations;
 using Marten.Testing.Documents;
 using NSubstitute;
+using Shouldly;
 using Xunit;
 
 namespace DaemonTests.Internals;
@@ -19,10 +22,59 @@ public class AsyncOptionsTests
 
 
         var operations = Substitute.For<IDocumentOperations>();
-        options.Teardown(operations);
+        options.Teardown(operations, new StoreOptions());
 
         operations.Received().QueueOperation(new TruncateTable(typeof(Target)));
         operations.Received().QueueOperation(new TruncateTable(typeof(User)));
     }
 
+    /// <summary>
+    /// #5329: a document type with custom projection storage (EF Core) keeps its rows somewhere
+    /// other than <c>mt_doc_&lt;tdoc&gt;</c>, so teardown must not queue a truncate against a table
+    /// Marten never created. The guard is keyed strictly on that registry — the sibling type here
+    /// has no entry and must still be truncated, which is the half of this that would turn a rebuild
+    /// into a silent no-op if it ever regressed.
+    /// </summary>
+    [Fact]
+    public void teardown_skips_view_types_that_are_not_stored_by_marten()
+    {
+        var options = new AsyncOptions();
+        options.DeleteViewTypeOnTeardown<Target>();
+        options.DeleteViewTypeOnTeardown(typeof(User));
+
+        var storeOptions = new StoreOptions();
+        storeOptions.CustomProjectionStorageProviders[typeof(Target)] = (_, _) => new object();
+
+        var operations = Substitute.For<IDocumentOperations>();
+        options.Teardown(operations, storeOptions);
+
+        operations.DidNotReceive().QueueOperation(new TruncateTable(typeof(Target)));
+        operations.Received().QueueOperation(new TruncateTable(typeof(User)));
+    }
+
+    /// <summary>
+    /// #5329: the per-tenant rebuild path shares the same cleanup list and needs the same guard.
+    /// </summary>
+    [Fact]
+    public void teardown_for_tenant_skips_view_types_that_are_not_stored_by_marten()
+    {
+        var options = new AsyncOptions();
+        options.DeleteViewTypeOnTeardown<Target>();
+        options.DeleteViewTypeOnTeardown(typeof(User));
+
+        var storeOptions = new StoreOptions();
+        storeOptions.CustomProjectionStorageProviders[typeof(Target)] = (_, _) => new object();
+
+        var operations = Substitute.For<IDocumentOperations>();
+        var queued = new List<IStorageOperation>();
+        operations.When(x => x.QueueOperation(Arg.Any<IStorageOperation>()))
+            .Do(call => queued.Add(call.Arg<IStorageOperation>()));
+
+        options.TeardownForTenant(operations, "blue", storeOptions);
+
+        // DeleteAllForTenant has no value equality, so assert on what was actually queued
+        queued.OfType<DeleteAllForTenant>().Select(x => x.DocumentType)
+            .ShouldHaveSingleItem()
+            .ShouldBe(typeof(User));
+    }
 }

--- a/src/Marten.EntityFrameworkCore.Tests/Bug_5329_efcore_projection_rebuild_teardown.cs
+++ b/src/Marten.EntityFrameworkCore.Tests/Bug_5329_efcore_projection_rebuild_teardown.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace Marten.EntityFrameworkCore.Tests;
+
+public class MartenOrderTally
+{
+    public string Id { get; set; } = string.Empty;
+    public int Count { get; set; }
+}
+
+/// <summary>
+/// A perfectly ordinary Marten-stored multi-stream projection over the same events, registered
+/// alongside the EF Core one. It applies events by overriding <c>DetermineActionAsync</c> rather
+/// than by Create/Apply conventions only because this test project does not wire the projection
+/// source generator; what matters here is where its data lives, not how it is built.
+/// </summary>
+public class MartenOrderTallyProjection: MultiStreamProjection<MartenOrderTally, string>
+{
+    public MartenOrderTallyProjection()
+    {
+        Identity<CustomerOrderPlaced>(e => e.CustomerName);
+    }
+
+    public override ValueTask<(MartenOrderTally?, ActionType)> DetermineActionAsync(
+        IQuerySession session,
+        MartenOrderTally? snapshot,
+        string identity,
+        IIdentitySetter<MartenOrderTally, string> identitySetter,
+        IReadOnlyList<IEvent> events,
+        CancellationToken cancellation)
+    {
+        snapshot ??= new MartenOrderTally { Id = identity };
+        snapshot.Count += events.Count;
+
+        return new ValueTask<(MartenOrderTally?, ActionType)>((snapshot, ActionType.Store));
+    }
+}
+
+/// <summary>
+/// #5329: an EF Core projection's data lives in a DbContext-managed table, never in Marten's
+/// conventional <c>mt_doc_&lt;tdoc&gt;</c> document table -- <c>FetchProjectionStorageAsync</c>
+/// already skips <c>EnsureStorageExistsAsync(typeof(TDoc))</c> for these types, so that table is
+/// never created. Rebuild teardown asked the wrong question anyway: every aggregate projection
+/// inherits <c>Options.DeleteViewTypeOnTeardown&lt;TDoc&gt;()</c> from JasperFx, so the rebuild
+/// queued a <c>truncate table mt_doc_customerorderhistory</c> that
+///
+/// <list type="bullet">
+/// <item>blew up with <c>42P01: relation does not exist</c> under
+/// <see cref="AutoCreate.None"/> -- the reported symptom; and</item>
+/// <item>silently left the REAL EF Core table fully populated even when it did not blow up, so a
+/// rebuild replayed on top of stale rows -- the quieter and worse half of the same bug.</item>
+/// </list>
+///
+/// Every test below runs with <see cref="AutoCreate.None"/> against a schema built by a separate
+/// migration pass, which is the reporter's deployment shape and the only one where the first
+/// failure is visible rather than papered over by Marten auto-creating an unused table. The store
+/// also carries a conventional Marten projection throughout, so the third test can prove the fix
+/// did not go too far the other way.
+/// </summary>
+public class Bug_5329_efcore_projection_rebuild_teardown: IAsyncLifetime
+{
+    private const string SchemaName = "efcore_rebuild_5329";
+
+    public async ValueTask InitializeAsync()
+    {
+        await dropSchemaAsync();
+
+        // Stand up the schema the way the reporter does: a migration pass that knows about the
+        // EF Core entity tables and the event store, but does not register the EF Core projection.
+        using var schemaStore = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = SchemaName;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Events.AddEventType<CustomerOrderPlaced>();
+            opts.Events.AddEventType<CustomerOrderCompleted>();
+            opts.AddEntityTablesFromDbContext<TestDbContext>();
+
+            // A conventional, Marten-stored projection shares the store, so every rebuild below
+            // exercises the new teardown guard in a mixed store rather than an EF-only one.
+            opts.Projections.Add(new MartenOrderTallyProjection(), ProjectionLifecycle.Async);
+        });
+
+        await schemaStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // The premise of the whole bug: the EF Core table exists, the Marten document table for the
+        // EF-backed aggregate does not -- while the conventional projection's document table does.
+        (await tableExistsAsync("ef_customer_order_histories")).ShouldBeTrue();
+        (await tableExistsAsync("mt_doc_customerorderhistory")).ShouldBeFalse();
+        (await tableExistsAsync("mt_doc_martenordertally")).ShouldBeTrue();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await dropSchemaAsync();
+    }
+
+    private static DocumentStore buildProjectionStore()
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = SchemaName;
+            opts.AutoCreateSchemaObjects = AutoCreate.None;
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Add(new CustomerOrderHistoryProjection(), ProjectionLifecycle.Async);
+            opts.Projections.Add(new MartenOrderTallyProjection(), ProjectionLifecycle.Async);
+        });
+    }
+
+    [Fact]
+    public async Task rebuild_does_not_try_to_truncate_a_marten_document_table()
+    {
+        using var store = buildProjectionStore();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(Guid.NewGuid().ToString(),
+                new CustomerOrderPlaced(Guid.NewGuid(), "Rebuild customer", 100.00m));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var daemon = await store.BuildProjectionDaemonAsync();
+
+        // Before the fix this threw Npgsql.PostgresException 42P01:
+        // relation "efcore_rebuild_5329.mt_doc_customerorderhistory" does not exist
+        await daemon.RebuildProjectionAsync<CustomerOrderHistoryProjection>(
+            TestContext.Current.CancellationToken);
+
+        var (totalOrders, totalSpent) = await readHistoryAsync("Rebuild customer");
+        totalOrders.ShouldBe(1);
+        totalSpent.ShouldBe(100.00m);
+
+        // ...and the rebuild must not have conjured the Marten table into existence either.
+        (await tableExistsAsync("mt_doc_customerorderhistory")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task rebuild_clears_stale_rows_out_of_the_ef_core_table()
+    {
+        using var store = buildProjectionStore();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(Guid.NewGuid().ToString(),
+                new CustomerOrderPlaced(Guid.NewGuid(), "Kept customer", 25.00m));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // A row no event in the store can produce. A correct teardown wipes it; the old behavior
+        // truncated an unrelated Marten table and left this sitting there forever.
+        await executeAsync(
+            "insert into ef_customer_order_histories (id, total_orders, total_spent) values ('Ghost customer', 99, 999.99)");
+
+        using var daemon = await store.BuildProjectionDaemonAsync();
+        await daemon.RebuildProjectionAsync<CustomerOrderHistoryProjection>(
+            TestContext.Current.CancellationToken);
+
+        (await rowExistsAsync("Ghost customer")).ShouldBeFalse();
+
+        var (totalOrders, totalSpent) = await readHistoryAsync("Kept customer");
+        totalOrders.ShouldBe(1);
+        totalSpent.ShouldBe(25.00m);
+    }
+
+    /// <summary>
+    /// The guard against fixing this in the wrong direction. Skipping teardown too eagerly would
+    /// leave a rebuilt Marten projection sitting on stale rows and still report success -- a worse
+    /// bug than the one being fixed, because nothing throws. This rebuilds an ordinary Marten
+    /// projection out of the SAME store as the EF Core one, so the guard is live, and proves its
+    /// document table is still truncated.
+    /// </summary>
+    [Fact]
+    public async Task rebuild_of_a_conventional_marten_projection_still_truncates_its_document_table()
+    {
+        using var store = buildProjectionStore();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(Guid.NewGuid().ToString(),
+                new CustomerOrderPlaced(Guid.NewGuid(), "Kept customer", 25.00m));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // A Marten document no event in the store can produce. Only a real truncate removes it.
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new MartenOrderTally { Id = "Ghost customer", Count = 99 });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var daemon = await store.BuildProjectionDaemonAsync();
+        await daemon.RebuildProjectionAsync<MartenOrderTallyProjection>(
+            TestContext.Current.CancellationToken);
+
+        await using var query = store.QuerySession();
+        var tallies = await query.Query<MartenOrderTally>()
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        tallies.Select(x => x.Id).ShouldBe(["Kept customer"]);
+        tallies.Single().Count.ShouldBe(1);
+    }
+
+    private static async Task<NpgsqlConnection> openConnectionAsync()
+    {
+        var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var setSchema = conn.CreateCommand();
+        setSchema.CommandText = $"SET search_path TO {SchemaName}";
+        await setSchema.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        return conn;
+    }
+
+    private static async Task executeAsync(string sql)
+    {
+        await using var conn = await openConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task<bool> tableExistsAsync(string tableName)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select to_regclass(@name) is not null";
+        cmd.Parameters.AddWithValue("name", $"{SchemaName}.{tableName}");
+        return (bool)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+    }
+
+    private static async Task<bool> rowExistsAsync(string id)
+    {
+        await using var conn = await openConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select exists(select 1 from ef_customer_order_histories where id = @id)";
+        cmd.Parameters.AddWithValue("id", id);
+        return (bool)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+    }
+
+    private static async Task<(int TotalOrders, decimal TotalSpent)> readHistoryAsync(string id)
+    {
+        await using var conn = await openConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select total_orders, total_spent from ef_customer_order_histories where id = @id";
+        cmd.Parameters.AddWithValue("id", id);
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
+        return (reader.GetInt32(0), reader.GetDecimal(1));
+    }
+
+    private static async Task dropSchemaAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"DROP SCHEMA IF EXISTS {SchemaName} CASCADE";
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/src/Marten.EntityFrameworkCore/EfCoreMultiStreamProjection.cs
+++ b/src/Marten.EntityFrameworkCore/EfCoreMultiStreamProjection.cs
@@ -63,6 +63,18 @@ public abstract class EfCoreMultiStreamProjection<
     {
         _schemaName = options.DatabaseSchemaName;
         var schemaName = _schemaName;
+
+        // #5329: point rebuild teardown at the table EF Core actually writes. The inherited
+        // DeleteViewTypeOnTeardown<TDoc>() cleanup names Marten's mt_doc_<tdoc> table, which is
+        // never created for an EF-backed projection; Marten's teardown skips it once the line
+        // below registers this type as having custom storage.
+        var efTable = EfCoreProjectionExtensions
+            .ResolveEntityTableIdentifier<TDoc, TDbContext>(schemaName, ConfigureDbContext);
+        if (efTable != null)
+        {
+            Options.DeleteDataInTableOnTeardown(efTable);
+        }
+
         options.CustomProjectionStorageProviders[typeof(TDoc)] = (session, tenantId) =>
         {
             var (dbContext, initialConnection) = session.Database.Create<TDbContext>(ConfigureDbContext, schemaName);

--- a/src/Marten.EntityFrameworkCore/EfCoreProjectionExtensions.cs
+++ b/src/Marten.EntityFrameworkCore/EfCoreProjectionExtensions.cs
@@ -4,10 +4,12 @@ using System.Linq;
 using JasperFx.Events.Projections;
 using Marten.Events.Projections;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Weasel.Core;
 using Weasel.EntityFrameworkCore;
 using Weasel.Postgresql;
 using Weasel.Postgresql.Tables;
+using ITable = Weasel.Core.ITable;
 
 namespace Marten.EntityFrameworkCore;
 
@@ -141,19 +143,71 @@ public static class EfCoreProjectionExtensions
 
         foreach (var entityType in DbContextExtensions.GetEntityTypesForMigration(dbContext))
         {
-            var table = migrator.MapToTable(entityType);
-
-            // Only move tables to the Marten schema if the entity does NOT have an
-            // explicit schema configured in EF Core. When a user has deliberately placed
-            // entities in a separate schema (e.g., via HasDefaultSchema or ToTable("name", "schema")),
-            // that schema should be respected. See https://github.com/JasperFx/marten/issues/4175
-            var efSchema = entityType.GetSchema();
-            if (efSchema == null && !string.IsNullOrEmpty(schemaName) && table is Table pgTable)
-            {
-                pgTable.MoveToSchema(schemaName);
-            }
-
-            options.Storage.ExtendedSchemaObjects.Add(table);
+            options.Storage.ExtendedSchemaObjects.Add(mapToMartenSchema(migrator, entityType, schemaName));
         }
+    }
+
+    /// <summary>
+    /// Map one EF Core entity type onto the Weasel table Marten will migrate for it.
+    /// </summary>
+    /// <remarks>
+    /// Only move tables to the Marten schema if the entity does NOT have an explicit schema
+    /// configured in EF Core. When a user has deliberately placed entities in a separate schema
+    /// (e.g., via HasDefaultSchema or ToTable("name", "schema")), that schema should be respected.
+    /// See https://github.com/JasperFx/marten/issues/4175
+    /// </remarks>
+    private static ITable mapToMartenSchema(PostgresqlMigrator migrator, IEntityType entityType, string? schemaName)
+    {
+        var table = migrator.MapToTable(entityType);
+
+        var efSchema = entityType.GetSchema();
+        if (efSchema == null && !string.IsNullOrEmpty(schemaName) && table is Table pgTable)
+        {
+            pgTable.MoveToSchema(schemaName);
+        }
+
+        return table;
+    }
+
+    /// <summary>
+    /// #5329: resolve the schema-qualified table EF Core actually persists <typeparamref name="TEntity"/>
+    /// into, so a rebuild tears down the projection's real data instead of Marten's never-created
+    /// <c>mt_doc_&lt;tdoc&gt;</c> table. Deliberately shares <see cref="mapToMartenSchema"/> with
+    /// <see cref="AddEntityTablesFromDbContext{TDbContext}"/> — the teardown target and the migrated
+    /// table have to be the same table, and they would drift apart the moment the schema rule was
+    /// spelled out twice.
+    /// </summary>
+    /// <returns>
+    /// The quoted, schema-qualified identifier, or null when the DbContext does not map the type at
+    /// all — in which case the projection cannot persist through EF Core either and fails loudly on
+    /// its first write, so there is nothing here to tear down.
+    /// </returns>
+    internal static string? ResolveEntityTableIdentifier<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors
+            | DynamicallyAccessedMemberTypes.NonPublicConstructors
+            | DynamicallyAccessedMemberTypes.PublicFields
+            | DynamicallyAccessedMemberTypes.NonPublicFields
+            | DynamicallyAccessedMemberTypes.PublicProperties
+            | DynamicallyAccessedMemberTypes.NonPublicProperties
+            | DynamicallyAccessedMemberTypes.Interfaces)]
+        TEntity,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TDbContext>(string? schemaName, Action<DbContextOptionsBuilder<TDbContext>>? configure)
+        where TDbContext : DbContext
+    {
+        // Same throwaway DbContext trick as AddEntityTablesFromDbContext: the connection is never
+        // opened, it only exists to satisfy UseNpgsql so the model can be read.
+        var builder = new DbContextOptionsBuilder<TDbContext>();
+        builder.UseNpgsql("Host=localhost");
+        configure?.Invoke(builder);
+
+        using var dbContext = (TDbContext)Activator.CreateInstance(typeof(TDbContext), builder.Options)!;
+
+        var entityType = dbContext.Model.FindEntityType(typeof(TEntity));
+        if (entityType?.GetTableName() == null) return null;
+
+        // ToString() rather than QualifiedName: EF Core tables are mapped with
+        // PreserveIdentifierCase, so a PascalCase table name has to keep its quoting to be found.
+        return mapToMartenSchema(new PostgresqlMigrator(), entityType, schemaName).Identifier.ToString();
     }
 }

--- a/src/Marten.EntityFrameworkCore/EfCoreSingleStreamProjection.cs
+++ b/src/Marten.EntityFrameworkCore/EfCoreSingleStreamProjection.cs
@@ -63,6 +63,18 @@ public abstract class EfCoreSingleStreamProjection<
     {
         _schemaName = options.DatabaseSchemaName;
         var schemaName = _schemaName;
+
+        // #5329: point rebuild teardown at the table EF Core actually writes. The inherited
+        // DeleteViewTypeOnTeardown<TDoc>() cleanup names Marten's mt_doc_<tdoc> table, which is
+        // never created for an EF-backed projection; Marten's teardown skips it once the line
+        // below registers this type as having custom storage.
+        var efTable = EfCoreProjectionExtensions
+            .ResolveEntityTableIdentifier<TDoc, TDbContext>(schemaName, ConfigureDbContext);
+        if (efTable != null)
+        {
+            Options.DeleteDataInTableOnTeardown(efTable);
+        }
+
         options.CustomProjectionStorageProviders[typeof(TDoc)] = (session, tenantId) =>
         {
             var (dbContext, initialConnection) = session.Database.Create<TDbContext>(ConfigureDbContext, schemaName);

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -361,7 +361,7 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
     {
         if (source.Options.TeardownDataOnRebuild)
         {
-            source.Options.TeardownForTenant(session, tenantId);
+            source.Options.TeardownForTenant(session, tenantId, Options);
         }
     }
 
@@ -369,7 +369,7 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
     {
         if (source.Options.TeardownDataOnRebuild)
         {
-            source.Options.Teardown(session);
+            source.Options.Teardown(session, Options);
         }
 
         foreach (var agent in source.Shards())

--- a/src/Marten/Events/Daemon/AsyncOptionsExtensions.cs
+++ b/src/Marten/Events/Daemon/AsyncOptionsExtensions.cs
@@ -7,12 +7,42 @@ namespace Marten.Events.Daemon;
 
 internal static class AsyncOptionsExtensions
 {
-    public static void Teardown(this AsyncOptions options, IDocumentOperations session)
+    /// <summary>
+    /// #5329: a <see cref="DeleteDocuments"/> cleanup names a document TYPE, and resolving that type
+    /// to a table only works if the type really is in Marten's document storage. Every aggregate
+    /// projection inherits <c>Options.DeleteViewTypeOnTeardown&lt;TDoc&gt;()</c> from
+    /// <c>JasperFxAggregationProjectionBase</c>, including ones whose data Marten does not own at all
+    /// — an EF Core projection writes to a DbContext-mapped table, and Marten never creates
+    /// <c>mt_doc_&lt;tdoc&gt;</c> for it (see
+    /// <c>DocumentSessionBase.FetchProjectionStorageAsync</c>, which consults this same registry to
+    /// skip <c>EnsureStorageExistsAsync(typeof(TDoc))</c> on the write path).
+    ///
+    /// <para>
+    /// So teardown asks the registry the same question the write path already asks: does this
+    /// document type have custom projection storage? If it does, its rows are somewhere else and the
+    /// document-table truncate is wrong — it either blows up with <c>42P01</c> under
+    /// <see cref="JasperFx.AutoCreate.None"/> (the reported symptom) or silently truncates an empty,
+    /// unused table while leaving the real data in place. Such a projection contributes its own
+    /// <see cref="DeleteTableData"/> cleanup naming the table it actually writes.
+    /// </para>
+    ///
+    /// <para>
+    /// A conventional Marten projection has no entry here, so nothing about its teardown changes.
+    /// </para>
+    /// </summary>
+    private static bool isStoredOutsideMarten(StoreOptions storeOptions, DeleteDocuments cleanup)
+    {
+        return storeOptions.CustomProjectionStorageProviders.ContainsKey(cleanup.DocumentType);
+    }
+
+    public static void Teardown(this AsyncOptions options, IDocumentOperations session, StoreOptions storeOptions)
     {
         foreach (var cleanUp in options.CleanUps)
         {
             if (cleanUp is DeleteDocuments documents)
             {
+                if (isStoredOutsideMarten(storeOptions, documents)) continue;
+
                 session.QueueOperation(new TruncateTable(documents.DocumentType));
             }
 
@@ -35,12 +65,16 @@ internal static class AsyncOptionsExtensions
     /// <c>AllDocumentsAreMultiTenanted*</c> policies, which are the only
     /// configurations compatible with <c>UseTenantPartitionedEvents</c>).
     /// </summary>
-    public static void TeardownForTenant(this AsyncOptions options, IDocumentOperations session, string tenantId)
+    public static void TeardownForTenant(this AsyncOptions options, IDocumentOperations session, string tenantId,
+        StoreOptions storeOptions)
     {
         foreach (var cleanUp in options.CleanUps)
         {
             if (cleanUp is DeleteDocuments documents)
             {
+                // #5329 — same reasoning as Teardown above: not Marten's table, not Marten's to wipe.
+                if (isStoredOutsideMarten(storeOptions, documents)) continue;
+
                 session.QueueOperation(new DeleteAllForTenant(documents.DocumentType, tenantId));
             }
 


### PR DESCRIPTION
Fixes #5329

## Two bugs, one cause — and the reported one is the safer half

**The reported bug (loud).** Rebuilding an EF Core projection through `IProjectionDaemon` tried to clear Marten's *conventional* document table for `TDoc`. That table is never created for an EF-persisted projection, so with the schema built by SQL migration and `AutoCreateSchemaObjects = AutoCreate.None`:

```
Npgsql.PostgresException : 42P01: relation "public.mt_doc_customerorderhistory" does not exist
```

**The unreported bug (silent, and worse).** Everywhere the first symptom *didn't* fire — i.e. any store where Marten had auto-created that unused table — the rebuild truncated an empty Marten table, left every real EF Core row in place, and **reported success**. So a rebuild silently replayed on top of stale data. Nothing threw, nothing logged, and the projection looked rebuilt. Before this PR, an EF Core projection's data was never cleared on rebuild at all.

The `42P01` is the better failure of the two: it fails loudly and stops. The silent one is the shape that ships.

Reproduced verbatim from @markotny's repro before touching anything:

```
truncate table efcore_rebuild_5329.mt_doc_customerorderhistory CASCADE
42P01: relation "efcore_rebuild_5329.mt_doc_customerorderhistory" does not exist
```

## Root cause

Every aggregate projection inherits `Options.DeleteViewTypeOnTeardown<TDoc>()` from `JasperFxAggregationProjectionBase`, and Marten's `AsyncOptionsExtensions.Teardown` turned that into a `TruncateTable(TDoc)` resolved through `session.StorageFor(...)`. But an EF Core projection's rows live in a `DbContext`-mapped table, and `DocumentSessionBase.FetchProjectionStorageAsync` already skips `EnsureStorageExistsAsync(typeof(TDoc))` for these types — so `mt_doc_<tdoc>` is never created. Teardown simply never asked the question the write path already asks.

## The fix

Teardown consults `StoreOptions.CustomProjectionStorageProviders` — the same registry the write path uses — and skips a `DeleteDocuments` cleanup whose type is not in Marten document storage. The EF Core projections then register the table they *actually* write via `Options.DeleteDataInTableOnTeardown`, resolved through the same EF-model mapping and schema rule that `AddEntityTablesFromDbContext` uses to create it (factored into a shared `mapToMartenSchema`, so the teardown target and the migrated table cannot drift apart).

Considered and rejected: adding a teardown member to `IProjectionStorage<TDoc,TId>`, or giving `AsyncOptions.CleanUps` a removal API so the EF projection could drop the inherited cleanup. Both need a JasperFx release and a pin bump to land a Marten bug fix; the registry lookup is Marten-side only and reuses a seam that already exists to answer exactly this question.

## Blast radius

Rebuild teardown is shared by every projection type, and skipping too eagerly would leave real Marten projections sitting on stale rows while still reporting success — the same silent-success shape, just pointed at a different table. A conventional projection has no entry in `CustomProjectionStorageProviders`, so nothing about its teardown changes, and that is asserted rather than assumed:

- `Bug_5329...rebuild_of_a_conventional_marten_projection_still_truncates_its_document_table` rebuilds an ordinary Marten projection **out of the same store as the EF Core one**, so the guard is live, and asserts a seeded row that no event produces is gone afterwards.
- `AsyncOptionsTests.teardown_skips_view_types_that_are_not_stored_by_marten` (and its per-tenant twin) pin the sibling type that must *still* be truncated.

Falsified rather than assumed: making the skip unconditional fails exactly the conventional-projection test and leaves the two EF ones green. `DaemonTests.build_aggregate_projection.rebuild_the_projection_clears_state` — the existing regression test for "conventional projection data IS deleted on rebuild" — also passes.

Composite projections route every leaf through the same `teardownProjectionStorage`, so EF members added via `composite.Add(...)` get the same treatment.

## Known limitation

A **per-tenant** rebuild scopes the wipe with `delete from <entity table> where tenant_id = ?`. That column name is not read from the EF model, so it works for a snake_case `DbContext` (as the conjoined-tenancy sample and tests use) but yields `42703` under EF Core's default `TenantId` naming. Strictly better than the previous unconditional `42P01`, but documented in `docs/events/projections/efcore.md` and tracked in #5351 rather than left in a PR thread.

## Found but deliberately not fixed here

The same wrong assumption exists in **schema generation**: registering an EF Core projection makes Marten build a `DocumentMapping` for `TDoc` and create a useless `mt_doc_<tdoc>` table, and it throws `InvalidDocumentException` from every full-schema operation for an EF entity whose key is not named `Id`. Filed as #5351. That change alters which schema objects Marten generates for *all* stores, so its regression surface is the schema/migration suites rather than the daemon suites — a much wider blast radius than a teardown fix, and not something to bundle late in a cycle alongside a concurrent JasperFx/Weasel pin bump.

## Validation

- `Marten.EntityFrameworkCore.Tests` — 48/48 green (45 pre-existing + 3 new), re-run after merging current `master`.
- `DaemonTests` teardown/rebuild areas — `multistream_data_teardown_on_rebuild`, `Bug_5175_composite_member_teardown`, `rebuilding_an_inline_projection`, `AsyncOptionsTests` — green.
- Full `DaemonTests` run compared against an unmodified `origin/master` baseline; the residual failures are pre-existing and unrelated to teardown (high-water detection, gap detectors, dead letters, coordinator lifecycle).
- `src/Marten` and `src/Marten.EntityFrameworkCore` build clean on both `net9.0` and `net10.0`.
- Docs updated; markdownlint and cspell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)