### PR TITLE
Adopt JasperFx 2.65.0 and Weasel 9.31.0 (#5347)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -447,16 +447,57 @@
          listener; jasperfx#762 adds facts to FetchLatestCompliance, StreamArchivingCompliance,
          EventDataMaskingCompliance and StrongTypedIdentityCompliance; jasperfx#774/#775 add the two
          FlatTableProjectionCompliance facts that pin Increment/Decrement onto a row that does not
-         exist yet => the increment half is marten#5342, already fixed on this branch's base. -->
-    <PackageVersion Include="JasperFx" Version="2.64.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.64.0" />
+         exist yet => the increment half is marten#5342, already fixed on this branch's base.
+
+         JasperFx 2.65.0 (marten#5347): the answer to what marten#5343's first-ever runtime run of
+         those suites found. One product fix Marten consumes directly plus two suite fixes, all in
+         jasperfx#780/#784, and no new API.
+
+         jasperfx#780, the product half: JasperFxSingleStreamProjectionBase.ApplyInline left
+         `transformed` null when an Archived event arrived with NO other handled event in the same
+         batch, so an early `continue` skipped maybeArchiveStream and the stream stayed live. The
+         tell that it was a bug rather than intent is that the ownership gate below it,
+         `ownsStream: snapshot != null || transformed != null`, had a DEAD disjunct — the only way
+         past the `continue` was `transformed != null` — and that disjunct documents exactly the
+         intent the `continue` defeated. Reproduced under both Guid and string stream identity, so
+         the identity in the failing fact's name is incidental.
+
+         BUT this does NOT close the archiving fact, and 2.65.0 is not the release that will.
+         Measured on this bump: stream_archiving_compliance.capturing_an_archived_event_archives_a_
+         string_identified_stream is still red, and a Marten-local reproduction of the lone-marker
+         case fails identically. jasperfx#784 (gh-778) says why in its own commit message — "#780
+         closed the inline `continue` ... and on Fisher that changed nothing: both of
+         StreamArchivingCompliance's archived-event facts still failed against it". Two gates sit
+         OUTSIDE the one #780 closed, and the outer one is decisive: Archived is not in a single
+         stream projection's AllEventTypes (an aggregate has no reason to declare an Apply for a
+         stateless marker), so AppliesTo answered false and ApplyInline's opening
+         `streams.Where(x => AppliesTo(...))` screened the stream out before the `continue` was ever
+         reached. #784 merged AFTER the 2.65.0 version-bump commit and is not in the published
+         package, so this fact stays red until a JasperFx release carries it. The Marten-local
+         regression is added on this bump in archiving_events.cs but SKIPPED with that reason, since
+         the blind spot that let this through is that every one of Marten's own archiving tests
+         appends a handled event beside the marker.
+
+         jasperfx#780, the suite half: the two ProjectionSideEffectCompliance rebuild facts asked
+         the daemon for nameof(ComplianceWatchtowerProjection), which silently assumed a store names
+         a projection after the PROJECTION type; Marten names it after the aggregated DOCUMENT type.
+         Neither convention is wrong, which is precisely why a shared suite must not depend on
+         either — the projection now pins its own Name. And AggregateToLinqOperatorCompliance's
+         can_aggregate_with_initial_state_asynchronously asserted a merge of creator output into
+         supplied state that no store performs; the over-tight assertion was dropped.
+
+         Not in 2.65.0: jasperfx#784 (gh-778), which is the commit that actually closes the archiving
+         fact — see above. Track it with the next JasperFx bump. -->
+
+    <PackageVersion Include="JasperFx" Version="2.65.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.65.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.64.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.65.0" />
     <!--
       No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
       whole family moves together, and this note is kept for the history below. This package is
@@ -475,11 +516,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.64.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.65.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.64.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.65.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
@@ -530,7 +571,7 @@
     <PackageVersion Include="Vogen" Version="7.0.0" />
     <!-- 9.16.2: the hold at 9.2.1 (were newer builds actually being published?) is resolved —
          Weasel.EntityFrameworkCore is on nuget.org, so it tracks the rest of the Weasel line. -->
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.29.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.31.0" />
     <!-- Weasel.Postgresql 9.1.x: managed LIST partitions under multi-database (sharded) apply.
          9.1.2 (marten#4706): managed-partition tables are no longer destructively rebuilt — the
          out-of-band AddPartitionToAllTables path creates partitions while the generic schema diff
@@ -679,9 +720,32 @@
          matters because a changed index expression makes Weasel drop and recreate the index.
          Also arriving: 9.28.0 (weasel#538) lets a rebuildable Invalid delta through
          AssertPatchingIsValid, and weasel#539/#540 are SQLite and foreign-key-cycle fixes with no
-         Marten surface. -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.29.0" />
-    <PackageVersion Include="Weasel.Storage" Version="9.29.0" />
+         Marten surface.
+
+         9.31.0 (weasel#579/#580, raised from marten#5345): AssertStreamVersionOperation no longer
+         treats "no row came back" as an unconditional conflict. A stream with no row is at version
+         0, so that is a conflict only when the caller expected something other than 0 — and under
+         AlwaysEnforceConsistency on a never-created stream the caller expects exactly 0, which is
+         how the guard managed to throw "expected 0 but was 0". The operation is shared with Polecat,
+         which is why the fix belongs here rather than in Marten skipping the queue. Closes
+         always_enforce_consistency_compliance.with_the_flag_on_a_never_created_stream_commits with
+         no Marten change; the suite's own remark had named this as "the case a naive 'is there a
+         row?' implementation gets wrong".
+
+         This bump also skips 9.30.0, so more than one release of delta arrives. The one item with a
+         Marten-visible behaviour change is weasel#577/#578: ChangeTracker.DetectChanges no longer
+         falls back to JsonNode.DeepEquals when the ordinal string compare misses, unless
+         IStorageSession.UseSemanticJsonChangeDetection is turned on (a default interface member,
+         defaulting to false, so Marten needs no change to compile). The consequence for a dirty-
+         tracking session is that a document whose Dictionary/HashSet members were REORDERED without
+         changing content is now reported as changed. That can only ever cost a redundant,
+         semantically identical write — never a missed one — which is the safe direction for a
+         detector whose real hazard is dropping a user's edit. The rest of 9.30.0/9.31.0 is lifts and
+         allocation work with no Marten surface: streaming JSON column reads (weasel#576), the
+         flat-table decrement parameter fix already consumed via jasperfx#773, MasterTableTenancy and
+         EventLoaderBase lifts, and precomputed parameter names. -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.31.0" />
+    <PackageVersion Include="Weasel.Storage" Version="9.31.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <!-- The whole test suite is on xunit v3. VSTest stays the execution mode, so the
          Nuke targets and the GitHub workflows are unaffected. -->

--- a/src/CoreTests/StoreOptionsTests.cs
+++ b/src/CoreTests/StoreOptionsTests.cs
@@ -30,7 +30,9 @@ public class StoreOptionsTests
     [Fact]
     public void STJ_is_the_default_serializer()
     {
-        new StoreOptions().Serializer().ShouldBeOfType<SystemTextJsonSerializer>();
+        // Qualified since Weasel 9.30.0 lifted an STJ serializer of the same simple name into
+        // Weasel.Core (weasel#559). Marten's is the one that has to be the default.
+        new StoreOptions().Serializer().ShouldBeOfType<Marten.Services.SystemTextJsonSerializer>();
     }
 
     [Fact]

--- a/src/EventSourcingTests/Bugs/Bug_2465_make_event_serialization_strategy_be_lazy.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2465_make_event_serialization_strategy_be_lazy.cs
@@ -22,8 +22,10 @@ public class Bug_2465_make_event_serialization_strategy_be_lazy : BugIntegration
             o.Events.AddEventType<TestEvent>();
 
             // If this is set before adding the events works fine
+            // Qualified since Weasel 9.30.0 lifted an STJ serializer of the same simple name into
+            // Weasel.Core (weasel#559); this test is about Marten's.
             o.Serializer(
-                new SystemTextJsonSerializer { EnumStorage = EnumStorage.AsString });
+                new Marten.Services.SystemTextJsonSerializer { EnumStorage = EnumStorage.AsString });
         });
         await using var session = theStore.LightweightSession();
         var @event = new TestEvent()

--- a/src/EventSourcingTests/archiving_events.cs
+++ b/src/EventSourcingTests/archiving_events.cs
@@ -370,6 +370,53 @@ public class archiving_events: OneOffConfigurationsContext, IAsyncLifetime
     }
 
 
+    /// <summary>
+    /// #5347 / jasperfx#778: the same thing as the fact above, except the <c>Archived</c> marker
+    /// arrives <em>alone</em>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// That distinction is the whole test, and the blind spot it covers is this file's own: every
+    /// other archiving test here appends <c>new DEvent()</c> beside the marker, so not one of them
+    /// exercises the lone-marker case. It took a shared compliance fact to find it.
+    /// </para>
+    /// <para>
+    /// <b>Skipped deliberately, and not because the case is unimportant.</b> jasperfx#780 (in the
+    /// 2.65.0 bump this test arrives on) closed the inline <c>continue</c> in
+    /// <c>JasperFxSingleStreamProjectionBase.ApplyInline</c>, but that is not the gate that decides
+    /// this: <c>Archived</c> is absent from a single stream projection's <c>AllEventTypes</c>, since
+    /// an aggregate has no reason to declare an <c>Apply</c> for a stateless marker, so
+    /// <c>AppliesTo</c> answers false and the stream is screened out before the <c>continue</c> is
+    /// ever reached. jasperfx#784 is the commit that closes it, and it merged after the 2.65.0
+    /// version bump, so it is not in the published package. Measured on this bump rather than
+    /// assumed — this test and
+    /// <c>stream_archiving_compliance.capturing_an_archived_event_archives_a_string_identified_stream</c>
+    /// fail identically. Unskip on the JasperFx bump that carries jasperfx#784.
+    /// </para>
+    /// </remarks>
+    [Fact(Skip =
+        "Blocked on a JasperFx release carrying jasperfx#784 (gh-778). 2.65.0 has jasperfx#780, which is not the gate that decides this -- see the remarks. Unskip with that bump.")]
+    public async Task capture_a_lone_archived_event_with_inline_projection_will_archive_the_stream()
+    {
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent());
+        await theSession.SaveChangesAsync();
+
+        // No handled event beside the marker -- the case the four tests around this one all miss.
+        theSession.Events.Append(streamId, new Archived("Complete"));
+        await theSession.SaveChangesAsync();
+
+        var events = await theSession.Events.QueryAllRawEvents()
+            .Where(x => x.MaybeArchived() && x.StreamId == streamId).ToListAsync();
+
+        events.ShouldNotBeEmpty();
+        events.All(x => x.IsArchived).ShouldBeTrue();
+    }
+
+
     [Fact]
     public async Task capture_archived_event_with_inline_custom_projection_will_archive_the_stream()
     {

--- a/src/LinqTests/Acceptance/json_naming_attributes.cs
+++ b/src/LinqTests/Acceptance/json_naming_attributes.cs
@@ -38,7 +38,9 @@ public class json_naming_attributes
         {
             opts.Connection(ConnectionSource.ConnectionString);
             opts.DatabaseSchemaName = "atts";
-            opts.Serializer<SystemTextJsonSerializer>();
+            // Qualified since Weasel 9.30.0 lifted an STJ serializer of the same simple name into
+            // Weasel.Core (weasel#559); this test is about Marten's.
+            opts.Serializer<Marten.Services.SystemTextJsonSerializer>();
         });
 
         using var session = store.LightweightSession();

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -841,7 +841,14 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
         Casing casing = Casing.Default,
         Action<JsonSerializerOptions>? configure = null)
     {
-        var serializer = new SystemTextJsonSerializer(options) { EnumStorage = enumStorage, Casing = casing, };
+        // Fully qualified because Weasel 9.30.0 lifted the STJ serializer shared by Polecat and
+        // Fisher into Weasel.Core under the same simple name (weasel#559). Marten's own
+        // SystemTextJsonSerializer is public API with Marten-specific behaviour, so it stays the one
+        // this method builds.
+        var serializer = new Marten.Services.SystemTextJsonSerializer(options)
+        {
+            EnumStorage = enumStorage, Casing = casing,
+        };
 
         if (configure is not null)
             serializer.Configure(configure);


### PR DESCRIPTION
Addresses #5347 (and closes #5345 by consuming the Weasel fix). **#5347 stays open** — see below.

Bumps `JasperFx*` **2.64.0 → 2.65.0** and `Weasel.*` **9.29.0 → 9.31.0**, consuming the two releases that answer what #5343's first-ever runtime run of the event-store compliance suites found.

**Four of the six red facts on `master` go green, with no Marten behaviour change of its own.** The fifth is #5346. The sixth was expected to close here and does not — that is the finding of this PR.

## Green from Weasel 9.31.0

`always_enforce_consistency_compliance.with_the_flag_on_a_never_created_stream_commits` (#5345, fixed as weasel#579/#580).

`AssertStreamVersionOperation.PostprocessAsync` no longer reads "no row came back" as an unconditional conflict. A stream with no row is at version **0**, so that is a conflict only when the caller expected something other than 0 — and under `AlwaysEnforceConsistency` on a never-created stream the caller expects exactly 0, which is how the guard managed to throw `expected 0 but was 0`. Fixed in Weasel rather than Marten because the operation is shared with Polecat. No Marten change.

## Green from JasperFx 2.65.0 (jasperfx#780, the suite half)

- `projection_side_effect_compliance.side_effects_are_suppressed_during_a_rebuild`
- `projection_side_effect_compliance.no_messages_are_published_during_a_rebuild`

Both asked the daemon for `nameof(ComplianceWatchtowerProjection)`, silently assuming a store names a projection after the *projection* type; Marten names it after the aggregated *document* type. Neither convention is wrong, which is exactly why the suite must not depend on either — it now pins the projection's `Name`.

- `aggregate_to_linq_operator_compliance.can_aggregate_with_initial_state_asynchronously`

Its two assertions could not both hold under any coherent implementation. The over-tight one was dropped.

## Still red, and this is the finding: `capturing_an_archived_event_archives_a_string_identified_stream`

#5347 expected 2.65.0 to close this. **It does not**, and I measured that rather than assuming either way.

jasperfx#780 closed the inline `continue` in `JasperFxSingleStreamProjectionBase.ApplyInline` — but that is not the gate that decides this fact. `Archived` is absent from a single stream projection's `AllEventTypes`, because an aggregate has no reason to declare an `Apply` for a stateless marker. So `AppliesTo` answers false and `ApplyInline`'s opening `streams.Where(x => AppliesTo(...))` screens the whole stream out **before the `continue` #780 fixed is ever reached**.

jasperfx#784 (gh-778) is the commit that closes it, and its own message says so: *"#780 closed the inline `continue` … and on Fisher that changed nothing: both of `StreamArchivingCompliance`'s archived-event facts still failed against it."* #784 merged **after** the 2.65.0 version-bump commit and is not in the published package.

Corroborated locally rather than inferred from the shared fact alone: a Marten-local reproduction of the lone-marker case fails identically on 2.65.0. That reproduction is added here in `archiving_events.cs` and **skipped**, with the reason and the unskip condition written on the `Skip` string and in the remarks — because this file's own blind spot is precisely that *every other* archiving test in it appends `new DEvent()` beside the marker, which is why none of them ever caught this and a shared compliance fact had to.

**So #5347 stays open** pending a JasperFx release carrying jasperfx#784. Two of its three named facts are closed here; the third is not.

## Weasel 9.30.0 rides along

Skipping a release means more delta than usual. Two items have a Marten surface:

- **weasel#559** lifted the STJ serializer shared by Polecat and Fisher into `Weasel.Core` under the same simple name as `Marten.Services.SystemTextJsonSerializer`, so five call sites went ambiguous (CS0104) across `Marten`, `CoreTests`, `EventSourcingTests` and `LinqTests`. Qualified in place rather than aliased: five sites is not the repo-wide collision that earned the alias blocks in `GlobalUsings.cs`, and #5346 exists to *remove* such blocks rather than add one.
- **weasel#577/#578** puts `ChangeTracker`'s `JsonNode.DeepEquals` fallback behind `UseSemanticJsonChangeDetection`, a default interface member defaulting to **false**. A dirty-tracking session now reports a document whose `Dictionary`/`HashSet` members were **reordered without changing content** as changed. That can only ever cost a redundant, semantically identical write — never a missed one — which is the safe direction for a detector whose real hazard is dropping a user's edit. No Marten test depends on the old behaviour.

The rest is lifts and allocation work with no Marten surface. All of it is written up at the pins in `Directory.Packages.props`, as that file does for every other bump.

## Testing

**Each suite against its own freshly created database.** These suites share schema names, and CI gives each project its own database; running two of them concurrently against one shared database produced a deadlock and left corrupted schema state that then presented as 15–23 spurious `MartenSchemaException` failures across two runs with *different* failing sets each time. On clean databases every one of those disappears. Worth recording, because that failure mode reads convincingly like a migration regression in the bump and is not one.

| Suite | Result |
|---|---|
| `EventSourcingTests` | **2192 passed, 2 failed, 21 skipped** |
| `DaemonTests` | **319 passed, 0 failed** |
| `CoreTests` | **603 passed, 0 failed, 7 skipped** |
| `LinqTests` | **1460 passed, 0 failed** |

Full solution builds clean on net9.0 and net10.0. The 2 failures are the archiving fact above and `a_unit_of_work_that_fails_publishes_nothing` (#5346).

**Red compliance facts: 6 → 2.** With #5349 earlier today that is **9 → 2** for the day. No new failures, so nothing needed classifying as a Marten bug, suite bug, or divergence.

No NuGet package was published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
