### PR TITLE
gh-5346: name Marten's own six exceptions from the compliance fixture

### DIFF
--- a/src/Marten.Testing/Harness/MartenComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenComplianceFixture.cs
@@ -495,6 +495,42 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
     /// </summary>
     public override bool SupportsUnarchiveStream => false;
 
+    /// <summary>
+    ///     Marten names its own six exceptions rather than the ones lifted into JasperFx.Events by
+    ///     jasperfx#751.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Not an oversight and not a gap. Marten enforces
+    ///         CoreTests.all_exceptions_should_derive_from_MartenException:
+    ///         every exception Marten throws must derive from MartenException, so that a caller can
+    ///         catch the whole family in one clause. C# has single inheritance, so a Marten type
+    ///         cannot derive from both MartenException and the lifted JasperFx type -- adopting the
+    ///         shared types by subclassing, the way Polecat and Fisher did, would break that
+    ///         convention. Marten therefore keeps all six in Marten.Exceptions and nominates them
+    ///         here. Revisiting the convention is deferred to Marten 10 (marten#5346).
+    ///     </para>
+    ///     <para>
+    ///         Fully qualified because JasperFx.Events is imported above and declares six types of
+    ///         exactly these names; the unqualified name would silently resolve to the wrong one and
+    ///         the assertion would fail with a type mismatch rather than a compile error.
+    ///     </para>
+    /// </remarks>
+    public override Type ExceptionTypeFor(ComplianceExceptionKind kind) =>
+        kind switch
+        {
+            ComplianceExceptionKind.UnknownEventType => typeof(Marten.Exceptions.UnknownEventTypeException),
+            ComplianceExceptionKind.NonExistentStream => typeof(Marten.Exceptions.NonExistentStreamException),
+            ComplianceExceptionKind.ExistingStreamIdCollision =>
+                typeof(Marten.Exceptions.ExistingStreamIdCollisionException),
+            ComplianceExceptionKind.EventDeserializationFailure =>
+                typeof(Marten.Exceptions.EventDeserializationFailureException),
+            ComplianceExceptionKind.StreamLocked => typeof(Marten.Exceptions.StreamLockedException),
+            ComplianceExceptionKind.DefaultTenantUsageDisabled =>
+                typeof(Marten.Exceptions.DefaultTenantUsageDisabledException),
+            _ => base.ExceptionTypeFor(kind)
+        };
+
     public override async ValueTask DisposeAsync()
     {
         foreach (var disposable in _disposables)


### PR DESCRIPTION
Closes #5346.

## The ruling

Marten keeps its own six event store exceptions. **No existing Marten behaviour changes.** Adoption
of the exceptions lifted into `JasperFx.Events` by JasperFx/jasperfx#751 is deferred to Marten 10.
The compliance suite is made variable on exception type instead (JasperFx/jasperfx#791).

Adopting the lifted types by subclassing, the way Polecat and Fisher did, would break
`all_exceptions_should_derive_from_MartenException`: C# has single inheritance, so a Marten type
cannot derive from both `MartenException` and the lifted JasperFx type.

## What this changes

One override on `MartenComplianceFixture`, naming Marten's own six:

| Kind | Marten type |
|---|---|
| `UnknownEventType` | `Marten.Exceptions.UnknownEventTypeException` |
| `NonExistentStream` | `Marten.Exceptions.NonExistentStreamException` |
| `ExistingStreamIdCollision` | `Marten.Exceptions.ExistingStreamIdCollisionException` |
| `EventDeserializationFailure` | `Marten.Exceptions.EventDeserializationFailureException` |
| `StreamLocked` | `Marten.Exceptions.StreamLockedException` |
| `DefaultTenantUsageDisabled` | `Marten.Exceptions.DefaultTenantUsageDisabledException` |

**No Marten production code changed** — one test-harness file, 36 added lines, nothing removed.

## This unblocks only half of one fact

`a_unit_of_work_that_fails_publishes_nothing` is still red, and legitimately so. Behind the exception
type assertion sits a second, independent bug: a failed unit of work still commits an outbox batch.
Run locally against jasperfx#791 via `ComplianceSourceDir`, the fact now gets past the type
assertion and fails on:

```
Shouldly.ShouldAssertException : _outbox.CommittedBatches
    should be empty but had
1
    item
```

That is #5353. Not chased here and deliberately not weakened.

## Merge ordering — please read

This does **not** compile against the currently referenced `JasperFx.Events.ComplianceTests`
package, because `ComplianceExceptionKind` and `ExceptionTypeFor` do not exist there yet:

```
src/Marten.Testing/Harness/MartenComplianceFixture.cs(519,43): error CS0246:
  The type or namespace name 'ComplianceExceptionKind' could not be found
```

`Marten.Testing.csproj` references the published package unconditionally — it has no
`ComplianceSourceDir` switch, unlike `EventSourcingTests.csproj`. So merging this before the JasperFx
package bump breaks `master`'s build. **Hold until jasperfx#791 is released and adopted**, the same
ordering as #5347.

## Validation

Built and run against jasperfx#791 via
`-p:ComplianceSourceDir=<jasperfx>/src/JasperFx.Events.ComplianceTests`, on a private database
(`marten_testing_database` pointed at a dedicated `marten_5346_varexc`) rather than shared
`marten_testing` state.

`projection_side_effect_compliance`: 9 total, 8 passed, 1 failed — the #5353 outbox assertion above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)