### PR TITLE
Adopt JasperFx 2.66.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -487,17 +487,48 @@
          supplied state that no store performs; the over-tight assertion was dropped.
 
          Not in 2.65.0: jasperfx#784 (gh-778), which is the commit that actually closes the archiving
-         fact — see above. Track it with the next JasperFx bump. -->
+         fact — see above. Track it with the next JasperFx bump.
 
-    <PackageVersion Include="JasperFx" Version="2.65.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.65.0" />
+         JasperFx 2.66.0: the bump that carries jasperfx#784, and it does what the 2.65.0 note said
+         it would. Measured on this bump rather than assumed:
+
+         stream_archiving_compliance.capturing_an_archived_event_archives_a_string_identified_stream
+         PASSES. On 2.65.0 it failed `state.IsArchived should be True but was False`. #784 closed the
+         two gates outside the one #780 closed — the decisive one being that Archived is absent from
+         a single stream projection's AllEventTypes, so AppliesTo answered false and ApplyInline's
+         opening `streams.Where(x => AppliesTo(...))` screened the stream out before the `continue`
+         was ever reached. The Marten-local regression added SKIPPED on the 2.65.0 bump
+         (archiving_events.cs, capture_a_lone_archived_event_with_inline_projection_will_archive_the_
+         stream) is UNSKIPPED here, which its own remarks instructed — and it passes, so the local
+         reproduction and the shared fact agree on the way out exactly as they agreed on the way in.
+
+         Also in 2.66.0 and consumed by marten#5354 rather than by this file: jasperfx#791 adds
+         ComplianceExceptionKind, which is what lets MartenComplianceFixture name Marten's own six
+         exception types to the shared suite. #5354 could not compile against the 2.65.0 pin because
+         Marten.Testing references JasperFx.Events.ComplianceTests unconditionally (no
+         ComplianceSourceDir switch, unlike EventSourcingTests), so it was deliberately held open
+         until this bump landed. Merge order is therefore this bump FIRST, then #5354.
+
+         STILL RED after this bump, and correctly so:
+         projection_side_effect_compliance.a_unit_of_work_that_fails_publishes_nothing. On the 2.65.0
+         pin and on this one before #5354 it fails on the exception-type assertion — "Expected
+         ExistingStreamIdCollisionException ... but got Marten.Exceptions.ExistingStreamIdCollision
+         Exception", the fixture not naming Marten's own type rather than a behavioural difference.
+         With #5354 merged it gets PAST that assertion and fails on
+         `_outbox.CommittedBatches should be empty but had 1 item`, which is marten#5353, a genuine
+         outbox bug. That transition is the evidence #5354 worked; the fact stays red until #5353 is
+         fixed and must not be weakened to make it green. -->
+
+
+    <PackageVersion Include="JasperFx" Version="2.66.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.66.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.65.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.66.0" />
     <!--
       No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
       whole family moves together, and this note is kept for the history below. This package is
@@ -516,11 +547,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.65.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.66.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.65.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.66.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/archiving_events.cs
+++ b/src/EventSourcingTests/archiving_events.cs
@@ -381,21 +381,20 @@ public class archiving_events: OneOffConfigurationsContext, IAsyncLifetime
     /// exercises the lone-marker case. It took a shared compliance fact to find it.
     /// </para>
     /// <para>
-    /// <b>Skipped deliberately, and not because the case is unimportant.</b> jasperfx#780 (in the
-    /// 2.65.0 bump this test arrives on) closed the inline <c>continue</c> in
+    /// <b>Was skipped through the 2.65.0 pin, and is live again as of 2.66.0.</b> jasperfx#780 (in
+    /// the 2.65.0 bump this test arrived on) closed the inline <c>continue</c> in
     /// <c>JasperFxSingleStreamProjectionBase.ApplyInline</c>, but that is not the gate that decides
     /// this: <c>Archived</c> is absent from a single stream projection's <c>AllEventTypes</c>, since
     /// an aggregate has no reason to declare an <c>Apply</c> for a stateless marker, so
     /// <c>AppliesTo</c> answers false and the stream is screened out before the <c>continue</c> is
-    /// ever reached. jasperfx#784 is the commit that closes it, and it merged after the 2.65.0
-    /// version bump, so it is not in the published package. Measured on this bump rather than
-    /// assumed — this test and
+    /// ever reached. jasperfx#784 is the commit that closes it; it merged after the 2.65.0 version
+    /// bump and shipped in <b>2.66.0</b>, which is the bump that unskipped this. Measured rather
+    /// than assumed on both bumps — on 2.65.0 this test and
     /// <c>stream_archiving_compliance.capturing_an_archived_event_archives_a_string_identified_stream</c>
-    /// fail identically. Unskip on the JasperFx bump that carries jasperfx#784.
+    /// failed identically, and on 2.66.0 both pass.
     /// </para>
     /// </remarks>
-    [Fact(Skip =
-        "Blocked on a JasperFx release carrying jasperfx#784 (gh-778). 2.65.0 has jasperfx#780, which is not the gate that decides this -- see the remarks. Unskip with that bump.")]
+    [Fact]
     public async Task capture_a_lone_archived_event_with_inline_projection_will_archive_the_stream()
     {
         StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));


### PR DESCRIPTION
## What

Bumps the five JasperFx pins from 2.65.0 to 2.66.0, and unskips the one Marten-local test that was explicitly waiting on this release.

## Why

The 2.65.0 note in `Directory.Packages.props` ends: *"Not in 2.65.0: jasperfx#784 (gh-778), which is the commit that actually closes the archiving fact — see above. Track it with the next JasperFx bump."* This is that bump.

## Result — measured on the bump, not assumed

Compliance suites (`EventSourcingTests.Compliance`, net10.0): **2 red → 1 red**, 517 total, 503 passed, 13 skipped.

**Cleared:** `stream_archiving_compliance.capturing_an_archived_event_archives_a_string_identified_stream` — failed `state.IsArchived should be True but was False` on the 2.65.0 pin, passes here. #784 closed the two gates outside the one #780 closed; the decisive one is that `Archived` is absent from a single stream projection's `AllEventTypes`, so `AppliesTo` answered false and `ApplyInline`'s opening `streams.Where(x => AppliesTo(...))` screened the stream out before the `continue` was ever reached.

**Unskipped:** `archiving_events.capture_a_lone_archived_event_with_inline_projection_will_archive_the_stream`, added SKIPPED on the 2.65.0 bump with remarks saying to unskip on the release carrying #784. All 30 `archiving_events` tests now pass with **nothing skipped** — the local reproduction and the shared fact agree on the way out exactly as they agreed on the way in.

## What stays red, deliberately

`projection_side_effect_compliance.a_unit_of_work_that_fails_publishes_nothing`.

On this bump it still fails on the **exception-type** assertion — `Expected ExistingStreamIdCollisionException ... but got Marten.Exceptions.ExistingStreamIdCollisionException` — which is the fixture not naming Marten's own type, not a behavioural difference. That is exactly what **marten#5354** fixes, and #5354 needs `ComplianceExceptionKind` from jasperfx#791, which ships in 2.66.0. `Marten.Testing` references `JasperFx.Events.ComplianceTests` unconditionally (no `ComplianceSourceDir` switch, unlike `EventSourcingTests`), so #5354 could not compile against the 2.65.0 pin and was held open on purpose.

**Merge order: this PR first, then #5354.** With #5354 merged the fact gets past the type assertion and fails on `_outbox.CommittedBatches should be empty but had 1 item` — which is **marten#5353**, a genuine outbox bug. That transition is the evidence #5354 worked. The fact stays red until #5353 is fixed, and must not be weakened to make it green.

## CI

Actions is stalled org-wide, so this was validated locally against a private database: the compliance suites and the full `archiving_events` class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)