### PR TITLE
gh-5353: a failed unit of work must not commit its outbox batch

### DIFF
--- a/src/DaemonTests/Bugs/Bug_5353_daemon_outbox_hooks_bracket_the_commit.cs
+++ b/src/DaemonTests/Bugs/Bug_5353_daemon_outbox_hooks_bracket_the_commit.cs
@@ -1,0 +1,92 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.Aggregations;
+using JasperFx.Events.Daemon;
+using Marten.Events.Daemon.Internals;
+using Marten.Internal.Sessions;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.Bugs;
+
+/// <summary>
+/// marten#5353 — the async daemon's half of "a failed unit of work still commits its outbox batch".
+/// </summary>
+/// <remarks>
+/// <para>
+/// The daemon used to add its <c>IMessageBatch</c> to <see cref="ProjectionUpdateBatch.Listeners" />,
+/// which meant <see cref="ProjectionUpdateBatch.PreUpdateAsync" /> fired the batch's before-commit
+/// hook before a single one of the batch's pages had been executed. A daemon batch that then failed
+/// had already told its outbox the transaction was about to commit, and there is no rollback hook on
+/// <c>IChangeListener</c> to take that back — the same defect the inline
+/// <c>SaveChangesAsync</c> path had, and the reason the compliance fact
+/// <c>a_unit_of_work_that_fails_publishes_nothing</c> was red.
+/// </para>
+/// <para>
+/// The batch is now enlisted as an <c>ITransactionParticipant</c>, which the connection lifetime runs
+/// after every page has succeeded and immediately before the <c>COMMIT</c>, so a batch that fails
+/// never reaches it. The after-commit hook still fires from <c>PostUpdateAsync</c>.
+/// <c>side_effects_in_aggregations.publishing_messages_in_continuous_mode</c> is the end-to-end
+/// positive control that both hooks still fire on a batch that does commit.
+/// </para>
+/// </remarks>
+public class Bug_5353_daemon_outbox_hooks_bracket_the_commit: OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task the_before_commit_hook_is_not_fired_before_the_batch_executes()
+    {
+        var outbox = new RecordingMessageOutbox();
+        StoreOptions(opts => opts.Events.MessageOutbox = outbox);
+
+        var session = (DocumentSessionBase)theStore.LightweightSession();
+        await using var batch = new ProjectionUpdateBatch(theStore.Options.Projections, session,
+            ShardExecutionMode.Continuous, CancellationToken.None) { ShouldApplyListeners = true };
+
+        await batch.SpinUpMessageBatchAsync(session);
+
+        var messageBatch = outbox.Batches.ShouldHaveSingleItem();
+
+        // The pre-execution listener pass runs before any of this batch's SQL has been attempted, so
+        // it must no longer reach the outbox.
+        await batch.PreUpdateAsync(session);
+        messageBatch.BeforeCommitWasCalled.ShouldBeFalse(
+            "the outbox batch must not be told about a commit that has not been attempted yet");
+
+        // It is enlisted as a transaction participant instead. The connection lifetime invokes these
+        // inside the transaction, after every page has succeeded and immediately before the COMMIT.
+        var participant = batch.TransactionParticipants.ShouldHaveSingleItem();
+        await participant.BeforeCommitAsync(null!, null!, CancellationToken.None);
+        messageBatch.BeforeCommitWasCalled.ShouldBeTrue();
+
+        // ...and the after hook still fires even though the batch is no longer a Listener.
+        await batch.PostUpdateAsync(session);
+        messageBatch.AfterCommitWasCalled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task no_participant_is_enlisted_when_commit_hooks_are_suppressed()
+    {
+        // ShouldApplyListeners is false for rebuilds and for batches carrying no events; the
+        // listener path already gated both hooks on it, and the participant path has to keep that
+        // gate or a rebuild would start firing commit hooks it never used to fire.
+        var outbox = new RecordingMessageOutbox();
+        StoreOptions(opts => opts.Events.MessageOutbox = outbox);
+
+        var session = (DocumentSessionBase)theStore.LightweightSession();
+        await using var batch = new ProjectionUpdateBatch(theStore.Options.Projections, session,
+            ShardExecutionMode.Rebuild, CancellationToken.None) { ShouldApplyListeners = false };
+
+        await batch.SpinUpMessageBatchAsync(session);
+
+        batch.TransactionParticipants.Any().ShouldBeFalse();
+
+        await batch.PreUpdateAsync(session);
+        await batch.PostUpdateAsync(session);
+
+        var messageBatch = outbox.Batches.ShouldHaveSingleItem();
+        messageBatch.BeforeCommitWasCalled.ShouldBeFalse();
+        messageBatch.AfterCommitWasCalled.ShouldBeFalse();
+    }
+}

--- a/src/Marten/Events/Aggregation/MessageBatchTransactionParticipant.cs
+++ b/src/Marten/Events/Aggregation/MessageBatchTransactionParticipant.cs
@@ -1,0 +1,65 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Services;
+using Npgsql;
+
+namespace Marten.Events.Aggregation;
+
+/// <summary>
+/// Adapts an <see cref="IMessageBatch" /> onto <see cref="ITransactionParticipant" /> so that its
+/// before-commit hook fires <em>inside</em> Marten's write transaction, after every operation in
+/// the unit of work has executed successfully and immediately before the <c>COMMIT</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// #5353. The hook used to be invoked straight from <c>SaveChangesAsync</c> before the
+/// <c>UpdateBatch</c> was even built -- so it ran before the transaction was open and before a
+/// single statement had been attempted. A unit of work that then failed (a stream id collision, a
+/// concurrency violation, any SQL error at all) left the outbox batch enlisted with no way to
+/// un-enlist it: the batch had been told the transaction was about to commit, and was never told
+/// that it did not.
+/// </para>
+/// <para>
+/// Running it here instead gives the hook the meaning its name promises, and makes it unreachable
+/// on the failure path -- an outbox that persists rows in the before hook still gets them in the
+/// same transaction as the events that produced them, and an outbox that only flushes in the after
+/// hook is untouched. It also matches the placement Polecat and Fisher already use, which is what
+/// the shared <c>ProjectionSideEffectCompliance</c> suite asserts.
+/// </para>
+/// <para>
+/// The change set is resolved lazily because the daemon builds its own from the batch's pages,
+/// which are not final until the batch flushes.
+/// </para>
+/// <para>
+/// One consequence worth naming: <c>AmbientTransactionLifetime</c> does not run transaction
+/// participants at all -- it has no <see cref="NpgsqlTransaction" /> to hand one, because the
+/// ambient <c>TransactionScope</c> owns the commit -- so a session enlisted in an ambient
+/// transaction gets the after hook and not the before hook. That is the same pre-existing gap EF
+/// Core participants already have there, and it is the honest answer: Marten cannot offer a
+/// "before MY commit" hook for a commit it does not perform.
+/// </para>
+/// </remarks>
+internal sealed class MessageBatchTransactionParticipant: ITransactionParticipant
+{
+    private readonly IMessageBatch _batch;
+    private readonly IDocumentSession _session;
+    private readonly Func<IChangeSet> _commit;
+
+    public MessageBatchTransactionParticipant(IMessageBatch batch, IDocumentSession session,
+        Func<IChangeSet> commit)
+    {
+        _batch = batch;
+        _session = session;
+        _commit = commit;
+    }
+
+    internal IMessageBatch Batch => _batch;
+
+    public Task BeforeCommitAsync(NpgsqlConnection connection, NpgsqlTransaction transaction,
+        CancellationToken token)
+    {
+        return _batch.BeforeCommitAsync(_session, _commit(), token);
+    }
+}

--- a/src/Marten/Events/Daemon/Internals/ProjectionUpdateBatch.cs
+++ b/src/Marten/Events/Daemon/Internals/ProjectionUpdateBatch.cs
@@ -292,7 +292,7 @@ public class ProjectionUpdateBatch: IUpdateBatch, IAsyncDisposable, IDisposable,
             return;
         }
 
-        if (_settings.AsyncListeners.Count == 0 && Listeners.Count == 0)
+        if (_settings.AsyncListeners.Count == 0 && Listeners.Count == 0 && _batch == null)
         {
             return;
         }
@@ -306,6 +306,14 @@ public class ProjectionUpdateBatch: IUpdateBatch, IAsyncDisposable, IDisposable,
         foreach (var listener in Listeners)
         {
             await listener.AfterCommitAsync((IDocumentSession)session, unitOfWorkData, _token)
+                .ConfigureAwait(false);
+        }
+
+        // #5353: the message batch's before hook is a transaction participant rather than a
+        // listener, so its after hook is fired here rather than falling out of the loop above.
+        if (_batch != null)
+        {
+            await _batch.AfterCommitAsync((IDocumentSession)session, unitOfWorkData, _token)
                 .ConfigureAwait(false);
         }
     }
@@ -524,7 +532,7 @@ public class ProjectionUpdateBatch: IUpdateBatch, IAsyncDisposable, IDisposable,
             }
 
             _batch = await ((IMartenSession)_session).Options.Events.MessageOutbox.CreateBatch(session).ConfigureAwait(false);
-            Listeners.Add(_batch);
+            enlistMessageBatch();
 
             return _batch;
         }
@@ -542,6 +550,25 @@ public class ProjectionUpdateBatch: IUpdateBatch, IAsyncDisposable, IDisposable,
         var projectionSession = new ProjectionDocumentSession((DocumentStore)_session.DocumentStore, this, sessionOptions,
             ShardExecutionMode.Continuous);
         _batch = await ((IMartenSession)_session).Options.Events.MessageOutbox.CreateBatch(projectionSession).ConfigureAwait(false);
-        Listeners.Add(_batch);
+        enlistMessageBatch();
+    }
+
+    /// <summary>
+    /// #5353: the message batch is NOT an ordinary <see cref="IChangeListener" /> on this batch. It
+    /// used to be, which meant <see cref="PreUpdateAsync" /> fired its before-commit hook before a
+    /// single one of the batch's pages had been executed -- so a daemon batch that then failed had
+    /// already told its outbox the transaction was about to commit, exactly the inline-session
+    /// defect #5353 describes. As a transaction participant it runs after the pages have succeeded
+    /// and immediately before the COMMIT instead; the after-commit hook is fired explicitly from
+    /// <see cref="PostUpdateAsync" />.
+    /// </summary>
+    private void enlistMessageBatch()
+    {
+        // Preserves the gate the listener path already had: no commit hooks on a rebuild, or on a
+        // batch that carries no events.
+        if (!ShouldApplyListeners) return;
+
+        AddTransactionParticipant(new MessageBatchTransactionParticipant(_batch!, (IDocumentSession)_session,
+            () => new UnitOfWork(_pages.SelectMany(x => x.Operations))));
     }
 }

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
@@ -57,23 +57,13 @@ public abstract partial class DocumentSessionBase
             await listener.BeforeSaveChangesAsync(this, token).ConfigureAwait(false);
         }
 
-        // #5343: Marten declares IMessageBatch : IMessageSink, IChangeListener -- so it promises BOTH
-        // commit hooks -- but only ever called AfterCommitAsync below. The before hook is the half a
-        // transactional outbox actually needs, because it is the only point at which an outbox can
-        // queue its own operations and have them land in the SAME UpdateBatch, and therefore the same
-        // transaction, as the events that produced the messages. Hence the placement: immediately
-        // after the session listeners' BeforeSaveChangesAsync and before the UpdateBatch is built
-        // from _workTracker, which is exactly the contract those listeners already get.
-        //
-        // Found by the jasperfx#763 ProjectionSideEffectCompliance suite, whose commit-boundary facts
-        // observe what the rest of the database can see at each hook rather than merely that the
-        // hooks ran. Wolverine's MartenToWolverineMessageBatch.BeforeCommitAsync is currently a
-        // no-op, so nothing downstream changes behaviour on this fix today.
-        if (_messageBatch != null)
-        {
-            await _messageBatch.BeforeCommitAsync(this, _workTracker, token).ConfigureAwait(false);
-        }
-
+        // #5343 wired up IMessageBatch.BeforeCommitAsync, which Marten promised (IMessageBatch :
+        // IMessageSink, IChangeListener) but never called. #5353 moved WHERE it is called from. It
+        // used to run here, before the UpdateBatch was built and before the transaction was even
+        // open, so it fired for units of work that went on to fail -- and there is no rollback hook
+        // on IChangeListener to take it back. The batch is now enlisted as an ITransactionParticipant
+        // in StartMessageBatch below, which runs it after every operation has succeeded and
+        // immediately before the COMMIT. See MessageBatchTransactionParticipant.
         var batch = new UpdateBatch(_workTracker.AllOperations);
 
         await ExecuteBatchAsync(batch, token).ConfigureAwait(false);
@@ -84,6 +74,7 @@ public abstract partial class DocumentSessionBase
             // This is important, we need to throw this away on every commit and start w/ a fresh
             // one on new transactions
             _messageBatch = null;
+            discardMessageBatchParticipant();
         }
 
 
@@ -105,10 +96,30 @@ public abstract partial class DocumentSessionBase
     }
 
     private IMessageBatch? _messageBatch;
+    private MessageBatchTransactionParticipant? _messageBatchParticipant;
+
     internal virtual async ValueTask<IMessageBatch> StartMessageBatch()
     {
-        _messageBatch ??= await Options.Events.MessageOutbox.CreateBatch(this).ConfigureAwait(false);
+        if (_messageBatch == null)
+        {
+            _messageBatch = await Options.Events.MessageOutbox.CreateBatch(this).ConfigureAwait(false);
+
+            // #5353: the batch's before-commit hook is a transaction participant, not something
+            // SaveChangesAsync calls on its way in. That is what keeps it off the failure path.
+            _messageBatchParticipant =
+                new MessageBatchTransactionParticipant(_messageBatch, this, () => _workTracker);
+            AddTransactionParticipant(_messageBatchParticipant);
+        }
+
         return _messageBatch;
+    }
+
+    private void discardMessageBatchParticipant()
+    {
+        if (_messageBatchParticipant == null) return;
+
+        RemoveTransactionParticipant(_messageBatchParticipant);
+        _messageBatchParticipant = null;
     }
 
     bool IStorageOperations.EnableSideEffectsOnInlineProjections => Options.Events.EnableSideEffectsOnInlineProjections;

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -59,6 +59,16 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
         _transactionParticipants.Add(participant);
     }
 
+    /// <summary>
+    /// #5353: the message batch enlists itself as a participant for the life of one unit of work,
+    /// and drops out again when that unit of work commits. Everything else registered here is
+    /// session-scoped and stays until disposal.
+    /// </summary>
+    internal virtual void RemoveTransactionParticipant(ITransactionParticipant participant)
+    {
+        _transactionParticipants.Remove(participant);
+    }
+
     internal IReadOnlyList<ITransactionParticipant> TransactionParticipants => _transactionParticipants;
 
     // #5228: release anything a participant is holding open, however the save ended. Disposal on


### PR DESCRIPTION
Fixes #5353.

`ProjectionSideEffectCompliance.a_unit_of_work_that_fails_publishes_nothing` was Marten's last red compliance fact:

```
_outbox.CommittedBatches should be empty but had 1 item
```

## The #5348 hypothesis held

#5353 asked whoever picked this up to check whether this and #5348 were the same root cause seen from two sides. They are — and more precisely than the issue guessed. #5348 was right that `IMessageBatch.BeforeCommitAsync` was dead code and had to be called. It put the call in the wrong place:

```csharp
// before this PR, in DocumentSessionBase.SaveChangesAsync
await _messageBatch.BeforeCommitAsync(this, _workTracker, token);   // <-- no transaction open yet
var batch = new UpdateBatch(_workTracker.AllOperations);
await ExecuteBatchAsync(batch, token);                              // <-- 23505 lands here
await _messageBatch.AfterCommitAsync(this, _workTracker, token);
```

The hook fired before the `UpdateBatch` was built and before the transaction was even open — so it fired for units of work that had not been attempted, let alone succeeded. The stream-id collision the compliance fact provokes is a Postgres unique violation on `mt_streams`, raised during batch execution, one step *after* the hook. `IChangeListener` has no rollback hook, so a batch enlisted on the way in could never be un-enlisted: it had been told the transaction was about to commit and was never told that it did not. That is the "enlisted before commit but never un-enlisted on failure" shape the issue predicted, and it is why `CommittedBatches` had exactly one item whose only hook was `"before"`.

Confirmed by reproduction before any change: 1 failed / 8 passed in `projection_side_effect_compliance`, on that assertion.

## The fix

Move *where* the hook is called from, not whether. The batch is now enlisted as an `ITransactionParticipant`, which Marten's connection lifetimes invoke inside the transaction after every page has executed successfully and immediately before the `COMMIT` (`MessageBatchTransactionParticipant`). A unit of work that fails never reaches it.

This is the placement Polecat already uses on both of its paths (`DocumentSessionBase.SaveChangesAsync` and `PolecatProjectionBatch`), which is why Polecat passes this fact. The three hook-boundary facts in the suite are all satisfied by it: `both_commit_hooks_fire_in_order` still sees `["before", "after"]`, and `the_before_hook_runs_inside_the_transaction_and_the_after_hook_outside_it` still sees the write invisible at the before hook and visible at the after hook — the before hook is still inside the transaction, just later in it.

The one property given up is #5348's stated rationale: the before hook can no longer queue operations into the session's own `UpdateBatch`, because the batch is already built by then. An outbox that wants rows in the same transaction writes them on the `NpgsqlConnection`/`NpgsqlTransaction` the participant hands it, which is what `ITransactionParticipant` is for and what the EF Core integration already does. No consumer loses anything today: `MartenToWolverineMessageBatch.BeforeCommitAsync` is a no-op, as is Polecat's and Fisher's.

## The async daemon had the same gap

It did, and it was not covered by the compliance fact. `ProjectionUpdateBatch.CurrentMessageBatch`/`SpinUpMessageBatchAsync` added the message batch to `Listeners`, and `PreUpdateAsync` fires every listener's `BeforeCommitAsync` from inside `ExecuteBatchAsync` — still before the batch's pages run. Identical defect, fixed identically: the daemon enlists the batch as a transaction participant instead, and fires its after hook explicitly from `PostUpdateAsync`.

Two details preserved deliberately:

- The `ShouldApplyListeners` gate (false for rebuilds and for batches with no events) now gates enlistment, so a rebuild still fires neither hook — `no_messages_are_published_during_a_rebuild` and `composite_rebuild_suppresses_side_effects` depend on that.
- On the daemon path, the before hook now propagates instead of being swallowed by `executeBeforeCommitListeners`'s catch-and-log. That is the right direction: an outbox that cannot enlist should abort the write rather than let it commit unannounced.

New coverage in `src/DaemonTests/Bugs/Bug_5353_daemon_outbox_hooks_bracket_the_commit.cs`, since the shared suite only exercises the inline path. `side_effects_in_aggregations.publishing_messages_in_continuous_mode` is the existing end-to-end positive control that both hooks still fire on a daemon batch that does commit.

## The partial-failure case

Not changed, and worth stating explicitly since this PR is about the boundary. If the database commit succeeds and the outbox's `AfterCommitAsync` then throws, Marten cannot make that atomic and does not try. The data stays committed; the flush failure is surfaced (rethrown out of `SaveChangesAsync` on the inline path, logged and swallowed on the daemon path so the shard keeps making progress) and delivery is recovered by the outbox's own retry, never by rolling back a committed transaction. That asymmetry between the two paths is pre-existing and deliberate — a daemon shard that failed a batch because a broker was briefly unreachable would rewind and reprocess events that are already persisted.

This is exactly why the before hook matters. An outbox that persists its rows there gets atomicity with the write and is recoverable; one that only flushes in the after hook is best-effort by construction. Both now sit on the correct side of the failure boundary.

One documented consequence: `AmbientTransactionLifetime` does not run transaction participants at all — it has no `NpgsqlTransaction` to hand one, because the ambient `TransactionScope` owns the commit — so a session enlisted in an ambient transaction gets the after hook and not the before hook. That is the same pre-existing gap EF Core participants have there, and it is the honest answer: Marten cannot offer a "before *my* commit" hook for a commit it does not perform.

## Validation

Local, against a private database (`marten_outbox5353` / `marten_outbox5353_daemon`) rather than the shared `marten_testing`.

- `projection_side_effect_compliance`: 9/9, was 8/9. **The compliance fact passes and Marten's red compliance count is zero.**
- `EventSourcingTests`: 2195 passed, 0 failed, 20 skipped (2215 total).
- `DaemonTests`: 317 passed, 6 failed. All six are pre-existing on `origin/master` — a baseline run of those four classes on `5656ab4` fails the same six (plus `skipped_shard_state_carries_skipped_events_count`, which passed here). They are high-water-mark and sequence-gap detection timeouts (`HighWaterAgentTests`, `HighWaterDetectorTests`, `Bug_4953`, `Bug_5108`) and touch no part of this change. Includes the two new `Bug_5353` facts.
- `TenantPartitionedEventsTests`: 249 passed, 0 failed, 2 skipped — it carries `composite_side_effects_rebuild_under_sharded_partitioning`, the rebuild-suppression path the `ShouldApplyListeners` gate protects.

CI is stalled org-wide and is not a gate on this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
