### PR TITLE
Fix #5328 — document reads work from a Native AOT binary

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -396,6 +396,58 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  # The RUNTIME Native AOT gate (#5328). Deliberately its OWN job rather than a matrix entry:
+  # it does not compile a test project and it does not run through the supervisor, it publishes a
+  # native binary with ILC and executes it. Two things make that worth a separate runner —
+  #
+  #   1. The ILC compile is minutes of CPU that no other job needs, so folding it into the matrix
+  #      shape would mean either a bespoke branch in every step or paying it 30 times over.
+  #   2. It is the only job here that can fail the way #5328 failed: a build that analyzes clean,
+  #      publishes clean, and then throws MissingMethodException on the first document read
+  #      because a generic instantiation only exists when a JIT can make one. The Marten.AotSmoke
+  #      project (built by every `compile-project` job) covers the analyzer axis and is structurally
+  #      blind to this one — it never opens a connection.
+  aot-runtime:
+    name: AOT runtime (net10, PGlatest, native)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    services:
+      postgres:
+        image: postgres:latest
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_DB: marten_testing
+          NAMEDATALEN: 150
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --user postgres
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      # ILC shells out to the platform linker and toolchain; the ubuntu runner image has clang
+      # but not the zlib/objcopy pieces a native link needs.
+      - name: Install the native toolchain
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+        shell: bash
+
+      - name: publish natively and run
+        run: ./build.sh test-aot-runtime
+        shell: bash
+
   # The roll-up. Per-job counts answer "is this job flaky"; only the aggregate answers "which
   # suites are costing us", which is the question that decides where the next fix goes.
   flakiness:

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -45,6 +45,7 @@
         "RecordBenchmarks",
         "Restore",
         "Test",
+        "TestAotRuntime",
         "TestAspnetcore",
         "TestBaseLib",
         "TestCompiledQueries",

--- a/build/build.cs
+++ b/build/build.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -48,7 +49,8 @@ partial class Build : NukeBuild
         .DependsOn(TestContainerScopedProjections)
         .DependsOn(TestStress)
         .DependsOn(TestCompiledQueries)
-        .DependsOn(TestSourceGenerator);
+        .DependsOn(TestSourceGenerator)
+        .DependsOn(TestAotRuntime);
 
     Target TestExtensions => _ => _
         .DependsOn(TestNodaTime)
@@ -251,6 +253,55 @@ partial class Build : NukeBuild
     Target TestCompiledQueries => _ => _
         .ProceedAfterFailure()
         .Executes(() => RunTestProject("src/CompiledQueryTests/CompiledQueryTests.csproj"));
+
+    /// <summary>
+    /// The RUNTIME Native AOT gate (#5328). Not an xUnit project: it publishes
+    /// src/Marten.AotRuntimeSmoke natively for the host RID and executes the binary against the
+    /// ordinary test database, so a read path that only breaks once the JIT is gone fails here.
+    /// src/Marten.AotSmoke stays the build-time analyzer gate; it cannot see this class of defect
+    /// because the offending code analyzes clean and throws one line later.
+    ///
+    /// Needs a native toolchain for the host platform (clang + zlib on Linux; Xcode command line
+    /// tools on macOS; the VS C++ workload on Windows) — see the aot-runtime job in tests.yml.
+    /// </summary>
+    Target TestAotRuntime => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            const string projectPath = "src/Marten.AotRuntimeSmoke/Marten.AotRuntimeSmoke.csproj";
+            const string framework = "net10.0";
+            var rid = RuntimeInformation.RuntimeIdentifier;
+
+            Log.Information("Publishing {Project} natively for {Rid} — the ILC compile takes a few minutes",
+                projectPath, rid);
+
+            DotNetPublish(s => s
+                .SetProject(projectPath)
+                .SetConfiguration(Configuration)
+                .SetFramework(framework)
+                .SetRuntime(rid)
+                .SetSelfContained(true));
+
+            var executable = RootDirectory / "src" / "Marten.AotRuntimeSmoke" / "bin" / Configuration / framework /
+                             rid / "publish" / (OperatingSystem.IsWindows()
+                                 ? "Marten.AotRuntimeSmoke.exe"
+                                 : "Marten.AotRuntimeSmoke");
+
+            if (!File.Exists(executable))
+            {
+                throw new InvalidOperationException(
+                    $"The native binary was never produced at {executable}. Either PublishAot did not run for this RID, or the native toolchain is missing — this target needs clang + zlib on Linux, Xcode command line tools on macOS, or the VS C++ workload on Windows.");
+            }
+
+            var process = ProcessTasks.StartProcess(executable, workingDirectory: RootDirectory);
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    "The Marten AOT runtime smoke failed. A document read path needs runtime code generation again — see the output above for which one.");
+            }
+        });
 
     /// <summary>
     /// Primary/standby read routing (~2 tests). Needs the streaming-replication pair from

--- a/docs/configuration/aot-publishing.md
+++ b/docs/configuration/aot-publishing.md
@@ -228,12 +228,12 @@ The source generator skips base types it doesn't recognize. If you wrote a custo
 
 `LoadAsync`, LINQ, raw SQL and compiled queries all run from a native binary as of the fix for [#5328](https://github.com/JasperFx/marten/issues/5328). Before that release, the first *read* of any kind threw even though the publish was clean:
 
-```
+```text
 MissingMethodException: No parameterless constructor defined for type
 'Marten.Internal.Sessions.QuerySession+StorageFinder`1[MyDocument]'
 ```
 
-```
+```text
 PlatformNotSupportedException: Dynamic code generation is not supported on this platform.
    at FastExpressionCompiler.ExpressionCompiler.CompileFast[R](...)
    at Marten.Linq.Parsing.LinqInternalExtensions.ReduceToConstant(Expression)

--- a/docs/configuration/aot-publishing.md
+++ b/docs/configuration/aot-publishing.md
@@ -201,6 +201,12 @@ Every warning carries the source location of the offending call. The fix path de
 
 For a baseline confidence check, Marten ships [`src/Marten.AotSmoke/`](https://github.com/JasperFx/marten/tree/master/src/Marten.AotSmoke) — a tiny app that consumes the AOT-clean cross-section of Marten's surface with all the IL warning codes promoted to errors. Mirror its csproj setup in your own app, scoped to the Marten surface you actually use.
 
+::: warning A clean publish is necessary, not sufficient
+Analyzer cleanliness and runtime correctness are different properties. A `MakeGenericType` call that the analyzer has been told to trust still needs the closed instantiation to exist in the native image, and if it does not you get a clean publish followed by `MissingMethodException` on the first call — which is exactly how [#5328](https://github.com/JasperFx/marten/issues/5328) reached a release.
+
+Marten now also ships [`src/Marten.AotRuntimeSmoke/`](https://github.com/JasperFx/marten/tree/master/src/Marten.AotRuntimeSmoke), which publishes natively and *runs* every document read path against a real PostgreSQL in CI. Doing the same for your own app — publish AOT, then exercise your real queries against a real database once in your pipeline — is worth more than any amount of analyzer output.
+:::
+
 ## Troubleshooting
 
 ### "No source-generated dispatcher found for aggregate `X`"
@@ -220,13 +226,27 @@ The source generator skips base types it doesn't recognize. If you wrote a custo
 
 ### LINQ query throwing in AOT mode
 
-Marten's runtime LINQ path uses expression-tree walking that the trim analyzer flags. The supported AOT pattern is:
+`LoadAsync`, LINQ, raw SQL and compiled queries all run from a native binary as of the fix for [#5328](https://github.com/JasperFx/marten/issues/5328). Before that release, the first *read* of any kind threw even though the publish was clean:
 
-1. Wrap the query in an `ICompiledQuery<TDoc, TOut>`.
-2. Reference `Marten.SourceGenerator` and add `[assembly: JasperFx.JasperFxAssembly]`.
-3. Call the compiled-query handler via `session.QueryAsync(compiledQueryInstance)`.
+```
+MissingMethodException: No parameterless constructor defined for type
+'Marten.Internal.Sessions.QuerySession+StorageFinder`1[MyDocument]'
+```
 
-The compiled-query path bypasses the LINQ-to-SQL translator at runtime and dispatches directly through the source-generated handler. See [`Marten.SourceGenerator/README.md`](https://github.com/JasperFx/marten/blob/master/src/Marten.SourceGenerator/README.md) for the full surface.
+```
+PlatformNotSupportedException: Dynamic code generation is not supported on this platform.
+   at FastExpressionCompiler.ExpressionCompiler.CompileFast[R](...)
+   at Marten.Linq.Parsing.LinqInternalExtensions.ReduceToConstant(Expression)
+```
+
+If you see either of those, you are on an older Marten — upgrade rather than working around it.
+
+Two shapes still need runtime code generation and therefore still need a JIT:
+
+- **A compiled query with an `enum`-typed parameter.** Marten closes `PropertyQueryMember<T>` over each supported parameter type ahead of time, but it cannot do that for an enum declared in your assembly. Store the value as its underlying type on the query object if you need this under AOT.
+- **A `where` clause whose value comes from a method call** — `x => x.Name == BuildName()`. Constants, captured locals, instance and static members, member chains and array literals are all evaluated reflectively; anything else falls back to expression compilation. Hoist the call into a local before the query.
+
+Compiled queries remain worth using under AOT for their own reasons — reference `Marten.SourceGenerator`, add `[assembly: JasperFx.JasperFxAssembly]`, and call `session.QueryAsync(compiledQueryInstance)` to dispatch through a source-generated handler instead of parsing the expression tree on every call. See [`Marten.SourceGenerator/README.md`](https://github.com/JasperFx/marten/blob/master/src/Marten.SourceGenerator/README.md) for the full surface. They are no longer a *workaround* for LINQ, though.
 
 ### Secondary store throws `MissingMethodException` at boot
 

--- a/src/CoreTests/Bug_5328_aot_generic_bridges.cs
+++ b/src/CoreTests/Bug_5328_aot_generic_bridges.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Marten;
+using Marten.Internal;
+using Marten.Internal.CompiledQueries;
+using Marten.Internal.Sessions;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests;
+
+// #5328: a Native AOT binary threw MissingMethodException on the first document read because two
+// bridges from a runtime Type back to a closed generic went through MakeGenericType +
+// Activator.CreateInstance, and ILC has no native code for an instantiation nothing constructs
+// statically:
+//
+//   QuerySession.StorageFor(Type)        -> QuerySession+StorageFinder`1[TDoc]
+//   CompiledQueryPlan.sortMembers()      -> PropertyQueryMember`1[System.String]
+//
+// Both now resolve through registrations captured at a generic entry point. These tests assert the
+// registrations happen and that the reflective fallback is genuinely unused for the shapes it
+// used to serve — a JIT would happily hide a regression here, so the assertion has to be about
+// which path ran, not about the result.
+public class Bug_5328_aot_generic_bridges: OneOffConfigurationsContext
+{
+    [Fact]
+    public void schema_registration_records_the_closed_generic_storage_lookup()
+    {
+        StoreOptions(opts => opts.Schema.For<Bug5328Registered>());
+
+        using var session = theStore.QuerySession();
+
+        // Schema.For<T>() is the earliest generic mention of a document type; it has to be enough
+        // on its own, because the Type-keyed admin paths (document cleaner, TruncateTable) may run
+        // before anything has ever queried or stored a T.
+        DocumentStorageResolvers.TryResolve(typeof(Bug5328Registered), (QuerySession)session)
+            .ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void querying_registers_the_document_type_before_storage_is_resolved()
+    {
+        using var session = theStore.QuerySession();
+
+        // Nothing has touched Bug5328Queried yet.
+        session.Query<Bug5328Queried>().ToString().ShouldNotBeNull();
+
+        DocumentStorageResolvers.TryResolve(typeof(Bug5328Queried), (QuerySession)session)
+            .ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void the_registry_and_the_reflective_shim_agree()
+    {
+        using var session = (QuerySession)theStore.QuerySession();
+
+        // The generic call is what proves the instantiation exists, so it is also what registers.
+        var throughTheGeneric = session.StorageFor<User>();
+        var throughTheRegistry = DocumentStorageResolvers.TryResolve(typeof(User), session);
+
+        throughTheRegistry.ShouldNotBeNull();
+        throughTheRegistry.DocumentType.ShouldBe(throughTheGeneric.DocumentType);
+    }
+
+    [Theory]
+    [InlineData(typeof(string))]
+    [InlineData(typeof(Guid))]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(long))]
+    [InlineData(typeof(decimal))]
+    [InlineData(typeof(DateTime))]
+    [InlineData(typeof(DateTimeOffset))]
+    [InlineData(typeof(string[]))]
+    [InlineData(typeof(Guid[]))]
+    [InlineData(typeof(int[]))]
+    public void a_parameter_finder_owns_every_supported_compiled_query_member_type(Type memberType)
+    {
+        // If no finder can build the member, CompiledQueryPlan falls back to MakeGenericType and
+        // the compiled query breaks under Native AOT. Each of these types must be owned by a
+        // finder that is already closed over it at compile time.
+        var member = typeof(Bug5328QueryShape).GetProperty(nameof(Bug5328QueryShape.Value))!;
+
+        QueryCompiler.Finders
+            .Select(finder => finder.BuildQueryMember(member, memberType))
+            .ShouldContain(x => x != null);
+    }
+
+    [Fact]
+    public void the_finder_built_member_matches_what_the_reflective_shim_produced()
+    {
+        var property = typeof(Bug5328QueryShape).GetProperty(nameof(Bug5328QueryShape.Value))!;
+
+        var built = QueryCompiler.Finders
+            .Select(finder => finder.BuildQueryMember(property, typeof(string)))
+            .First(x => x != null);
+
+        built.ShouldBeOfType<PropertyQueryMember<string>>();
+        built.Type.ShouldBe(typeof(string));
+        built.Member.ShouldBe((MemberInfo)property);
+        built.GetValueAsObject(new Bug5328QueryShape { Value = "hello" }).ShouldBe("hello");
+    }
+
+    [Fact]
+    public void fields_are_covered_too_because_compiled_queries_allow_them()
+    {
+        var field = typeof(Bug5328QueryShape).GetField(nameof(Bug5328QueryShape.Field))!;
+
+        var built = QueryCompiler.Finders
+            .Select(finder => finder.BuildQueryMember(field, typeof(int)))
+            .First(x => x != null);
+
+        built.ShouldBeOfType<FieldQueryMember<int>>();
+        built.GetValueAsObject(new Bug5328QueryShape { Field = 11 }).ShouldBe(11);
+    }
+
+    [Fact]
+    public void enum_members_are_the_one_documented_gap_and_fall_back_deliberately()
+    {
+        var property = typeof(Bug5328QueryShape).GetProperty(nameof(Bug5328QueryShape.Value))!;
+
+        // No finder is closed over a consumer's enum type, so this shape still needs the
+        // reflective path. Pinned so the gap is a decision rather than a surprise.
+        QueryCompiler.Finders
+            .Select(finder => finder.BuildQueryMember(property, typeof(Bug5328Colour)))
+            .ShouldAllBe(x => x == null);
+    }
+}
+
+public class Bug5328Registered
+{
+    public Guid Id { get; set; }
+}
+
+public class Bug5328Queried
+{
+    public Guid Id { get; set; }
+}
+
+public class Bug5328QueryShape
+{
+    public int Field;
+    public string Value { get; set; }
+}
+
+public enum Bug5328Colour
+{
+    Red,
+    Blue
+}

--- a/src/LinqTests/Bugs/Bug_5328_reduce_to_constant_without_emit.cs
+++ b/src/LinqTests/Bugs/Bug_5328_reduce_to_constant_without_emit.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Linq.Parsing;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+// #5328: ReduceToConstant compiled a parameterless lambda with FastExpressionCompiler for every
+// non-literal value in a where clause — a captured local, a compiled query's own property, a
+// static member. FastExpressionCompiler is Reflection.Emit underneath, so under Native AOT the
+// first such query threw
+//
+//     PlatformNotSupportedException: Dynamic code generation is not supported on this platform.
+//
+// The common shapes are now walked reflectively instead. These tests pin the shapes that must be
+// evaluated WITHOUT emitting (the AOT contract), the shapes that must still fall through to FEC,
+// and that the values that come out are the same either way.
+public class Bug_5328_reduce_to_constant_without_emit: BugIntegrationContext
+{
+    private static readonly string StaticField = "static-field";
+    private static string StaticProperty => "static-property";
+
+    private readonly string _instanceField = "instance-field";
+
+    [Fact]
+    public void evaluates_a_constant_without_emitting()
+    {
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(Expression.Constant("hello"), out var value)
+            .ShouldBeTrue();
+        value.ShouldBe("hello");
+    }
+
+    [Fact]
+    public void evaluates_a_captured_local_without_emitting()
+    {
+        var captured = "captured-local";
+
+        // The compiler turns `captured` into a field read on a display class, which is the single
+        // most common shape reaching ReduceToConstant.
+        Expression<Func<string>> expression = () => captured;
+
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(expression.Body, out var value).ShouldBeTrue();
+        value.ShouldBe("captured-local");
+    }
+
+    [Fact]
+    public void evaluates_instance_and_static_members_without_emitting()
+    {
+        Expression<Func<string>> instance = () => _instanceField;
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(instance.Body, out var instanceValue).ShouldBeTrue();
+        instanceValue.ShouldBe("instance-field");
+
+        LinqInternalExtensions
+            .TryEvaluateWithoutCompiling(Expression.Field(null, typeof(Bug_5328_reduce_to_constant_without_emit),
+                nameof(StaticField)), out var staticFieldValue)
+            .ShouldBeTrue();
+        staticFieldValue.ShouldBe("static-field");
+
+        Expression<Func<string>> staticProperty = () => StaticProperty;
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(staticProperty.Body, out var staticPropertyValue)
+            .ShouldBeTrue();
+        staticPropertyValue.ShouldBe("static-property");
+    }
+
+    [Fact]
+    public void evaluates_a_nested_member_chain_without_emitting()
+    {
+        var holder = new Holder { Inner = new Inner { Name = "nested" } };
+        Expression<Func<string>> expression = () => holder.Inner.Name;
+
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(expression.Body, out var value).ShouldBeTrue();
+        value.ShouldBe("nested");
+    }
+
+    [Fact]
+    public void evaluates_a_boxing_conversion_without_emitting()
+    {
+        var number = 42;
+        Expression<Func<object>> expression = () => number;
+
+        // `() => number` where the return type is object wraps the field read in Convert.
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(expression.Body, out var value).ShouldBeTrue();
+        value.ShouldBe(42);
+    }
+
+    [Fact]
+    public void evaluates_a_nullable_wrap_without_emitting()
+    {
+        var number = 42;
+        Expression<Func<int?>> expression = () => number;
+
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(expression.Body, out var value).ShouldBeTrue();
+        value.ShouldBe(42);
+    }
+
+    [Fact]
+    public void evaluates_an_array_literal_without_emitting()
+    {
+        var second = "b";
+        Expression<Func<string[]>> expression = () => new[] { "a", second };
+
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(expression.Body, out var value).ShouldBeTrue();
+        value.ShouldBe(new[] { "a", "b" });
+    }
+
+    [Fact]
+    public void declines_a_numeric_conversion_so_the_value_is_never_reinterpreted_here()
+    {
+        var number = 42L;
+        Expression<Func<int>> expression = () => (int)number;
+
+        // A narrowing conversion changes the representation. Rather than reimplement the
+        // conversion rules, hand it back to FastExpressionCompiler.
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(expression.Body, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void declines_a_method_call()
+    {
+        Expression<Func<string>> expression = () => Guid.NewGuid().ToString();
+
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(expression.Body, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void the_shapes_it_declines_still_reduce_correctly_through_the_fallback()
+    {
+        var number = 42L;
+        Expression<Func<int>> narrowing = () => (int)number;
+
+        LinqInternalExtensions.ReduceToConstant(narrowing.Body).Value.ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task queries_with_captured_values_still_return_the_same_rows()
+    {
+        var target = new Bug5328Doc { Id = Guid.NewGuid(), Name = "Anne", Number = 7 };
+        var other = new Bug5328Doc { Id = Guid.NewGuid(), Name = "Bob", Number = 9 };
+
+        theSession.Store(target, other);
+        await theSession.SaveChangesAsync();
+
+        var name = "Anne";
+        var number = 7;
+        var names = new[] { "Anne", "Nobody" };
+        var holder = new Holder { Inner = new Inner { Name = "Anne" } };
+
+        (await theSession.Query<Bug5328Doc>().Where(x => x.Name == name).ToListAsync())
+            .Single().Id.ShouldBe(target.Id);
+
+        (await theSession.Query<Bug5328Doc>().Where(x => x.Number == number).ToListAsync())
+            .Single().Id.ShouldBe(target.Id);
+
+        (await theSession.Query<Bug5328Doc>().Where(x => x.Name.IsOneOf(names)).ToListAsync())
+            .Single().Id.ShouldBe(target.Id);
+
+        (await theSession.Query<Bug5328Doc>().Where(x => x.Name == holder.Inner.Name).ToListAsync())
+            .Single().Id.ShouldBe(target.Id);
+    }
+
+    public class Holder
+    {
+        public Inner Inner { get; set; }
+    }
+
+    public class Inner
+    {
+        public string Name { get; set; }
+    }
+}
+
+public class Bug5328Doc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public int Number { get; set; }
+}

--- a/src/Marten.AotRuntimeSmoke/Marten.AotRuntimeSmoke.csproj
+++ b/src/Marten.AotRuntimeSmoke/Marten.AotRuntimeSmoke.csproj
@@ -1,0 +1,57 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <!--
+        RUNTIME AOT smoke test (marten#5328).
+
+        src/Marten.AotSmoke is a BUILD-time gate: it promotes the IL analyzer warnings to
+        errors and never opens a connection. #5328 is exactly the failure that gate cannot
+        see — a native binary that publishes analyzer-clean and then throws on the first
+        document READ, because MakeGenericType + Activator.CreateInstance over a user
+        document type has no native code to run:
+
+            MissingMethodException: No parameterless constructor defined for type
+            'Marten.Internal.Sessions.QuerySession+StorageFinder`1[Praktijk]'
+
+        This project closes that gap. It PUBLISHES natively and EXECUTES against a real
+        PostgreSQL, exercising every read path a document consumer actually takes:
+        LoadAsync, LINQ (literal, captured variable, StartsWith + OrderBy, IsOneOf),
+        raw SQL, aggregates, and a source-generated compiled query. Any regression that
+        reintroduces runtime code generation on a read path fails here with a non-zero exit,
+        not with a clean build and a broken app.
+
+        Deliberately NOT a test project — no xUnit, no test discovery. `./build.sh
+        test-aot-runtime` publishes it for the host RID and runs the binary.
+
+        Single-TFM (net10.0) on purpose: this gate is about the native runtime, not about
+        TFM coverage, and one ILC compile per CI run is enough to pay for.
+        -->
+        <TargetFrameworks>net10.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsAotCompatible>true</IsAotCompatible>
+        <PublishAot>true</PublishAot>
+        <TrimMode>full</TrimMode>
+        <InvariantGlobalization>true</InvariantGlobalization>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <!-- Marten reflects over the document type to find its Id member, so the consumer's own
+             assembly has to survive trimming. This is step 1 of the documented AOT recipe
+             (docs/configuration/aot-publishing.md) and the reporter in #5328 had it in place. -->
+        <TrimmerRootAssembly Include="Marten.AotRuntimeSmoke" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
+        <!-- The consumer-facing opt-in shape for source-generated compiled queries: analyzer
+             reference + [assembly: JasperFxAssembly]. Same wiring as src/CompiledQueryTests. -->
+        <ProjectReference Include="..\Marten.SourceGenerator\Marten.SourceGenerator.csproj"
+                          OutputItemType="Analyzer"
+                          ReferenceOutputAssembly="false" />
+        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    </ItemGroup>
+
+</Project>

--- a/src/Marten.AotRuntimeSmoke/Program.cs
+++ b/src/Marten.AotRuntimeSmoke/Program.cs
@@ -1,0 +1,161 @@
+// Runtime AOT smoke test (marten#5328).
+//
+// See Marten.AotRuntimeSmoke.csproj for why this exists alongside src/Marten.AotSmoke:
+// that one is a build-time analyzer gate, this one publishes natively and runs.
+//
+// Each check below corresponds to a MakeGenericType / Activator.CreateInstance /
+// Reflection.Emit site that used to be on a document read path:
+//
+//   LINQ                  QuerySession.StorageFor(Type) closed StorageFinder<T> reflectively.
+//   captured variable     LinqInternalExtensions.ReduceToConstant compiled a lambda with
+//                         FastExpressionCompiler, i.e. Reflection.Emit.
+//   compiled query        CompiledQueryPlan.sortMembers closed PropertyQueryMember<T>
+//                         reflectively.
+//
+// Exits non-zero with the offending stack trace on the first failure, so CI reports the
+// specific read path that regressed.
+
+using System.Linq.Expressions;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JasperFx;
+using Marten;
+using Marten.Linq;
+using Weasel.Core;
+
+[assembly: JasperFxAssembly]
+
+var connection = Environment.GetEnvironmentVariable("marten_testing_database")
+                 ?? "Host=localhost;Port=5432;Database=marten_testing;Username=postgres;password=postgres";
+
+var store = DocumentStore.For(o =>
+{
+    o.Connection(connection);
+    // Reflection-based serialization is disabled under PublishAot, so the source-generated
+    // resolver below is part of the supported recipe rather than a smoke-test shortcut.
+    o.UseSystemTextJsonForSerialization(new JsonSerializerOptions { TypeInfoResolver = SmokeJson.Default });
+    o.AutoCreateSchemaObjects = AutoCreate.All;
+    o.DatabaseSchemaName = "aot_runtime_smoke";
+    o.Schema.For<Praktijk>().Index(x => x.AgbCode);
+});
+
+var failures = 0;
+
+try
+{
+    await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+    var id = Guid.NewGuid();
+
+    await using (var writing = store.LightweightSession())
+    {
+        writing.Store(new Praktijk { Id = id, AgbCode = "01059910", Naam = "Praktijk Jansen" });
+        writing.Store(new Praktijk { Id = Guid.NewGuid(), AgbCode = "01059911", Naam = "Praktijk Pietersen" });
+        await writing.SaveChangesAsync();
+    }
+
+    Console.WriteLine("OK   write + schema creation");
+
+    await using var session = store.QuerySession();
+
+    await Check("LoadAsync", async () =>
+    {
+        var loaded = await session.LoadAsync<Praktijk>(id);
+        return loaded?.Naam == "Praktijk Jansen";
+    });
+
+    await Check("LINQ with a literal", async () =>
+    {
+        var found = await session.Query<Praktijk>().Where(x => x.AgbCode == "01059910").ToListAsync();
+        return found.Count == 1;
+    });
+
+    await Check("LINQ with a captured variable", async () =>
+    {
+        var captured = "01059910";
+        var found = await session.Query<Praktijk>().Where(x => x.AgbCode == captured).ToListAsync();
+        return found.Count == 1;
+    });
+
+    await Check("LINQ with StartsWith + OrderBy", async () =>
+    {
+        var found = await session.Query<Praktijk>().Where(x => x.Naam.StartsWith("Praktijk"))
+            .OrderBy(x => x.Naam).ToListAsync();
+        return found.Count == 2 && found[0].Naam == "Praktijk Jansen";
+    });
+
+    await Check("LINQ with IsOneOf", async () =>
+    {
+        var codes = new[] { "01059910", "99999999" };
+        var found = await session.Query<Praktijk>().Where(x => x.AgbCode.IsOneOf(codes)).ToListAsync();
+        return found.Count == 1;
+    });
+
+    await Check("LINQ aggregate", async () => await session.Query<Praktijk>().CountAsync() == 2);
+
+    await Check("raw SQL", async () =>
+    {
+        var found = await session.QueryAsync<Praktijk>("where data ->> 'AgbCode' = ?", "01059910");
+        return found.Count == 1;
+    });
+
+    await Check("compiled query", async () =>
+    {
+        var found = await session.QueryAsync(new PraktijkByAgb { AgbCode = "01059910" });
+        return found.Count() == 1;
+    });
+}
+catch (Exception e)
+{
+    Console.Error.WriteLine("FAIL setup");
+    Console.Error.WriteLine(e);
+    return 1;
+}
+
+if (failures > 0)
+{
+    Console.Error.WriteLine($"Marten AOT runtime smoke FAILED — {failures} read path(s) broken under Native AOT.");
+    return 1;
+}
+
+Console.WriteLine("Marten AOT runtime smoke OK — every document read path ran from a native binary.");
+return 0;
+
+async Task Check(string description, Func<Task<bool>> check)
+{
+    try
+    {
+        if (await check())
+        {
+            Console.WriteLine($"OK   {description}");
+            return;
+        }
+
+        Console.Error.WriteLine($"FAIL {description} — ran, but returned the wrong result");
+    }
+    catch (Exception e)
+    {
+        Console.Error.WriteLine($"FAIL {description}");
+        Console.Error.WriteLine(e);
+    }
+
+    failures++;
+}
+
+public class Praktijk
+{
+    public Guid Id { get; set; }
+    public string AgbCode { get; set; } = "";
+    public string Naam { get; set; } = "";
+}
+
+public class PraktijkByAgb: ICompiledListQuery<Praktijk>
+{
+    public string AgbCode { get; set; } = "";
+
+    public Expression<Func<IMartenQueryable<Praktijk>, IEnumerable<Praktijk>>> QueryIs() =>
+        q => q.Where(x => x.AgbCode == AgbCode);
+}
+
+[JsonSerializable(typeof(Praktijk))]
+public partial class SmokeJson: JsonSerializerContext;

--- a/src/Marten.AotSmoke/Program.cs
+++ b/src/Marten.AotSmoke/Program.cs
@@ -44,8 +44,15 @@
 //   - Connecting / querying / persisting anything — this is a build-time
 //     analyzer test, not a runtime test. The connection string is a
 //     placeholder; the host is built but never actually opens a connection.
+//     src/Marten.AotRuntimeSmoke is the counterpart that DOES connect and
+//     query from a native binary. It exists because this project is
+//     structurally blind to #5328: reflective generic construction over a
+//     user document type analyzes clean here and throws
+//     MissingMethodException on the first read. Neither gate replaces the
+//     other.
 //   - Compiled queries — Marten.SourceGenerator covers that surface and has
-//     its own analyzer-level tests in Marten.SourceGenerator.Tests.
+//     its own analyzer-level tests in Marten.SourceGenerator.Tests, and
+//     Marten.AotRuntimeSmoke runs one natively (#5328).
 //   - JasperFx.RuntimeCompiler / services.AddRuntimeCompilation() — Marten 9
 //     retired that path (#4454 / #4461). This smoke deliberately does not
 //     pull it back in.

--- a/src/Marten.slnx
+++ b/src/Marten.slnx
@@ -91,6 +91,7 @@
   <Project Path="EventAppenderPerfTester/EventAppenderPerfTester.csproj" />
   <Project Path="Marten.ScaleTesting/Marten.ScaleTesting.csproj" />
   <Project Path="Marten.AotSmoke/Marten.AotSmoke.csproj" />
+  <Project Path="Marten.AotRuntimeSmoke/Marten.AotRuntimeSmoke.csproj" />
   <Project Path="Marten.EntityFrameworkCore.Tests/Marten.EntityFrameworkCore.Tests.csproj" />
   <Project Path="Marten.EntityFrameworkCore/Marten.EntityFrameworkCore.csproj" />
   <Project Path="Marten.Newtonsoft/Marten.Newtonsoft.csproj" />

--- a/src/Marten/Internal/CompiledQueries/ArrayParameterFinder.cs
+++ b/src/Marten/Internal/CompiledQueries/ArrayParameterFinder.cs
@@ -1,6 +1,8 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Marten.Internal.CompiledQueries;
 
@@ -33,6 +35,19 @@ internal class ArrayParameterFinder<TElement> : IParameterFinder
     public bool Matches(Type memberType)
     {
         return memberType == typeof(TElement[]);
+    }
+
+    // #5328: see IParameterFinder.BuildQueryMember — closed at compile time for Native AOT.
+    public IQueryMember? BuildQueryMember(MemberInfo member, Type memberType)
+    {
+        if (memberType != typeof(TElement[]))
+        {
+            return null;
+        }
+
+        return member is PropertyInfo property
+            ? new PropertyQueryMember<TElement[]>(property)
+            : new FieldQueryMember<TElement[]>((FieldInfo)member);
     }
 
     public bool AreValuesUnique(object query, CompiledQueryPlan plan)

--- a/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
@@ -96,15 +96,9 @@ public class CompiledQueryPlan : ICommandBuilder
                 // Arrays like string[], int[], Guid[] etc. whose element type has a registered
                 // parameter finder should be treated as query parameters, NOT as include members.
                 // This check must come before the IList<> check since arrays implement IList<T>.
-                if (member is PropertyInfo)
+                if (member is PropertyInfo or FieldInfo)
                 {
-                    var queryMember = typeof(PropertyQueryMember<>).CloseAndBuildAs<IQueryMember>(member, memberType);
-                    QueryMembers.Add(queryMember);
-                }
-                else if (member is FieldInfo)
-                {
-                    var queryMember = typeof(FieldQueryMember<>).CloseAndBuildAs<IQueryMember>(member, memberType);
-                    QueryMembers.Add(queryMember);
+                    QueryMembers.Add(buildQueryMember(member, memberType));
                 }
             }
             else if (memberType.Closes(typeof(IList<>)))
@@ -119,17 +113,35 @@ public class CompiledQueryPlan : ICommandBuilder
             {
                 InvalidMembers.Add(member);
             }
-            else if (member is PropertyInfo)
+            else if (member is PropertyInfo or FieldInfo)
             {
-                var queryMember = typeof(PropertyQueryMember<>).CloseAndBuildAs<IQueryMember>(member, memberType);
-                QueryMembers.Add(queryMember);
-            }
-            else if (member is FieldInfo)
-            {
-                var queryMember = typeof(FieldQueryMember<>).CloseAndBuildAs<IQueryMember>(member, memberType);
-                QueryMembers.Add(queryMember);
+                QueryMembers.Add(buildQueryMember(member, memberType));
             }
         }
+    }
+
+    /// <summary>
+    ///     #5328: ask the registered <see cref="IParameterFinder" />s to build the member first.
+    ///     Each finder is already closed over its own type (<c>SimpleParameterFinder&lt;string&gt;</c>
+    ///     and friends), so the resulting <c>PropertyQueryMember&lt;T&gt;</c> /
+    ///     <c>FieldQueryMember&lt;T&gt;</c> instantiations are statically reachable and Native AOT
+    ///     has native code for them. Only enum-valued members fall through to the reflective
+    ///     <c>CloseAndBuildAs</c>, which needs a JIT.
+    /// </summary>
+    private static IQueryMember buildQueryMember(MemberInfo member, Type memberType)
+    {
+        foreach (var finder in QueryCompiler.Finders)
+        {
+            var queryMember = finder.BuildQueryMember(member, memberType);
+            if (queryMember != null)
+            {
+                return queryMember;
+            }
+        }
+
+        return member is PropertyInfo
+            ? typeof(PropertyQueryMember<>).CloseAndBuildAs<IQueryMember>(member, memberType)
+            : typeof(FieldQueryMember<>).CloseAndBuildAs<IQueryMember>(member, memberType);
     }
 
     private IEnumerable<MemberInfo> findMembers()

--- a/src/Marten/Internal/CompiledQueries/EnumParameterFinder.cs
+++ b/src/Marten/Internal/CompiledQueries/EnumParameterFinder.cs
@@ -1,6 +1,8 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CompiledQueries;
@@ -40,5 +42,17 @@ internal class EnumParameterFinder: IParameterFinder
     {
         var enumValues = type.GetEnumValues();
         return new Queue<object>(enumValues.OfType<object>());
+    }
+
+    /// <summary>
+    ///     Enum members are the one shape this finder cannot close statically — the enum type comes
+    ///     from the consumer's compiled query. Returning null routes <c>CompiledQueryPlan</c> to its
+    ///     reflective fallback, which is correct anywhere a JIT is available; under Native AOT an
+    ///     enum-valued compiled query member still needs the consumer to keep that instantiation
+    ///     reachable.
+    /// </summary>
+    public IQueryMember? BuildQueryMember(MemberInfo member, Type memberType)
+    {
+        return null;
     }
 }

--- a/src/Marten/Internal/CompiledQueries/IParameterFinder.cs
+++ b/src/Marten/Internal/CompiledQueries/IParameterFinder.cs
@@ -1,5 +1,7 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Marten.Internal.CompiledQueries;
 
@@ -8,4 +10,21 @@ internal interface IParameterFinder
     bool Matches(Type memberType);
     bool AreValuesUnique(object query, CompiledQueryPlan plan);
     Queue<object> UniqueValueQueue(Type type);
+
+    /// <summary>
+    ///     Build the <see cref="IQueryMember" /> for a compiled query member of
+    ///     <paramref name="memberType" />, or null if this finder does not own that type.
+    /// </summary>
+    /// <remarks>
+    ///     #5328: <c>PropertyQueryMember&lt;T&gt;</c> / <c>FieldQueryMember&lt;T&gt;</c> used to be
+    ///     closed with <c>MakeGenericType</c> + <c>Activator.CreateInstance</c>, which Native AOT
+    ///     cannot satisfy — the first compiled query threw
+    ///     <c>MissingMethodException: No parameterless constructor defined for type
+    ///     'PropertyQueryMember`1[System.String]'</c>. The finders already know their own closed
+    ///     type at compile time (they are constructed as <c>SimpleParameterFinder&lt;string&gt;</c>,
+    ///     <c>ArrayParameterFinder&lt;Guid&gt;</c>, ... in <see cref="QueryCompiler" />'s static
+    ///     constructor), so letting each finder build its own member keeps every instantiation
+    ///     statically reachable.
+    /// </remarks>
+    IQueryMember? BuildQueryMember(MemberInfo member, Type memberType);
 }

--- a/src/Marten/Internal/CompiledQueries/SimpleParameterFinder.cs
+++ b/src/Marten/Internal/CompiledQueries/SimpleParameterFinder.cs
@@ -1,6 +1,8 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Marten.Internal.CompiledQueries;
 
@@ -23,6 +25,27 @@ internal class SimpleParameterFinder<T>: IParameterFinder
     public bool Matches(Type memberType)
     {
         return memberType == DotNetType;
+    }
+
+    // #5328: both T and T[] are closed here at compile time, so Native AOT has native code for
+    // PropertyQueryMember<T> / PropertyQueryMember<T[]> and never needs MakeGenericType.
+    public IQueryMember? BuildQueryMember(MemberInfo member, Type memberType)
+    {
+        if (memberType == typeof(T))
+        {
+            return member is PropertyInfo property
+                ? new PropertyQueryMember<T>(property)
+                : new FieldQueryMember<T>((FieldInfo)member);
+        }
+
+        if (memberType == typeof(T[]))
+        {
+            return member is PropertyInfo arrayProperty
+                ? new PropertyQueryMember<T[]>(arrayProperty)
+                : new FieldQueryMember<T[]>((FieldInfo)member);
+        }
+
+        return null;
     }
 
     public bool AreValuesUnique(object query, CompiledQueryPlan plan)

--- a/src/Marten/Internal/DocumentStorageResolvers.cs
+++ b/src/Marten/Internal/DocumentStorageResolvers.cs
@@ -1,0 +1,77 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using Marten.Internal.Sessions;
+using Marten.Internal.Storage;
+
+namespace Marten.Internal;
+
+/// <summary>
+///     AOT-safe bridge from a runtime <see cref="Type" /> to the closed generic
+///     <c>StorageFor&lt;T&gt;()</c> calls.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Several places in the LINQ pipeline only know the document type as a
+///         <see cref="Type" /> — <c>LinqQueryParser.BuildStatements()</c> works off
+///         <c>CollectionUsage.ElementType</c>, includes work off the generic arguments of the
+///         user-supplied receiver, and the document cleaner works off the registered mappings.
+///         Historically those went through <c>CloseAndBuildAs</c>, i.e.
+///         <c>MakeGenericType</c> + <c>Activator.CreateInstance</c> over a private
+///         <c>StorageFinder&lt;T&gt;</c> shim.
+///     </para>
+///     <para>
+///         Under Native AOT that shim's instantiation over a user document type is never
+///         statically reachable, so the runtime has no native code for it and
+///         <c>Activator.CreateInstance</c> throws
+///         <c>MissingMethodException: No parameterless constructor defined for type
+///         'QuerySession+StorageFinder`1[TDoc]'</c> on the first read (#5328).
+///     </para>
+///     <para>
+///         Every document type reaches Marten through *some* generic entry point first —
+///         <c>Query&lt;T&gt;()</c>, <c>Include&lt;TInclude&gt;()</c>, <c>Store&lt;T&gt;()</c>,
+///         <c>LoadAsync&lt;T&gt;()</c> — and at that point the compiler has already emitted the
+///         closed instantiation. Those entry points call <see cref="Register{T}" />, which
+///         captures the two closed-generic lookups in static lambdas. The <see cref="Type" />-keyed
+///         sites then resolve through this registry with no runtime code generation at all.
+///     </para>
+///     <para>
+///         The registry is a fast path, not a contract: a miss falls back to the reflective
+///         <c>CloseAndBuildAs</c> shim, which is still correct everywhere a JIT is available.
+///     </para>
+/// </remarks>
+internal static class DocumentStorageResolvers
+{
+    private static readonly ConcurrentDictionary<Type, Resolver> _resolvers = new();
+
+    /// <summary>
+    ///     Record the closed-generic storage lookups for <typeparamref name="T" />. Called from the
+    ///     generic entry points, where the instantiation is statically reachable.
+    /// </summary>
+    internal static void Register<T>() where T : notnull
+    {
+        // ContainsKey first so the steady state is a lookup rather than a delegate allocation.
+        if (_resolvers.ContainsKey(typeof(T)))
+        {
+            return;
+        }
+
+        _resolvers[typeof(T)] = new Resolver(
+            static session => session.StorageFor<T>(),
+            static providers => providers.StorageFor<T>().Lightweight);
+    }
+
+    internal static IDocumentStorage? TryResolve(Type documentType, QuerySession session)
+    {
+        return _resolvers.TryGetValue(documentType, out var resolver) ? resolver.FromSession(session) : null;
+    }
+
+    internal static IDocumentStorage? TryResolve(Type documentType, IProviderGraph providers)
+    {
+        return _resolvers.TryGetValue(documentType, out var resolver) ? resolver.FromProviders(providers) : null;
+    }
+
+    private sealed record Resolver(
+        Func<QuerySession, IDocumentStorage> FromSession,
+        Func<IProviderGraph, IDocumentStorage> FromProviders);
+}

--- a/src/Marten/Internal/ProviderGraphExtensions.cs
+++ b/src/Marten/Internal/ProviderGraphExtensions.cs
@@ -16,7 +16,9 @@ internal static class ProviderGraphExtensions
 {
     internal static IDocumentStorage StorageFor(this IProviderGraph providers, Type documentType)
     {
-        return typeof(StorageFinder<>).CloseAndBuildAs<IStorageFinder>(documentType).Find(providers);
+        // #5328: registry first so Native AOT never needs MakeGenericType here.
+        return DocumentStorageResolvers.TryResolve(documentType, providers)
+               ?? typeof(StorageFinder<>).CloseAndBuildAs<IStorageFinder>(documentType).Find(providers);
     }
 
     private interface IStorageFinder

--- a/src/Marten/Internal/Sessions/QuerySession.Storage.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Storage.cs
@@ -30,7 +30,12 @@ public partial class QuerySession
             return storage;
         }
 
-        storage = typeof(StorageFinder<>).CloseAndBuildAs<IStorageFinder>(documentType).Find(this);
+        // #5328: prefer the AOT-safe registry. Every document type passes through a generic
+        // entry point (Query<T>, Include<TInclude>, Store<T>, ...) before it can reach here, and
+        // that entry point registers the closed-generic lookup. Falling back to the reflective
+        // shim keeps behaviour identical anywhere a JIT is available.
+        storage = DocumentStorageResolvers.TryResolve(documentType, this)
+                  ?? typeof(StorageFinder<>).CloseAndBuildAs<IStorageFinder>(documentType).Find(this);
         _byType = _byType.AddOrUpdate(documentType, storage);
 
         return storage;
@@ -64,6 +69,10 @@ public partial class QuerySession
         {
             return (IDocumentStorage<T>)storage;
         }
+
+        // #5328: this call site proves the closed instantiation exists, which is exactly what
+        // the Type-keyed StorageFor(Type) overload needs under Native AOT.
+        DocumentStorageResolvers.Register<T>();
 
         return selectStorage(_providers.StorageFor<T>());
     }

--- a/src/Marten/Linq/Includes/MartenQueryableIncludeBuilder.cs
+++ b/src/Marten/Linq/Includes/MartenQueryableIncludeBuilder.cs
@@ -51,8 +51,8 @@ internal class MartenQueryableIncludeBuilder<T, TInclude>: IMartenQueryableInclu
 
     internal IIncludePlan BuildInclude(Expression<Func<T, object>> idSource, Expression? where = null)
     {
-        var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor(typeof(TInclude));
-        var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(T))).QueryMembers.MemberFor(idSource);
+        var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor<TInclude>();
+        var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor<T>()).QueryMembers.MemberFor(idSource);
 
         var include = new IncludePlan<TInclude>(storage, identityMember, _callback) { Where = where };
 
@@ -64,9 +64,9 @@ internal class MartenQueryableIncludeBuilder<T, TInclude>: IMartenQueryableInclu
         Expression<Func<TInclude, TId>> idMapping,
         Expression? where = null)
     {
-        var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor(typeof(TInclude));
-        var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(T))).QueryMembers.MemberFor(idSource);
-        var mappingMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(TInclude))).QueryMembers.MemberFor(idMapping);
+        var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor<TInclude>();
+        var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor<T>()).QueryMembers.MemberFor(idSource);
+        var mappingMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor<TInclude>()).QueryMembers.MemberFor(idMapping);
 
         var include = new IncludePlan<TInclude>(storage, identityMember, mappingMember, _callback) { Where = where };
 
@@ -174,10 +174,10 @@ internal class MartenQueryableIncludeBuilder<T, TKey, TInclude>
 
     internal IIncludePlan BuildInclude(Expression<Func<T, object>> idSource)
     {
-        var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor(typeof(TInclude));
+        var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor<TInclude>();
         if (storage is IDocumentStorage<TInclude, TKey> typedStorage)
         {
-            var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(T))).QueryMembers.MemberFor(idSource);
+            var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor<T>()).QueryMembers.MemberFor(idSource);
 
             void Callback(TInclude item)
             {
@@ -204,10 +204,10 @@ internal class MartenQueryableIncludeBuilder<T, TKey, TInclude>
             }
         }
 
-        var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor(typeof(TInclude));
+        var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor<TInclude>();
 
-        var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(T))).QueryMembers.MemberFor(idSource);
-        var mappingMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(TInclude))).QueryMembers.MemberFor(idMapping);
+        var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor<T>()).QueryMembers.MemberFor(idSource);
+        var mappingMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor<TInclude>()).QueryMembers.MemberFor(idMapping);
 
         return new IncludePlan<TInclude>(storage, identityMember, mappingMember, Callback);
     }
@@ -228,10 +228,10 @@ internal class MartenQueryableIncludeBuilder<T, TKey, TInclude>
             }
         }
 
-        var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor(typeof(TInclude));
+        var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor<TInclude>();
 
-        var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(T))).QueryMembers.MemberFor(idSource);
-        var mappingMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(TInclude))).QueryMembers.MemberFor(idMapping);
+        var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor<T>()).QueryMembers.MemberFor(idSource);
+        var mappingMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor<TInclude>()).QueryMembers.MemberFor(idMapping);
 
         return new IncludePlan<TInclude>(storage, identityMember, mappingMember, Callback);
     }

--- a/src/Marten/Linq/MartenLinqQueryable.cs
+++ b/src/Marten/Linq/MartenLinqQueryable.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using Marten.Internal;
 using Marten.Internal.Sessions;
 using Marten.Linq.Includes;
 using Marten.Linq.Parsing;
@@ -33,6 +34,11 @@ internal class MartenLinqQueryable<T> : IOrderedQueryable<T>, IMartenQueryable<T
 {
     public MartenLinqQueryable(QuerySession session, MartenLinqQueryProvider provider, Expression expression)
     {
+        // #5328: the LINQ pipeline resolves document storage from CollectionUsage.ElementType,
+        // i.e. a runtime Type. This is the generic entry point every LINQ query passes through,
+        // so it is where the closed instantiation is proven to exist for Native AOT.
+        DocumentStorageResolvers.Register<T>();
+
         Provider = provider;
         Session = session;
         MartenProvider = provider;
@@ -41,6 +47,8 @@ internal class MartenLinqQueryable<T> : IOrderedQueryable<T>, IMartenQueryable<T
 
     public MartenLinqQueryable(QuerySession session)
     {
+        DocumentStorageResolvers.Register<T>();
+
         Session = session;
         MartenProvider = new MartenLinqQueryProvider(session, typeof(T));
         Provider = MartenProvider;

--- a/src/Marten/Linq/Parsing/LinqInternalExtensions.cs
+++ b/src/Marten/Linq/Parsing/LinqInternalExtensions.cs
@@ -397,6 +397,28 @@ public static class LinqInternalExtensions
                 $"Marten cannot reduce the expression '{expression}' to a constant because it references the free parameter '{p.Name}' of type '{p.Type.Name}'. This usually indicates a Linq parser issue at the call site.");
         }
 
+        // #5328: the overwhelmingly common shapes here are a closure field read
+        // (`where x.Name == localVariable`), a compiled query's own property
+        // (`q => q.Where(x => x.Name == QueryProperty)`), or a static member. Walking those
+        // by reflection is both faster than emitting a lambda and the only option under
+        // Native AOT, where FastExpressionCompiler falls back to Reflection.Emit and throws
+        // PlatformNotSupportedException. Anything more exotic still goes through FEC.
+        try
+        {
+            if (TryEvaluateWithoutCompiling(expression, out var evaluated))
+            {
+                return Expression.Constant(evaluated, expression.Type);
+            }
+        }
+        catch (Exception e)
+        {
+            // Same contract as the FastExpressionCompiler path below: a value that cannot be read
+            // (a null receiver in `where x.Id == someNullObject.Id`, a throwing getter) is a bad
+            // Linq expression, not an internal reflection failure.
+            throw new BadLinqExpressionException(
+                "Error while trying to find a value for the Linq expression " + expression, e);
+        }
+
         var lambdaWithoutParameters = Expression.Lambda<Func<object>>(Expression.Convert(expression, typeof(object)));
         var compiledLambda = FastExpressionCompiler.ExpressionCompiler.CompileFast(lambdaWithoutParameters);
 
@@ -411,6 +433,125 @@ public static class LinqInternalExtensions
             throw new BadLinqExpressionException(
                 "Error while trying to find a value for the Linq expression " + expression, e);
         }
+    }
+
+    /// <summary>
+    ///     Evaluate the closed expression shapes Marten sees most often — constants, field and
+    ///     property reads (instance or static), boxing/upcast conversions, and array literals of
+    ///     those — without compiling a delegate. Returns false for anything else so the caller can
+    ///     fall back to <c>FastExpressionCompiler</c>.
+    /// </summary>
+    /// <remarks>
+    ///     #5328: <c>CompileFast</c> is Reflection.Emit under the covers, which Native AOT cannot
+    ///     do. Every `where x.Member == captured` clause and every compiled-query parameter lands
+    ///     here, so without this the first non-literal filter throws
+    ///     <c>PlatformNotSupportedException: Dynamic code generation is not supported on this
+    ///     platform</c>. Reflective member reads are AOT-safe as long as the declaring type
+    ///     survives trimming, which it does for the consumer's own query and closure types.
+    /// </remarks>
+    internal static bool TryEvaluateWithoutCompiling(Expression expression, out object? value)
+    {
+        switch (expression)
+        {
+            case ConstantExpression constant:
+                value = constant.Value;
+                return true;
+
+            case MemberExpression { Member: FieldInfo field } member:
+            {
+                if (field.IsStatic)
+                {
+                    value = field.GetValue(null);
+                    return true;
+                }
+
+                if (member.Expression == null || !TryEvaluateWithoutCompiling(member.Expression, out var target))
+                {
+                    value = null;
+                    return false;
+                }
+
+                value = field.GetValue(target);
+                return true;
+            }
+
+            case MemberExpression { Member: PropertyInfo property } member:
+            {
+                if (!property.CanRead || property.GetIndexParameters().Length > 0)
+                {
+                    value = null;
+                    return false;
+                }
+
+                if (property.GetMethod is { IsStatic: true })
+                {
+                    value = property.GetValue(null);
+                    return true;
+                }
+
+                if (member.Expression == null || !TryEvaluateWithoutCompiling(member.Expression, out var target))
+                {
+                    value = null;
+                    return false;
+                }
+
+                value = property.GetValue(target);
+                return true;
+            }
+
+            // Only the conversions that do not change the underlying value: boxing, upcasts, and
+            // Nullable<T> wrapping. Numeric conversions are left to FEC so we never silently
+            // change a value's representation here.
+            case UnaryExpression
+            {
+                NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked or ExpressionType.Quote or
+                ExpressionType.TypeAs
+            } unary when IsValuePreservingConversion(unary):
+                return TryEvaluateWithoutCompiling(unary.Operand, out value);
+
+            case NewArrayExpression { NodeType: ExpressionType.NewArrayInit } array:
+            {
+                var elementType = array.Type.GetElementType();
+                if (elementType == null)
+                {
+                    value = null;
+                    return false;
+                }
+
+                var values = Array.CreateInstance(elementType, array.Expressions.Count);
+                for (var i = 0; i < array.Expressions.Count; i++)
+                {
+                    if (!TryEvaluateWithoutCompiling(array.Expressions[i], out var element))
+                    {
+                        value = null;
+                        return false;
+                    }
+
+                    values.SetValue(element, i);
+                }
+
+                value = values;
+                return true;
+            }
+
+            default:
+                value = null;
+                return false;
+        }
+    }
+
+    private static bool IsValuePreservingConversion(UnaryExpression unary)
+    {
+        if (unary.Method != null)
+        {
+            // A user-defined conversion operator; let FEC run it.
+            return false;
+        }
+
+        var from = unary.Operand.Type;
+        var to = unary.Type;
+
+        return to.IsAssignableFrom(from) || Nullable.GetUnderlyingType(to) == from;
     }
 
     /// <summary>

--- a/src/Marten/Patching/PatchExpression.cs
+++ b/src/Marten/Patching/PatchExpression.cs
@@ -29,7 +29,7 @@ internal class PatchExpression<T>: IPatchExpression<T>
     public PatchExpression(ISqlFragment filter, DocumentSessionBase session)
     {
         _session = session;
-        var storage = _session.StorageFor(typeof(T));
+        var storage = _session.StorageFor<T>();
         var operation = new PatchOperation(session, PatchFunction, storage, _patchSet, _session.Serializer);
         if (filter != null)
         {
@@ -45,7 +45,7 @@ internal class PatchExpression<T>: IPatchExpression<T>
     public PatchExpression(Expression<Func<T, bool>> filterExpression, DocumentSessionBase session)
     {
         _session = session;
-        var storage = _session.StorageFor(typeof(T));
+        var storage = _session.StorageFor<T>();
         var operation = new PatchOperation(session, PatchFunction, storage, _patchSet, _session.Serializer);
         if (filterExpression != null)
         {

--- a/src/Marten/Storage/StorageFeatures.cs
+++ b/src/Marten/Storage/StorageFeatures.cs
@@ -15,6 +15,7 @@ using Marten.Events;
 using Marten.Events.Daemon;
 using StreamState = JasperFx.Events.StreamState;
 using Marten.Exceptions;
+using Marten.Internal;
 using Marten.Schema;
 using Weasel.Core;
 using Weasel.Core.Migrations;
@@ -153,6 +154,12 @@ public class StorageFeatures: IFeatureSchema, IDescribeMyself
         {
             return (DocumentMappingBuilder<T>)builder;
         }
+
+        // #5328: Schema.For<T>() is the earliest generic mention of a document type, so it is
+        // the widest net for the AOT Type -> StorageFor<T>() bridge. Covers the Type-keyed
+        // admin paths (document cleaner, TruncateTable, DeleteAllForTenant) that a read or
+        // write of T may never have warmed.
+        DocumentStorageResolvers.Register<T>();
 
         builder = new DocumentMappingBuilder<T>();
         _builders.Swap(d => d.AddOrUpdate(typeof(T), builder));


### PR DESCRIPTION
Closes #5328.

## The report

A Marten app published with `PublishAot=true` builds and publishes analyzer-clean, then throws on the **first document read**. Writes — including schema creation — are fine.

I reproduced the reporter's exact setup as a native binary against a real PostgreSQL. Three distinct sites, all on the read path:

| symptom | site |
|---|---|
| `MissingMethodException: No parameterless constructor defined for type 'QuerySession+StorageFinder\`1[Praktijk]'` | `QuerySession.StorageFor(Type)` closed a private shim with `MakeGenericType` + `Activator.CreateInstance` |
| `MissingMethodException: ... 'PropertyQueryMember\`1[System.String]'` | `CompiledQueryPlan.sortMembers()`, same pattern |
| `PlatformNotSupportedException: Dynamic code generation is not supported on this platform` | `LinqInternalExtensions.ReduceToConstant` compiled a lambda with FastExpressionCompiler |

The third one is not in the issue — it surfaced once the first two were fixed and the read got further. It fires for every `where x.Member == captured`, which is roughly the most common query shape there is, so fixing only the two reported sites would have moved the wall rather than removed it.

ILC has no native code for a generic instantiation nothing constructs statically, and `Reflection.Emit` is not available at all. Neither is something a consumer can configure their way out of.

## The fixes

All three have the same shape: **capture the closed generic where the compiler has already emitted it**, instead of building it at runtime.

**`DocumentStorageResolvers`** (new) — a `Type`-keyed registry of `Func<QuerySession, IDocumentStorage>`, populated from the generic entry points every document type must pass through: `Schema.For<T>()`, `MartenLinqQueryable<T>`'s constructor, `StorageFor<T>()`. The `Type`-keyed lookups consult it first and fall back to the old reflective shim on a miss, so behaviour is identical anywhere a JIT exists.

`Schema.For<T>()` is the widest net deliberately — it also covers the `Type`-keyed admin paths (document cleaner, `TruncateTable`, `DeleteAllForTenant`) that a read or write of `T` may never have warmed.

**`IParameterFinder.BuildQueryMember`** — the finders are already closed over their own types (`SimpleParameterFinder<string>`, `ArrayParameterFinder<Guid>`, … built in `QueryCompiler`'s static constructor), so letting each build its own `PropertyQueryMember<T>` / `FieldQueryMember<T>` keeps every instantiation statically reachable. `EnumParameterFinder` returns null on purpose — no finder can be closed over a consumer's enum type — and that shape still takes the reflective path. It is pinned by a test and written down in the docs rather than left to be rediscovered.

**`LinqInternalExtensions.TryEvaluateWithoutCompiling`** — walks the shapes that actually reach `ReduceToConstant`: constants, instance/static field and property reads, member chains, boxing and `Nullable<T>` conversions, array literals. Anything else (numeric conversions, method calls, user-defined operators) still goes to FEC. Failures are wrapped in `BadLinqExpressionException` exactly as the FEC path was — `Bug_118`'s "null receiver" test asserts on that and caught it.

Call sites that already knew `T` statically now say so: `PatchExpression<T>` and the include builders call `StorageFor<T>()` instead of `StorageFor(typeof(T))`.

## The new gate

The issue is right that the existing gate cannot see this. `src/Marten.AotSmoke` says so itself — *"Connecting / querying / persisting anything … this is a build-time analyzer test"*. The failure is a clean build that throws one line later, so no amount of analyzer coverage reaches it.

`src/Marten.AotRuntimeSmoke` (new) publishes natively and **runs** against a real PostgreSQL: `LoadAsync`, LINQ with a literal, LINQ with a captured variable, `StartsWith` + `OrderBy`, `IsOneOf`, an aggregate, raw SQL, and a source-generated compiled query. Each check reports pass/fail by name so a regression names the read path that broke.

It fails on master and passes here. `./build.sh test-aot-runtime` runs it; it has its own CI job rather than a matrix entry because the ILC compile is minutes of CPU no other job needs, and because it does not compile a test project or run through the supervisor.

## Verification

Reproduced and fixed against a native `osx-arm64` binary. Suites on net10.0:

| suite | result |
|---|---|
| LinqTests | 1471 / 1471 |
| DocumentDbTests | 1108 passed, 1 skipped |
| CoreTests | 626 (incl. 16 new) |
| ValueTypeTests | 340 |
| PatchingTests | 133 passed, 1 skipped |
| CompiledQueryTests | 9 |

New regression tests: `LinqTests.Bugs.Bug_5328_reduce_to_constant_without_emit` pins which expression shapes must evaluate without emitting, which must still fall back, and that both produce the same values; `CoreTests.Bug_5328_aot_generic_bridges` pins the registrations and the finder coverage — a JIT would otherwise hide any regression here, so the assertions are about *which path ran*, not about the result.

## Docs

`docs/configuration/aot-publishing.md` claimed compiled queries were the answer for LINQ under AOT; that path was broken too. Rewritten to say reads work, to name the two remaining shapes that need a JIT (enum compiled-query parameters, method calls in a where clause) with the workaround for each, and to add a note that a clean publish is necessary but not sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDX5UV1He5if9vVo8Bdi7g