### PR TITLE
Fix #5361: reduce an enum compared to a variable without Reflection.Emit

### DIFF
--- a/src/LinqTests/Bugs/Bug_5361_enum_compared_to_a_variable.cs
+++ b/src/LinqTests/Bugs/Bug_5361_enum_compared_to_a_variable.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Linq.Parsing;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+// #5361: #5328 gave ReduceToConstant a reflective walk for the closed expression shapes Marten sees
+// most often, so a Native AOT binary would not hit Reflection.Emit on every `where x.Member ==
+// captured`. Enum equality was not one of those shapes. The C# compiler lowers
+//
+//     x.Soort == captured
+//
+// to Equal(Convert(x.Soort, Int32), Convert(closure.captured, Int32)), and the enum-to-underlying
+// Convert fell through to FastExpressionCompiler — so the comparison threw
+// PlatformNotSupportedException under AOT while the same comparison against a literal worked.
+//
+// Two changes, pinned here: the enum Convert is now walked reflectively like the rest, and the
+// shapes that do still need a compiled lambda fall back to the BCL expression interpreter instead
+// of hard-failing wherever the platform cannot emit.
+public class Bug_5361_enum_compared_to_a_variable: BugIntegrationContext
+{
+    [Fact]
+    public void evaluates_an_enum_to_underlying_convert_without_emitting()
+    {
+        var captured = Bug5361Soort.Apotheek;
+        Expression<Func<Bug5361Doc, bool>> expression = x => x.Soort == captured;
+
+        // The shape the compiler actually hands the parser.
+        var right = ((BinaryExpression)expression.Body).Right;
+        right.NodeType.ShouldBe(ExpressionType.Convert);
+        right.Type.ShouldBe(typeof(int));
+
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(right, out var value).ShouldBeTrue();
+        value.ShouldBe(1);
+    }
+
+    [Fact]
+    public void evaluates_a_nullable_enum_convert_without_emitting()
+    {
+        Bug5361Soort? captured = Bug5361Soort.Apotheek;
+        Expression<Func<Bug5361Doc, bool>> expression = x => x.OptioneleSoort == captured;
+
+        var right = ((BinaryExpression)expression.Body).Right;
+        right.Type.ShouldBe(typeof(int?));
+
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(right, out var value).ShouldBeTrue();
+        value.ShouldBe(1);
+    }
+
+    [Fact]
+    public void evaluates_a_null_nullable_enum_convert_without_emitting()
+    {
+        Bug5361Soort? captured = null;
+        Expression<Func<Bug5361Doc, bool>> expression = x => x.OptioneleSoort == captured;
+
+        var right = ((BinaryExpression)expression.Body).Right;
+
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(right, out var value).ShouldBeTrue();
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void evaluates_an_underlying_to_enum_cast_without_emitting()
+    {
+        var captured = 1;
+        Expression<Func<Bug5361Soort>> expression = () => (Bug5361Soort)captured;
+
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(expression.Body, out var value).ShouldBeTrue();
+        value.ShouldBe(Bug5361Soort.Apotheek);
+    }
+
+    [Fact]
+    public void evaluates_a_cast_between_two_enums_sharing_an_underlying_type_without_emitting()
+    {
+        var captured = Bug5361Soort.Apotheek;
+        Expression<Func<Bug5361Ander>> expression = () => (Bug5361Ander)captured;
+
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(expression.Body, out var value).ShouldBeTrue();
+        value.ShouldBe(Bug5361Ander.Tweede);
+    }
+
+    [Fact]
+    public void evaluates_an_enum_whose_underlying_type_is_not_int_without_emitting()
+    {
+        var captured = Bug5361Byte.Tweede;
+        Expression<Func<byte>> expression = () => (byte)captured;
+
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(expression.Body, out var value).ShouldBeTrue();
+        value.ShouldBe((byte)1);
+    }
+
+    [Fact]
+    public void still_declines_a_widening_conversion_out_of_an_enum()
+    {
+        var captured = Bug5361Soort.Apotheek;
+        Expression<Func<long>> expression = () => (long)captured;
+
+        // int -> long changes the representation, so it stays with the compiled path rather than
+        // being reinterpreted here. Only conversions that share one integral representation qualify.
+        LinqInternalExtensions.TryEvaluateWithoutCompiling(expression.Body, out _).ShouldBeFalse();
+
+        // ...and still reduces to the right value through that path.
+        LinqInternalExtensions.ReduceToConstant(expression.Body).Value.ShouldBe(1L);
+    }
+
+    [Fact]
+    public void the_interpreted_fallback_reads_the_same_value_as_the_emitted_one()
+    {
+        var captured = Bug5361Soort.Apotheek;
+        Expression<Func<long>> widening = () => (long)captured;
+        var lambda = Expression.Lambda<Func<object>>(Expression.Convert(widening.Body, typeof(object)));
+
+        // This is the branch a Native AOT binary takes: no Reflection.Emit anywhere.
+        LinqInternalExtensions.CompileValueReader(lambda, canEmit: false)()
+            .ShouldBe(LinqInternalExtensions.CompileValueReader(lambda, canEmit: true)());
+    }
+
+    [Fact]
+    public async Task queries_an_enum_against_a_captured_variable()
+    {
+        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Bug5361Doc));
+
+        var huisarts = new Bug5361Doc { Soort = Bug5361Soort.Huisarts, OptioneleSoort = Bug5361Soort.Huisarts };
+        var apotheek = new Bug5361Doc { Soort = Bug5361Soort.Apotheek };
+
+        theSession.Store(huisarts, apotheek);
+        await theSession.SaveChangesAsync();
+
+        var soort = Bug5361Soort.Huisarts;
+
+        (await theSession.Query<Bug5361Doc>().Where(x => x.Soort == soort).ToListAsync())
+            .Single().Id.ShouldBe(huisarts.Id);
+
+        (await theSession.Query<Bug5361Doc>().Where(x => x.Soort != soort).ToListAsync())
+            .Single().Id.ShouldBe(apotheek.Id);
+
+        (await theSession.Query<Bug5361Doc>().Where(x => x.Soort > soort).ToListAsync())
+            .Single().Id.ShouldBe(apotheek.Id);
+
+        Bug5361Soort? optioneel = Bug5361Soort.Huisarts;
+        (await theSession.Query<Bug5361Doc>().Where(x => x.OptioneleSoort == optioneel).ToListAsync())
+            .Single().Id.ShouldBe(huisarts.Id);
+
+        // The same rows the literal form returns, which is what made the failure so surprising in
+        // the field: one of these two spellings worked and the other did not.
+        (await theSession.Query<Bug5361Doc>().Where(x => x.Soort == Bug5361Soort.Huisarts).ToListAsync())
+            .Single().Id.ShouldBe(huisarts.Id);
+    }
+
+    [Fact]
+    public async Task queries_an_enum_against_a_captured_variable_when_stored_as_a_string()
+    {
+        StoreOptions(opts => opts.UseSystemTextJsonForSerialization(EnumStorage.AsString));
+        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Bug5361Doc));
+
+        var huisarts = new Bug5361Doc { Soort = Bug5361Soort.Huisarts };
+        var apotheek = new Bug5361Doc { Soort = Bug5361Soort.Apotheek };
+
+        theSession.Store(huisarts, apotheek);
+        await theSession.SaveChangesAsync();
+
+        var soort = Bug5361Soort.Huisarts;
+
+        // The reduced constant is the integral value either way; turning it back into a name is
+        // EnumAsStringMember's job, so the storage mode must not change what comes back.
+        (await theSession.Query<Bug5361Doc>().Where(x => x.Soort == soort).ToListAsync())
+            .Single().Id.ShouldBe(huisarts.Id);
+
+        (await theSession.Query<Bug5361Doc>().Where(x => x.Soort != soort).ToListAsync())
+            .Single().Id.ShouldBe(apotheek.Id);
+    }
+}
+
+public class Bug5361Doc
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Bug5361Soort Soort { get; set; }
+    public Bug5361Soort? OptioneleSoort { get; set; }
+}
+
+public enum Bug5361Soort
+{
+    Huisarts,
+    Apotheek
+}
+
+public enum Bug5361Ander
+{
+    Eerste,
+    Tweede
+}
+
+public enum Bug5361Byte: byte
+{
+    Eerste,
+    Tweede
+}

--- a/src/Marten.AotRuntimeSmoke/Program.cs
+++ b/src/Marten.AotRuntimeSmoke/Program.cs
@@ -9,6 +9,9 @@
 //   LINQ                  QuerySession.StorageFor(Type) closed StorageFinder<T> reflectively.
 //   captured variable     LinqInternalExtensions.ReduceToConstant compiled a lambda with
 //                         FastExpressionCompiler, i.e. Reflection.Emit.
+//   captured enum         same method, but the enum-to-underlying Convert the C# compiler emits
+//                         for `x.Enum == captured` was not one of the shapes it could walk
+//                         reflectively, so it still reached Reflection.Emit (#5361).
 //   compiled query        CompiledQueryPlan.sortMembers closed PropertyQueryMember<T>
 //                         reflectively.
 //
@@ -49,8 +52,15 @@ try
 
     await using (var writing = store.LightweightSession())
     {
-        writing.Store(new Praktijk { Id = id, AgbCode = "01059910", Naam = "Praktijk Jansen" });
-        writing.Store(new Praktijk { Id = Guid.NewGuid(), AgbCode = "01059911", Naam = "Praktijk Pietersen" });
+        writing.Store(new Praktijk
+        {
+            Id = id, AgbCode = "01059910", Naam = "Praktijk Jansen", Soort = Soort.Huisarts,
+            OptioneleSoort = Soort.Huisarts
+        });
+        writing.Store(new Praktijk
+        {
+            Id = Guid.NewGuid(), AgbCode = "01059911", Naam = "Praktijk Pietersen", Soort = Soort.Apotheek
+        });
         await writing.SaveChangesAsync();
     }
 
@@ -74,6 +84,34 @@ try
     {
         var captured = "01059910";
         var found = await session.Query<Praktijk>().Where(x => x.AgbCode == captured).ToListAsync();
+        return found.Count == 1;
+    });
+
+    await Check("LINQ with an enum literal", async () =>
+    {
+        var found = await session.Query<Praktijk>().Where(x => x.Soort == Soort.Huisarts).ToListAsync();
+        return found.Count == 1;
+    });
+
+    // #5361 — this is the one that threw where the literal above did not.
+    await Check("LINQ with an enum in a captured variable", async () =>
+    {
+        var soort = Soort.Huisarts;
+        var found = await session.Query<Praktijk>().Where(x => x.Soort == soort).ToListAsync();
+        return found.Count == 1;
+    });
+
+    await Check("LINQ with a nullable enum in a captured variable", async () =>
+    {
+        Soort? soort = Soort.Huisarts;
+        var found = await session.Query<Praktijk>().Where(x => x.OptioneleSoort == soort).ToListAsync();
+        return found.Count == 1;
+    });
+
+    await Check("LINQ with an enum comparison operator", async () =>
+    {
+        var soort = Soort.Apotheek;
+        var found = await session.Query<Praktijk>().Where(x => x.Soort < soort).ToListAsync();
         return found.Count == 1;
     });
 
@@ -147,6 +185,14 @@ public class Praktijk
     public Guid Id { get; set; }
     public string AgbCode { get; set; } = "";
     public string Naam { get; set; } = "";
+    public Soort Soort { get; set; }
+    public Soort? OptioneleSoort { get; set; }
+}
+
+public enum Soort
+{
+    Huisarts,
+    Apotheek
 }
 
 public class PraktijkByAgb: ICompiledListQuery<Praktijk>

--- a/src/Marten/Linq/Parsing/LinqInternalExtensions.cs
+++ b/src/Marten/Linq/Parsing/LinqInternalExtensions.cs
@@ -2,9 +2,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Marten.Exceptions;
@@ -205,12 +207,10 @@ public static class LinqInternalExtensions
         {
             if (m.Expression is ConstantExpression)
             {
-                var lambdaWithoutParameters =
-                    Expression.Lambda<Func<object>>(Expression.Convert(expression, typeof(object)));
-                var compiledLambda = FastExpressionCompiler.ExpressionCompiler.CompileFast(lambdaWithoutParameters);
-
-                var value = compiledLambda();
-                return new CommandParameter(value);
+                // #5361: this used to compile its own lambda. Going through ReduceToConstant instead
+                // means there is exactly one implementation of "evaluate a closed expression", so the
+                // reflective walk and the Native AOT fallback below cover this call site too.
+                return new CommandParameter(expression.ReduceToConstant().Value);
             }
 
             return collection.MemberFor(expression);
@@ -420,7 +420,7 @@ public static class LinqInternalExtensions
         }
 
         var lambdaWithoutParameters = Expression.Lambda<Func<object>>(Expression.Convert(expression, typeof(object)));
-        var compiledLambda = FastExpressionCompiler.ExpressionCompiler.CompileFast(lambdaWithoutParameters);
+        var compiledLambda = CompileValueReader(lambdaWithoutParameters);
 
         try
         {
@@ -436,18 +436,48 @@ public static class LinqInternalExtensions
     }
 
     /// <summary>
+    ///     Compile the parameter-less lambda that <see cref="ReduceToConstant" /> builds for the
+    ///     shapes <see cref="TryEvaluateWithoutCompiling" /> declines.
+    /// </summary>
+    /// <remarks>
+    ///     #5361: FastExpressionCompiler is Reflection.Emit underneath, so under Native AOT it threw
+    ///     <c>PlatformNotSupportedException</c> for every shape the reflective walk does not cover —
+    ///     leaving the parser one unrecognised expression shape away from a broken query. The BCL's
+    ///     own expression interpreter needs no dynamic code and evaluates the same tree, so it takes
+    ///     over wherever the platform cannot emit. FEC stays the default where it can run: this is on
+    ///     the query-parsing path and FEC is considerably faster than interpreting.
+    /// </remarks>
+    internal static Func<object> CompileValueReader(Expression<Func<object>> lambda)
+    {
+        return CompileValueReader(lambda, RuntimeFeature.IsDynamicCodeSupported);
+    }
+
+    /// <summary>
+    ///     Overload taking the platform capability explicitly so tests can exercise the interpreted
+    ///     path on a runtime that happens to support emitting.
+    /// </summary>
+    internal static Func<object> CompileValueReader(Expression<Func<object>> lambda, bool canEmit)
+    {
+        return canEmit
+            ? FastExpressionCompiler.ExpressionCompiler.CompileFast(lambda)
+            : lambda.Compile(preferInterpretation: true);
+    }
+
+    /// <summary>
     ///     Evaluate the closed expression shapes Marten sees most often — constants, field and
-    ///     property reads (instance or static), boxing/upcast conversions, and array literals of
-    ///     those — without compiling a delegate. Returns false for anything else so the caller can
-    ///     fall back to <c>FastExpressionCompiler</c>.
+    ///     property reads (instance or static), boxing/upcast and enum conversions, and array
+    ///     literals of those — without compiling a delegate. Returns false for anything else so the
+    ///     caller can fall back to <see cref="CompileValueReader(Expression{Func{object}})" />.
     /// </summary>
     /// <remarks>
     ///     #5328: <c>CompileFast</c> is Reflection.Emit under the covers, which Native AOT cannot
     ///     do. Every `where x.Member == captured` clause and every compiled-query parameter lands
-    ///     here, so without this the first non-literal filter throws
+    ///     here, so without this the first non-literal filter threw
     ///     <c>PlatformNotSupportedException: Dynamic code generation is not supported on this
     ///     platform</c>. Reflective member reads are AOT-safe as long as the declaring type
     ///     survives trimming, which it does for the consumer's own query and closure types.
+    ///     #5361 gave the remaining shapes an interpreted fallback, so this is now a fast path
+    ///     rather than the only thing standing between an AOT consumer and a broken query.
     /// </remarks>
     internal static bool TryEvaluateWithoutCompiling(Expression expression, out object? value)
     {
@@ -506,8 +536,29 @@ public static class LinqInternalExtensions
             {
                 NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked or ExpressionType.Quote or
                 ExpressionType.TypeAs
-            } unary when IsValuePreservingConversion(unary):
+            } unary when isValuePreservingConversion(unary):
                 return TryEvaluateWithoutCompiling(unary.Operand, out value);
+
+            // #5361: enum comparison is the one conversion ordinary C# forces through here. The
+            // compiler lowers `where x.Status == captured` to
+            //     Equal(Convert(x.Status, Int32), Convert(closure.captured, Int32))
+            // so the value side always arrives wrapped in an enum-to-underlying Convert. That changes
+            // the value's CLR type but not the number inside it, which makes it safe to do here — and
+            // doing it here is what keeps the most common non-literal filter off the emit path.
+            case UnaryExpression
+            {
+                NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked, Method: null
+            } unary when isEnumRepresentationConversion(unary):
+            {
+                if (!TryEvaluateWithoutCompiling(unary.Operand, out var enumValue))
+                {
+                    value = null;
+                    return false;
+                }
+
+                value = convertEnumRepresentation(enumValue, unary.Type);
+                return true;
+            }
 
             case NewArrayExpression { NodeType: ExpressionType.NewArrayInit } array:
             {
@@ -540,7 +591,7 @@ public static class LinqInternalExtensions
         }
     }
 
-    private static bool IsValuePreservingConversion(UnaryExpression unary)
+    private static bool isValuePreservingConversion(UnaryExpression unary)
     {
         if (unary.Method != null)
         {
@@ -552,6 +603,48 @@ public static class LinqInternalExtensions
         var to = unary.Type;
 
         return to.IsAssignableFrom(from) || Nullable.GetUnderlyingType(to) == from;
+    }
+
+    /// <summary>
+    ///     True for a conversion between an enum and something with the *same* integral
+    ///     representation: an enum to its own underlying type, back again, or between two enums that
+    ///     share one. Widening and narrowing stay out, so only the CLR type of the value changes here
+    ///     and never the number itself.
+    /// </summary>
+    private static bool isEnumRepresentationConversion(UnaryExpression unary)
+    {
+        var from = Nullable.GetUnderlyingType(unary.Operand.Type) ?? unary.Operand.Type;
+        var to = Nullable.GetUnderlyingType(unary.Type) ?? unary.Type;
+
+        if (!from.IsEnum && !to.IsEnum)
+        {
+            return false;
+        }
+
+        return representationOf(from) == representationOf(to);
+    }
+
+    private static object? convertEnumRepresentation(object? value, Type targetType)
+    {
+        // Only a Nullable<T> operand can be null here. Expression.Constant in the caller rejects it
+        // for a non-nullable target, which is the same failure the compiled path produces.
+        if (value == null)
+        {
+            return null;
+        }
+
+        var target = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
+        // Route through the shared integral representation rather than unboxing, so this reads the
+        // same for every enum underlying type rather than only for the int default.
+        var integral = Convert.ChangeType(value, representationOf(target), CultureInfo.InvariantCulture)!;
+
+        return target.IsEnum ? Enum.ToObject(target, integral) : integral;
+    }
+
+    private static Type representationOf(Type type)
+    {
+        return type.IsEnum ? Enum.GetUnderlyingType(type) : type;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #5361.

## The failure

Under `PublishAot`, comparing an enum against a captured variable threw, while the *same*
comparison against a literal worked:

```csharp
await session.Query<Regel>().Where(x => x.Type == Soort.A).ToListAsync();  // fine

var soort = Soort.A;
await session.Query<Regel>().Where(x => x.Type == soort).ToListAsync();    // PlatformNotSupportedException
```

```text
BadLinqExpressionException: Whoa pardner, Marten could not parse
'Convert(value(<>c__DisplayClass0_1).soort, Int32)' with the SimpleExpression construct
 ---> PlatformNotSupportedException: Dynamic code generation is not supported on this platform.
   at FastExpressionCompiler.ExpressionCompiler.CompileFast[R](...)
   at Marten.Linq.Parsing.LinqInternalExtensions.ReduceToConstant(Expression)
```

C# lowers enum equality to a comparison of the underlying integers, so the value side always
arrives as `Convert(closure.captured, Int32)`. #5328 gave `ReduceToConstant` a reflective walk for
the closed shapes that reach it, but that `Convert` was not one of them, so it still fell through
to `FastExpressionCompiler` — which is `Reflection.Emit`.

## The change

Two parts, because the enum shape is the symptom and the missing fallback is the cause.

**1. Walk the enum conversion reflectively.** `TryEvaluateWithoutCompiling` now handles conversions
between an enum and anything sharing its integral representation: an enum to its own underlying
type, back again, between two enums over the same one, and the `Nullable<T>` forms. Widening and
narrowing stay excluded, so no value is ever reinterpreted here — only its CLR type changes, never
the number inside it, and the constant that comes out is byte-for-byte what FEC produced. This
keeps the most common non-literal filter in an application off the emit path on every platform,
not just AOT.

**2. Stop depending on being able to emit at all.** Where the platform cannot emit, the shapes the
reflective walk declines now go to the BCL's expression interpreter
(`Compile(preferInterpretation: true)`) instead of throwing. FEC stays the default where it can
run, since this sits on the query-parsing path and is meaningfully faster.

Part 1 alone would have closed this issue. Without part 2, though, every expression shape Marten
has not explicitly taught itself to walk stays a latent AOT failure — this bug is the second one
of exactly that kind, after #5328. `LambdaExpression.Compile` carries no `[RequiresDynamicCode]`
precisely because the interpreter is the sanctioned fallback, and ILC emits no new IL3050 for it.

While in there: `ReduceToValue` kept its own copy of the compile-a-lambda logic for the same
closure-field-read shape. It now goes through `ReduceToConstant`, so there is one implementation of
"evaluate a closed expression" to keep AOT-safe rather than two.

## On the gate

The issue notes that `src/Marten.AotSmoke` never connects or queries. That is still true — it is a
build-time analyzer gate — but `src/Marten.AotRuntimeSmoke` (added with #5328) does publish
natively and run. It simply had no enum shape in it. It now checks an enum literal, an enum in a
captured variable, a nullable enum, and an enum comparison operator.

Reverting **only** the source change and republishing makes exactly the three captured-variable
checks fail with the reported stack, while the literal check keeps passing:

```text
OK   LINQ with an enum literal
FAIL LINQ with an enum in a captured variable
FAIL LINQ with a nullable enum in a captured variable
FAIL LINQ with an enum comparison operator
Marten AOT runtime smoke FAILED — 3 read path(s) broken under Native AOT.
```

## Tests

`src/LinqTests/Bugs/Bug_5361_enum_compared_to_a_variable.cs` pins:

- the enum, nullable-enum, null-nullable, underlying-to-enum, enum-to-enum and non-`int`-underlying
  (`byte`) conversions all evaluate without emitting;
- a widening `enum` → `long` conversion is still declined, and still reduces correctly through the
  compiled path;
- the interpreted fallback reads the same value as the emitted one, which is the branch an AOT
  binary takes;
- integration coverage for `==`, `!=`, `>` and a nullable enum against captured variables, under
  both `EnumStorage.AsInteger` and `EnumStorage.AsString` — the reduced constant is the integral
  value either way, so turning it back into a name stays `EnumAsStringMember`'s job.

Verified locally on net10.0: LinqTests (1495), CoreTests (626) and CompiledQueryTests all green,
and the `Marten.AotRuntimeSmoke` native binary passes all 13 checks.
