### PR TITLE
Render DaemonTests as Bobcat specifications

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -520,6 +520,9 @@
          fixed and must not be weakened to make it green. -->
 
 
+    <!-- Marker-step specifications (JasperFx/bobcat#110), shipped in Bobcat 0.15.0. -->
+    <PackageVersion Include="Bobcat" Version="0.15.0" />
+    <PackageVersion Include="Bobcat.Generators" Version="0.15.0" />
     <PackageVersion Include="JasperFx" Version="2.66.0" />
     <PackageVersion Include="JasperFx.Events" Version="2.66.0" />
     <!--

--- a/src/DaemonTests/Aggregations/build_aggregate_projection.cs
+++ b/src/DaemonTests/Aggregations/build_aggregate_projection.cs
@@ -20,6 +20,8 @@ using Xunit;
 
 namespace DaemonTests.Aggregations;
 
+[Bobcat.BobcatFeature("Building an aggregate projection")]
+[BobcatScenario]
 public class build_aggregate_projection: DaemonContext
 {
     public build_aggregate_projection(ITestOutputHelper output): base(output)

--- a/src/DaemonTests/DaemonTests.csproj
+++ b/src/DaemonTests/DaemonTests.csproj
@@ -2,6 +2,9 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
+        <!-- Interceptors are opted into per namespace; Bobcat.Generated is the constant the
+             generator emits into, identical in every project (JasperFx/bobcat#110). -->
+        <InterceptorsNamespaces>$(InterceptorsNamespaces);Bobcat.Generated</InterceptorsNamespaces>
 
         <!-- This suite has been swept for xUnit1051 (#5067): every call that accepts a
              CancellationToken is handed TestContext.Current.CancellationToken, so a hung
@@ -10,6 +13,8 @@
         <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="Bobcat" />
+        <PackageReference Include="Bobcat.Generators" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <PackageReference Include="Bogus" />
         <PackageReference Include="Confluent.Kafka" />
         <PackageReference Include="Lamar.Microsoft.DependencyInjection" />

--- a/src/DaemonTests/TestingSupport/BobcatScenarioAttribute.cs
+++ b/src/DaemonTests/TestingSupport/BobcatScenarioAttribute.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Reflection;
+using Bobcat;
+using Bobcat.Monitoring;
+using Xunit.v3;
+
+namespace DaemonTests.TestingSupport;
+
+/// <summary>
+/// Opens a Bobcat scenario around each test, so calls to <c>[BobcatStep]</c> helpers on
+/// <see cref="DaemonContext"/> report themselves as steps, and publishes the verdict to a running
+/// Bobcat console (JasperFx/bobcat#110).
+/// </summary>
+/// <remarks>
+/// The runner-specific half of the marker-step style. Bobcat's own attributes stay runner-neutral
+/// — the generator matches test methods by attribute NAME and references no runner — so this small
+/// adapter is what a shipped Bobcat.Xunit package would contain.
+///
+/// Inert when nothing is listening: with no console on the wire the publisher is null, no events
+/// are sent, and the only cost is a few strings per test.
+/// </remarks>
+public sealed class BobcatScenarioAttribute : BeforeAfterTestAttribute
+{
+    internal static readonly Guid RunId = Guid.NewGuid();
+
+    private static readonly Lazy<IMonitorEventSink?> Sink = new(() =>
+    {
+        var publisher = MonitorPublisher.TryConnect().GetAwaiter().GetResult();
+
+        publisher?.Post(new RunStarted(
+            RunId, "DaemonTests", Repository: "", Branch: null, Mode: "xunit-marker-steps",
+            StartedAt: DateTimeOffset.UtcNow, TotalScenarios: null));
+
+        return publisher;
+    });
+
+    private ScenarioRecorder.Recording? _recording;
+
+    public override void Before(MethodInfo methodUnderTest, IXunitTest test)
+    {
+        var feature = methodUnderTest.DeclaringType?.GetCustomAttribute<BobcatFeatureAttribute>()?.Title
+                      ?? Prettify(methodUnderTest.DeclaringType?.Name ?? "DaemonTests");
+
+        _recording = ScenarioRecorder.Begin(feature, Prettify(methodUnderTest.Name), Sink.Value, RunId);
+    }
+
+    public override void After(MethodInfo methodUnderTest, IXunitTest test)
+    {
+        if (_recording is null) return;
+
+        Console.WriteLine($"  {_recording.Uid}");
+        foreach (var step in _recording.Steps)
+        {
+            Console.WriteLine($"    {step}  ({step.DurationMs}ms)");
+        }
+
+        _recording.Dispose();
+        _recording = null;
+    }
+
+    private static string Prettify(string name) => name.Replace('_', ' ');
+}

--- a/src/DaemonTests/TestingSupport/BobcatScenarioAttribute.cs
+++ b/src/DaemonTests/TestingSupport/BobcatScenarioAttribute.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Reflection;
 using Bobcat;

--- a/src/DaemonTests/TestingSupport/DaemonContext.cs
+++ b/src/DaemonTests/TestingSupport/DaemonContext.cs
@@ -58,6 +58,7 @@ public abstract class DaemonContext: OneOffConfigurationsContext, IAsyncLifetime
 
     public ILogger<IProjection> Logger { get; }
 
+    [Bobcat.BobcatStep("the projection daemon is running", Keyword = "When")]
     internal async Task<IProjectionDaemon> StartDaemon()
     {
         var daemon = theStore.Tenancy.Default.Database.As<MartenDatabase>()
@@ -128,7 +129,8 @@ public abstract class DaemonContext: OneOffConfigurationsContext, IAsyncLifetime
         return host;
     }
 
-    protected Task WaitForAction(string shardName, ShardAction action, TimeSpan timeout = default)
+    [Bobcat.BobcatStep("the {shardName} shard reports {action}", Keyword = "When")]
+    internal Task WaitForAction(string shardName, ShardAction action, TimeSpan timeout = default)
     {
         if (timeout == default)
         {
@@ -187,7 +189,8 @@ public abstract class DaemonContext: OneOffConfigurationsContext, IAsyncLifetime
     }
 
     // START HERE, NEEDS TO BE GENERALIZED
-    protected async Task CheckAllExpectedAggregatesAgainstActuals()
+    [Bobcat.BobcatStep("every expected aggregate matches the actual", Keyword = "Then")]
+    internal async Task CheckAllExpectedAggregatesAgainstActuals()
     {
         var actuals = await LoadAllAggregatesFromDatabase();
 
@@ -213,7 +216,7 @@ public abstract class DaemonContext: OneOffConfigurationsContext, IAsyncLifetime
         }
     }
 
-    protected async Task CheckAllExpectedGuidCentricAggregatesAgainstActuals<TDoc>(Func<TDoc, Guid> identifier) where TDoc : class
+    internal async Task CheckAllExpectedGuidCentricAggregatesAgainstActuals<TDoc>(Func<TDoc, Guid> identifier) where TDoc : class
     {
         var actuals = await LoadAllAggregatesFromDatabase<Guid, TDoc>(identifier);
 
@@ -239,7 +242,7 @@ public abstract class DaemonContext: OneOffConfigurationsContext, IAsyncLifetime
         }
     }
 
-    protected async Task CheckAllExpectedStringCentricAggregatesAgainstActuals<TDoc>(Func<TDoc, string> identifier) where TDoc : class
+    internal async Task CheckAllExpectedStringCentricAggregatesAgainstActuals<TDoc>(Func<TDoc, string> identifier) where TDoc : class
     {
         var actuals = await LoadAllAggregatesFromDatabase<string, TDoc>(identifier);
 
@@ -265,7 +268,7 @@ public abstract class DaemonContext: OneOffConfigurationsContext, IAsyncLifetime
         }
     }
 
-    protected async Task CheckAllExpectedAggregatesAgainstActuals(string tenantId)
+    internal async Task CheckAllExpectedAggregatesAgainstActuals(string tenantId)
     {
         var actuals = await LoadAllAggregatesFromDatabase(tenantId);
 
@@ -313,12 +316,13 @@ public abstract class DaemonContext: OneOffConfigurationsContext, IAsyncLifetime
         }
     }
 
-    protected async Task PublishSingleThreaded()
+    [Bobcat.BobcatStep("the events are published", Keyword = "Given")]
+    internal async Task PublishSingleThreaded()
     {
         await PublishSingleThreaded<Trip>();
     }
 
-    protected async Task PublishSingleThreaded<T>() where T : class
+    internal async Task PublishSingleThreaded<T>() where T : class
     {
         var groups = _streams.GroupBy(x => x.TenantId).ToArray();
         if (groups.Length > 1 || groups.Single().Key != StorageConstants.DefaultTenantId)
@@ -354,7 +358,8 @@ public abstract class DaemonContext: OneOffConfigurationsContext, IAsyncLifetime
         }
     }
 
-    protected Task PublishMultiThreaded(int threads)
+    [Bobcat.BobcatStep("the events are published on {threads} threads", Keyword = "Given")]
+    internal Task PublishMultiThreaded(int threads)
     {
         foreach (var stream in _streams)
         {

--- a/src/DaemonTests/rebuilding_an_inline_projection.cs
+++ b/src/DaemonTests/rebuilding_an_inline_projection.cs
@@ -9,6 +9,8 @@ using Xunit;
 
 namespace DaemonTests;
 
+[Bobcat.BobcatFeature("Rebuilding an inline projection")]
+[BobcatScenario]
 public class rebuilding_an_inline_projection : DaemonContext
 {
     public rebuilding_an_inline_projection(ITestOutputHelper output) : base(output)


### PR DESCRIPTION
An existing test, unedited, reporting itself as a specification while it runs:

```
Building an aggregate projection/end to end with events already published with caching
  When the projection daemon is running   (88ms)
  Given the events are published          (42ms)
  Then every expected aggregate matches   (22ms)
```

Marking two classes renders eighteen tests this way — in the console, in `dotnet test`, and in the Bobcat viewer under `{Feature}/{Scenario}` identities. **No test body changes.** The steps come from five `DaemonContext` helpers decorated once, plus a source generator (Bobcat 0.15.0) that intercepts the calls those tests already make.

### What this costs the suite

So it can be judged rather than discovered:

| | |
|---|---|
| **Eight `DaemonContext` helpers widen `protected` → `internal`** | Not a preference. A C# interceptor must be an extension method, and an extension method cannot see a `protected` member. The file already used this accessibility for `StartDaemon` and `StartDaemonInHotColdMode`, and `InternalsVisibleTo("DaemonTests.ManualOnly")` already exists — nothing new is exposed. |
| **One csproj line** | Opts the `Bobcat.Generated` namespace into interceptors. |
| **Two package references** | `Bobcat` and `Bobcat.Generators` 0.15.0 in `Directory.Packages.props`, beside the `Bobcat.Supervisor` this repo already depends on. Bobcat multi-targets net9.0 and net10.0 as of that release, so both of DaemonTests' frameworks are covered. |
| **`BobcatScenarioAttribute` in TestingSupport** | The runner-specific half — opens a scenario around each test. Bobcat's own attributes reference no test framework, so this small xUnit v3 adapter lives here until it ships as a package. |

Inert when nothing is listening: with no Bobcat viewer on the wire the publisher is null and the cost is a few strings per test.

### Verification

`net9.0` and `net10.0` each pass **18/18** against a real Postgres.

Running *both* frameworks concurrently fails with `MartenSchemaException` on `'All Configured Changes'`. That is **pre-existing** — it reproduces on untouched classes (`DaemonTests.Internals.basic_functionality`), being two test hosts issuing DDL against one shared database. Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)