### PR TITLE
Upgrade to Weasel 9.31.1 to fix the concurrent db-apply partition race (#5364)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -605,7 +605,7 @@
     <PackageVersion Include="Vogen" Version="7.0.0" />
     <!-- 9.16.2: the hold at 9.2.1 (were newer builds actually being published?) is resolved —
          Weasel.EntityFrameworkCore is on nuget.org, so it tracks the rest of the Weasel line. -->
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.31.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.31.1" />
     <!-- Weasel.Postgresql 9.1.x: managed LIST partitions under multi-database (sharded) apply.
          9.1.2 (marten#4706): managed-partition tables are no longer destructively rebuilt — the
          out-of-band AddPartitionToAllTables path creates partitions while the generic schema diff
@@ -777,9 +777,24 @@
          detector whose real hazard is dropping a user's edit. The rest of 9.30.0/9.31.0 is lifts and
          allocation work with no Marten surface: streaming JSON column reads (weasel#576), the
          flat-table decrement parameter fix already consumed via jasperfx#773, MasterTableTenancy and
-         EventLoaderBase lifts, and precomputed parameter names. -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.31.0" />
-    <PackageVersion Include="Weasel.Storage" Version="9.31.0" />
+         EventLoaderBase lifts, and precomputed parameter names.
+
+         9.31.1 (weasel#583/#584, raised from marten#5364): the managed partition registries are now
+         published as snapshots swapped copy-on-write, instead of a Dictionary mutated in place and
+         handed out through a ReadOnlyDictionary that WRAPS rather than copies it. One instance is
+         shared by every database in a store, and ManagedListPartitions.InitializeAsync used to
+         Clear() it while another database's parallel apply was mid-enumeration, surfacing as
+         "Collection was modified; enumeration operation may not execute" out of
+         DatabaseBase.assertValidIdentifiers (via PerTenantEventSequences.AllNames) during a
+         parallel db-apply, and silently as a torn partition set everywhere else, generated DDL and
+         partition deltas included. Hardening Marten's read side cannot fix this and was tried:
+         ToArray() over a dictionary growing underneath just trades the exception for "Destination
+         array is not long enough", so the write side had to change. Marten needs no product change,
+         only this bump. Bug_5364_concurrent_apply_partition_race is RED on 9.31.0 and GREEN here.
+         The same pass covers Weasel.SqlServer's ManagedTenantPartitions, which had the identical
+         shape, so Polecat gets it too. -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.31.1" />
+    <PackageVersion Include="Weasel.Storage" Version="9.31.1" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <!-- The whole test suite is on xunit v3. VSTest stays the execution mode, so the
          Nuke targets and the GitHub workflows are unaffected. -->

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_5364_concurrent_apply_partition_race.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_5364_concurrent_apply_partition_race.cs
@@ -1,0 +1,127 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Storage;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+/// <summary>
+/// #5364 — `db-apply --parallel` across many databases intermittently died with
+/// <c>InvalidOperationException: Collection was modified; enumeration operation may not execute</c>
+/// out of <c>PerTenantEventSequences.currentPartitionSuffixes()</c>.
+///
+/// <para>
+/// The defect was upstream (weasel#583): one <c>ManagedListPartitions</c> instance is shared by
+/// every database in a store, it mutated its partition dictionary IN PLACE, and published it
+/// through a <c>ReadOnlyDictionary</c> that wraps rather than copies. So
+/// <c>InitializeAsync</c>'s <c>Clear()</c>-and-refill ran while another database's worker was
+/// enumerating the same dictionary. Weasel 9.31.1 publishes a snapshot swapped copy-on-write;
+/// Marten needs no product change, which is exactly what this test pins.
+/// </para>
+///
+/// <para>
+/// Both halves below are production code. The writer is
+/// <c>ManagedListPartitions.InitializeAsync</c>, which <c>TenantPartitionsDatabaseInitializer</c>
+/// runs at the head of every migration operation. The reader is verbatim the body of Weasel's
+/// <c>DatabaseBase.assertValidIdentifiers</c>, which runs at the very TOP of
+/// <c>ApplyAllConfiguredChangesToDatabaseAsync</c> — before a connection is even opened, and
+/// therefore before this database's own partition view has been hydrated, which is what drops the
+/// read onto the shared store-wide fallback.
+/// </para>
+///
+/// <para>
+/// The two are driven directly rather than through a pair of real parallel applies because the
+/// end-to-end shape needs the reporter's scale to trip: the collision window is the span of one
+/// <c>Clear()</c>-and-refill, and it only opens for a worker that STARTS LATE (workers that begin
+/// together all finish reading before anyone writes). At the reporter's 29 databases /
+/// <c>--parallel 16</c> the bounded scheduler supplies those late starters and the failure showed
+/// up once per run; three shard databases with a handful of tenants each do not, and a test that
+/// only fails on someone else's hardware guards nothing.
+/// </para>
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public class Bug_5364_concurrent_apply_partition_race: ShardedPartitionedContext
+{
+    public Bug_5364_concurrent_apply_partition_race(ShardedPartitionedFixture fixture): base(fixture)
+    {
+    }
+
+    private DocumentStore FreshStore() => BuildShardedStore(opts =>
+    {
+        opts.AutoCreateSchemaObjects = AutoCreate.All;
+        opts.Events.AddEventType<ShardedTestEvent>();
+    });
+
+    [Fact]
+    public async Task enumerating_schema_object_names_while_the_partition_initializer_runs()
+    {
+        var token = TestContext.Current.CancellationToken;
+
+        // Seed: create the schema on every shard, then register enough tenants that the registry
+        // refill below is more than one row wide.
+        var seed = FreshStore();
+        foreach (var db in (await seed.Options.Tenancy.BuildDatabases()).OfType<IMartenDatabase>())
+        {
+            await db.ApplyAllConfiguredChangesToDatabaseAsync(ct: token);
+        }
+
+        for (var i = 0; i < 40; i++)
+        {
+            await seed.Advanced.AddTenantToShardAsync($"tenant{i:D3}", token);
+        }
+
+        Exception? captured = null;
+
+        // A store instance hydrates the shared store-wide snapshot at most once, so each round
+        // needs a fresh store to get one more attempt at the window.
+        for (var round = 0; round < 40 && captured == null; round++)
+        {
+            using var store = FreshStore();
+            var databases = (await store.Options.Tenancy.BuildDatabases()).OfType<IMartenDatabase>().ToArray();
+            var partitions = store.Options.TenantPartitions!.Partitions;
+
+            using var stop = new CancellationTokenSource();
+
+            var readers = databases.Skip(1).Select(db => Task.Run(() =>
+            {
+                while (!stop.IsCancellationRequested)
+                {
+                    try
+                    {
+                        foreach (var schemaObject in db.AllObjects())
+                        {
+                            foreach (var _ in schemaObject.AllNames())
+                            {
+                            }
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Interlocked.CompareExchange(ref captured, e, null);
+                        return;
+                    }
+                }
+            }, token)).ToArray();
+
+            await using (var conn = new NpgsqlConnection(Fixture.ConnectionStrings.Values.First()))
+            {
+                await conn.OpenAsync(token);
+                await partitions.InitializeAsync(conn, token);
+                await conn.CloseAsync();
+            }
+
+            await Task.Delay(50, token);
+            await stop.CancelAsync();
+            await Task.WhenAll(readers);
+        }
+
+        captured.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
Closes #5364.

`db-apply --parallel` across many databases intermittently died with `InvalidOperationException: Collection was modified; enumeration operation may not execute` out of `PerTenantEventSequences.currentPartitionSuffixes()`. The Marten frames are where it surfaced; the defect was upstream, and this PR is the bump plus a regression test. **No Marten product change.**

## What was wrong

One `ManagedListPartitions` instance is shared by every database in a store. It mutated its partition dictionary **in place** and published it through a `ReadOnlyDictionary` — which *wraps* rather than copies:

```csharp
private Dictionary<string, string> _partitions = new();
public ReadOnlyDictionary<string, string> Partitions => new(_partitions);   // live view

// InitializeAsync:
_partitions.Clear();                                   // another database's worker is mid-foreach
while (await reader.ReadAsync(token)) { _partitions[value] = suffix; }
```

The `SemaphoreSlim` in there serializes writers against each other only.

On the apply path the reader is `assertValidIdentifiers`, which runs at the **very top** of `ApplyAllConfiguredChangesToDatabaseAsync` — before a connection is even opened, and therefore before this database's own partition view has been hydrated, which is what drops the read onto the shared store-wide fallback. The writer is `initializeSchema` → `ManagedListPartitions.InitializeAsync`, several round-trips later, after the global lock.

That ordering also explains the reporter's numbers. Workers that *start together* all finish reading before anyone writes; the window only opens for a worker that starts **late**, which is exactly what `DatabaseBatch`'s bounded scheduler produces once the database count exceeds `--parallel N`. Hence 1 failure out of 29 databases at `--parallel 16`, and a clean immediate retry.

## The fix

Weasel 9.31.1 (JasperFx/weasel#583, PR JasperFx/weasel#584) publishes the registry as a snapshot swapped copy-on-write, with captured locals in the lazy iterators, in **both** `ManagedListPartitions` and the SQL Server `ManagedTenantPartitions` — so Polecat gets it too.

Worth recording, because it is the tempting fix: **hardening Marten's read side does not work.** I tried `.Values.ToArray()` in `currentPartitionSuffixes()`. LINQ routes that through `ICollection<T>.CopyTo`, which has no version check and so cannot throw `InvalidOperationException`. It throws this instead:

```
System.ArgumentException: Destination array is not long enough to copy all the items in the collection.
   at System.Collections.Generic.Dictionary`2.ValueCollection.CopyTo(TValue[] array, Int32 index)
   at System.Linq.Enumerable.ICollectionToArray[TSource](ICollection`1 collection)
```

`Count` is read, then the dictionary grows before the copy finishes. Any read-side snapshot against an in-place-mutated dictionary only changes which exception you get, or tears silently.

## Not the regression it was reported as

The reporter saw this after 9.31.2 → 9.32.1, but there is no code change behind it: `git diff` between those Marten tags touches nothing under `src/Marten/Schema/`, and Weasel 9.29.0 → 9.31.0 (the bump 9.32.1 carried) touches nothing under `Weasel.Core/Migrations` or `Weasel.Postgresql/Tables`. Latent since the multi-database partition work; 9.32.1 shifted timing. Noted because it means rolling back to 9.31.2 was never a fix, just better odds.

## The test

`Bug_5364_concurrent_apply_partition_race` drives the two colliding paths directly. Both halves are production code — the writer is `ManagedListPartitions.InitializeAsync` as run by `TenantPartitionsDatabaseInitializer`, the reader is verbatim the body of `DatabaseBase.assertValidIdentifiers`.

Deliberately *not* two real parallel applies: the end-to-end shape needs the reporter's scale to trip, because of the late-starter ordering above. Three shard databases with a handful of tenants each do not reproduce it, and a test that only fails on someone else's hardware guards nothing. I wrote that version too and it stayed green on both Weasel versions, so it is not in this PR.

## Verification

A/B with **unmodified Marten sources**, only the package version changing, and the resolved version checked in `deps.json` each time rather than trusting the restore:

| | `Bug_5364_concurrent_apply_partition_race` |
|---|---|
| Weasel 9.31.0 | **RED** on round 0, the reported frames |
| Weasel 9.31.1 | **GREEN**, four consecutive runs |

On 9.31.1, net10.0: `TenantPartitionedEventsTests` 251 passed / 0 failed, `MultiTenancyTests` 165 passed / 0 failed.

CoreTests shows 4 failures (`Bug_4185_codegen_conflict_projection_with_secondary_store_dependency`, `Bug_4187_ancillary_store_isolation`, `rolling_range_partitioning`, `divergent_application_assembly_reuse_warning_is_buffered_and_logged`). They are **identical on 9.31.0 and 9.31.1** and all four pass when run in isolation — pre-existing order-dependent interference on master, unrelated to this bump, not chased here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDX5UV1He5if9vVo8Bdi7g
