### PR TITLE
Adopt JasperFx 2.67.0: honor EventQuery.TagValues, infer the compaction fold (#5365, #5366)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -517,21 +517,50 @@
          With #5354 merged it gets PAST that assertion and fails on
          `_outbox.CommittedBatches should be empty but had 1 item`, which is marten#5353, a genuine
          outbox bug. That transition is the evidence #5354 worked; the fact stays red until #5353 is
-         fixed and must not be weakened to make it green. -->
+         fixed and must not be weakened to make it green.
+
+         JasperFx 2.67.0: two changes Marten consumes directly, each with its own adoption issue.
+
+         jasperfx#801/#802 (marten#5365) adds EventQuery.TagValues, a Dictionary tag filter in the
+         lossy name/value form beside the rich EventTagQuerySpec form. Two traps. First, TagValues
+         joined EventQueryFilters.All, and QueryEventStore declares All, so this bump alone would
+         have Marten silently claim a filter it does not implement, which is the exact failure the
+         jasperfx#737 guard rail exists to prevent. It is implemented in the same PR rather than
+         subtracted. Second, the two spellings combine differently: TagValues entries AND, while
+         TagConditions conditions OR, so one cannot be implemented by delegating to the other.
+         Names resolve through the new shared TagTypeRegistrationExtensions.FindByTagName matcher
+         (CLR simple name or registered table suffix, case-insensitively) and values match the
+         string form of the stored tag value ordinal case-insensitively, because an engine renders
+         a Guid tag in its own casing and an operator's copy-pasted id must not depend on which
+         store answered.
+
+         jasperfx#800/#805 (marten#5366) settles CompactStreamAsync&lt;T&gt; in favour of inferring
+         the fold for an unregistered aggregate, which is what Fisher and Polecat already did.
+         Marten is the store that moves: compaction was calling ProjectionGraph.TryFindAggregate,
+         the registration-only lookup, while every other aggregation path in Marten already calls
+         AggregatorFor&lt;T&gt;, which falls back to building a live aggregator on demand.
+         StreamCompactingCompliance.compacting_infers_the_fold_for_an_unregistered_aggregate is red
+         until that swap lands.
+
+         Also arriving and inert for Marten: jasperfx#803/#804 fixes the event-query CLI's tags
+         flag, which used to manufacture a TypeDescriptor whose FullName was the bare tag name and
+         so threw against every real store. Marten gains the working flag through the package with
+         no Marten change, and EventQueryCompliance now runs the command's own output through the
+         store, which is the only place that gap was visible. -->
 
 
     <!-- Marker-step specifications (JasperFx/bobcat#110), shipped in Bobcat 0.15.0. -->
     <PackageVersion Include="Bobcat" Version="0.15.0" />
     <PackageVersion Include="Bobcat.Generators" Version="0.15.0" />
-    <PackageVersion Include="JasperFx" Version="2.66.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.66.0" />
+    <PackageVersion Include="JasperFx" Version="2.67.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.67.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.66.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.67.0" />
     <!--
       No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
       whole family moves together, and this note is kept for the history below. This package is
@@ -550,11 +579,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.66.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.67.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.66.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.67.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/Aggregation/stream_compacting.cs
+++ b/src/EventSourcingTests/Aggregation/stream_compacting.cs
@@ -60,6 +60,40 @@ public class stream_compacting : OneOffConfigurationsContext
 
     #endregion
 
+    /// <summary>
+    /// #5366 / jasperfx#800: compaction infers the fold, so an aggregate that was never registered
+    /// as a projection compacts like any other. The shared suite pins the happy path; this is the
+    /// Marten-local half — the type with NO aggregation conventions at all must still be refused,
+    /// and loudly.
+    /// </summary>
+    /// <remarks>
+    /// This is the one failure mode worth a dedicated test, because compaction DELETES the events it
+    /// folds. Silently writing an empty snapshot for a type Marten cannot fold would destroy the
+    /// stream's history and leave a plausible-looking Compacted&lt;T&gt; behind — strictly worse than
+    /// the pre-#5366 refusal it replaces. The message has to say what is missing, since the caller's
+    /// mistake is now "this type has no Create/Apply" rather than "I forgot to register it".
+    /// </remarks>
+    [Fact]
+    public async Task compacting_a_type_with_no_aggregation_conventions_is_refused()
+    {
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId, A(), A(), B());
+        await theSession.SaveChangesAsync();
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            await theSession.Events.CompactStreamAsync<NotAnAggregate>(streamId);
+            await theSession.SaveChangesAsync();
+        });
+
+        ex.Message.ShouldContain(nameof(NotAnAggregate));
+
+        // And the stream is untouched: a refusal that had already deleted rows would be the worst
+        // of both worlds.
+        var events = await theSession.Events.FetchStreamAsync(streamId);
+        events.Count.ShouldBe(3);
+    }
+
     [Fact]
     public async Task start_with_self_aggregate()
     {
@@ -396,6 +430,15 @@ public class stream_compacting : OneOffConfigurationsContext
     }
 }
 
+
+/// <summary>
+/// No Create, no Apply, no projection: nothing Marten can fold. The negative case for the #5366
+/// inference change.
+/// </summary>
+public class NotAnAggregate
+{
+    public Guid Id { get; set; }
+}
 
 public class Letters : IRevisioned
 {

--- a/src/EventSourcingTests/Dcb/event_query_tag_values_tests.cs
+++ b/src/EventSourcingTests/Dcb/event_query_tag_values_tests.cs
@@ -1,0 +1,230 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Dcb;
+
+/// <summary>
+/// The two halves of #5365 / jasperfx#801 that no shared suite reaches.
+///
+/// <para>
+/// <see cref="EventQuery.TagValues"/> itself is covered by <c>EventQueryCompliance</c>, but only in
+/// the default <see cref="DcbStorageMode.TagTables"/> translation — the hstore branch is a
+/// Marten-only opt-in, so its own translation of the same filter is pinned here alongside the
+/// existing <c>event_query_tag_conditions_hstore_tests</c>.
+/// </para>
+///
+/// <para>
+/// The dictionary <c>IEventStore.QueryByTagsAsync</c> overload has no compliance coverage at all,
+/// which is how it drifted from Polecat's: it matched the CLR type name only and compared the value
+/// case-sensitively. That is what made the divergence undiscoverable — a caller holding a store
+/// descriptor cannot tell which spelling an engine takes, and gets an <c>ArgumentException</c> at
+/// runtime for guessing wrong. Both rules now come from the shared
+/// <c>TagTypeRegistrationExtensions</c> matcher, and these facts hold that path to them.
+/// </para>
+/// </summary>
+[Collection("OneOffs")]
+public class event_query_tag_values_tests: OneOffConfigurationsContext
+{
+    private void ConfigureStore(DcbStorageMode mode)
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.AddEventType<StudentEnrolled>();
+            opts.Events.AddEventType<AssignmentSubmitted>();
+
+            opts.Events.DcbStorageMode = mode;
+
+            opts.Events.RegisterTagType<StudentId>("student");
+            opts.Events.RegisterTagType<CourseId>("course");
+        });
+    }
+
+    private Task<PagedEvents> queryAsync(EventQuery query)
+        => ((IReadOnlyEventStore)theSession.Events).QueryEventsAsync(query, CancellationToken.None);
+
+    /// <summary>
+    /// Two tagged events, a decoy at a different value of the same tag type, and an untagged event.
+    /// Both decoys survive a store that drops the filter.
+    /// </summary>
+    private async Task<StudentId> seedAsync()
+    {
+        var matching = new StudentId(Guid.NewGuid());
+        var other = new StudentId(Guid.NewGuid());
+
+        var first = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        first.WithTag(matching);
+        theSession.Events.Append(Guid.NewGuid(), first);
+
+        var second = theSession.Events.BuildEvent(new AssignmentSubmitted("HW1", 90));
+        second.WithTag(matching);
+        theSession.Events.Append(Guid.NewGuid(), second);
+
+        var decoy = theSession.Events.BuildEvent(new StudentEnrolled("Bob", "Math"));
+        decoy.WithTag(other);
+        theSession.Events.Append(Guid.NewGuid(), decoy);
+
+        theSession.Events.Append(Guid.NewGuid(), new StudentEnrolled("Carol", "Art"));
+        await theSession.SaveChangesAsync();
+
+        return matching;
+    }
+
+    [Theory]
+    [InlineData(DcbStorageMode.TagTables)]
+    [InlineData(DcbStorageMode.HStore)]
+    public async Task tag_values_filter_in_both_storage_modes(DcbStorageMode mode)
+    {
+        ConfigureStore(mode);
+        var matching = await seedAsync();
+
+        var result = await queryAsync(new EventQuery
+        {
+            TagValues = { ["student"] = matching.Value.ToString() }, PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(2);
+        result.Events.ShouldContain(x => x.Data is StudentEnrolled);
+        result.Events.ShouldContain(x => x.Data is AssignmentSubmitted);
+    }
+
+    /// <summary>
+    /// A Guid tag rendered through <c>value::text</c> comes back lowercase from Postgres, so an
+    /// operator pasting the uppercase form an ASP.NET route or another store handed them still finds
+    /// their events. Exercised in both modes because the two translations lower different things.
+    /// </summary>
+    [Theory]
+    [InlineData(DcbStorageMode.TagTables)]
+    [InlineData(DcbStorageMode.HStore)]
+    public async Task tag_values_match_a_value_regardless_of_casing(DcbStorageMode mode)
+    {
+        ConfigureStore(mode);
+        var matching = await seedAsync();
+
+        var upper = await queryAsync(new EventQuery
+        {
+            TagValues = { ["student"] = matching.Value.ToString().ToUpperInvariant() }, PageSize = 1000
+        });
+
+        upper.TotalCount.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// Entries AND, so an event carrying only one of the two tags is excluded — and the one carrying
+    /// both is returned once, not once per matching tag.
+    /// </summary>
+    [Theory]
+    [InlineData(DcbStorageMode.TagTables)]
+    [InlineData(DcbStorageMode.HStore)]
+    public async Task multiple_tag_values_and_together(DcbStorageMode mode)
+    {
+        ConfigureStore(mode);
+
+        var student = new StudentId(Guid.NewGuid());
+        var course = new CourseId(Guid.NewGuid());
+
+        var both = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        both.WithTag(student);
+        both.WithTag(course);
+        theSession.Events.Append(Guid.NewGuid(), both);
+
+        var studentOnly = theSession.Events.BuildEvent(new AssignmentSubmitted("HW1", 90));
+        studentOnly.WithTag(student);
+        theSession.Events.Append(Guid.NewGuid(), studentOnly);
+
+        var courseOnly = theSession.Events.BuildEvent(new AssignmentSubmitted("HW2", 80));
+        courseOnly.WithTag(course);
+        theSession.Events.Append(Guid.NewGuid(), courseOnly);
+
+        await theSession.SaveChangesAsync();
+
+        var result = await queryAsync(new EventQuery
+        {
+            TagValues =
+            {
+                ["student"] = student.Value.ToString(),
+                ["course"] = course.Value.ToString()
+            },
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Data.ShouldBeOfType<StudentEnrolled>().StudentName.ShouldBe("Alice");
+    }
+
+    // ---- the dictionary QueryByTagsAsync overload, which had no coverage at all ----
+
+    private async Task<List<EventRecord>> queryByTagsAsync(IReadOnlyDictionary<string, string> tags)
+    {
+        var records = new List<EventRecord>();
+        await foreach (var record in ((IEventStore)theStore).QueryByTagsAsync(tags, CancellationToken.None))
+        {
+            records.Add(record);
+        }
+
+        return records;
+    }
+
+    /// <summary>
+    /// Either spelling of the tag name resolves — the CLR type name (<c>StudentId</c>) or the
+    /// registered table suffix (<c>student</c>), case-insensitively. Before #5365 only the first
+    /// worked here, while Polecat took both.
+    /// </summary>
+    [Fact]
+    public async Task query_by_tags_accepts_either_spelling_of_the_name()
+    {
+        ConfigureStore(DcbStorageMode.TagTables);
+        var matching = await seedAsync();
+
+        foreach (var name in new[] { "StudentId", "student", "STUDENTID", "Student" })
+        {
+            var records = await queryByTagsAsync(new Dictionary<string, string>
+            {
+                [name] = matching.Value.ToString()
+            });
+
+            records.Count.ShouldBe(2, $"the tag name spelling '{name}' should have resolved");
+        }
+    }
+
+    [Fact]
+    public async Task query_by_tags_matches_a_value_regardless_of_casing()
+    {
+        ConfigureStore(DcbStorageMode.TagTables);
+        var matching = await seedAsync();
+
+        var records = await queryByTagsAsync(new Dictionary<string, string>
+        {
+            ["student"] = matching.Value.ToString().ToUpperInvariant()
+        });
+
+        records.Count.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// An unregistered name stays an error rather than an empty answer, and the message still names
+    /// what is registered so the caller can correct a typo from it.
+    /// </summary>
+    [Fact]
+    public async Task query_by_tags_refuses_an_unregistered_name()
+    {
+        ConfigureStore(DcbStorageMode.TagTables);
+        await seedAsync();
+
+        var ex = await Should.ThrowAsync<ArgumentException>(async () =>
+            await queryByTagsAsync(new Dictionary<string, string> { ["no_such_tag"] = "whatever" }));
+
+        ex.Message.ShouldContain("no_such_tag");
+        ex.Message.ShouldContain(nameof(StudentId));
+    }
+}

--- a/src/Marten/DocumentStore.EventStoreExplorer.cs
+++ b/src/Marten/DocumentStore.EventStoreExplorer.cs
@@ -16,6 +16,7 @@ using JasperFx.Descriptors;
 using JasperFx.Events;
 using JasperFx.Events.Aggregation;
 using JasperFx.Events.Projections;
+using JasperFx.Events.Tags;
 using Marten.Events;
 using Marten.Events.Projections;
 using Marten.Internal.Sessions;
@@ -279,18 +280,24 @@ public partial class DocumentStore
         var idx = 0;
         foreach (var (tagName, tagValue) in tags)
         {
-            var registration = registered.FirstOrDefault(r => string.Equals(r.TagType.Name, tagName, StringComparison.OrdinalIgnoreCase));
-            if (registration == null)
-            {
-                throw new ArgumentException(
-                    $"Tag type '{tagName}' is not registered on this event store. Registered tag types: {registered.Select(t => t.TagType.Name).Join(", ")}",
-                    nameof(tags));
-            }
+            // #5365 / jasperfx#801: name resolution and value comparison are contract, not local
+            // choices, so both go through the shared matcher. This path used to match the CLR type
+            // name ONLY and compare the value case-sensitively, while Polecat accepted either
+            // spelling and compared case-insensitively — so the same dictionary answered differently
+            // per store, and a caller holding a store descriptor had no way to discover which
+            // spelling to send. It went unnoticed because this overload has no compliance coverage;
+            // EventQuery.TagValues, which does, now shares the same two rules.
+            var registration = registered.RequireByTagName(tagName, nameof(tags));
 
             var tagTable = $"{schema}.mt_event_tag_{registration.TableSuffix}";
             var paramName = $"@tag_value_{idx}";
-            subqueries.Add($"e.seq_id in (select seq_id from {tagTable} where value::text = {paramName})");
-            parameters.Add(new NpgsqlParameter($"tag_value_{idx}", tagValue));
+
+            // Both sides lowered: Postgres renders a Guid lowercase through ::text and SQL Server
+            // renders it uppercase, so an operator's copy-pasted id must not depend on which store
+            // answered. Lowering rather than ILIKE, which would treat _ and % in a tag value as
+            // wildcards.
+            subqueries.Add($"e.seq_id in (select seq_id from {tagTable} where lower(value::text) = {paramName})");
+            parameters.Add(new NpgsqlParameter($"tag_value_{idx}", tagValue.ToLowerInvariant()));
             idx++;
         }
 

--- a/src/Marten/Events/EventStore.StreamCompacting.cs
+++ b/src/Marten/Events/EventStore.StreamCompacting.cs
@@ -153,23 +153,49 @@ internal static class StreamCompactingExecution
             ((IMartenSession)session).Options.EventGraph, request.StreamId, request.StreamKey, request.Version));
     }
 
+    /// <summary>
+    /// The fold used to build the <see cref="Compacted{T}"/> snapshot.
+    ///
+    /// <para>
+    /// #5366 / jasperfx#800: this used to call <c>TryFindAggregate</c>, the registration-only
+    /// lookup, and refuse anything not already registered as an aggregation projection. That made
+    /// Marten the odd store out — Fisher and Polecat both infer the fold — and imposed a constraint
+    /// nobody would infer from the API: a compaction policy could only ever target an aggregate the
+    /// application already snapshots. It is a portability gap rather than a safety property, and it
+    /// was invisible until runtime.
+    /// </para>
+    ///
+    /// <para>
+    /// <c>AggregatorFor&lt;T&gt;</c> is the on-demand lookup sitting right beside it on the shared
+    /// <c>ProjectionGraph</c>: registered projections first, then a live aggregator built from
+    /// <typeparamref name="T"/>'s own <c>Create</c>/<c>Apply</c> conventions and cached. Every other
+    /// aggregation path in Marten already calls it — <c>AggregateToExtensions</c>, the fetch plans,
+    /// <c>QueryEventStore</c>, <c>RehydrateAtVersionAsync</c> — so compaction was the outlier, most
+    /// likely by accident. The typed overload names <typeparamref name="T"/> outright, which is the
+    /// same declaration of intent a registration would be.
+    /// </para>
+    ///
+    /// <para>
+    /// A type with no aggregation conventions at all still fails, and must: compaction DELETES the
+    /// events it folds, so an empty snapshot would be the worst outcome available here. The refusal
+    /// now comes out of the aggregator build rather than from a registration check, so it is
+    /// rephrased to name what is actually missing.
+    /// </para>
+    /// </summary>
     private static IAggregator<T, IQuerySession> FindAggregator<T>(DocumentSessionBase session) where T : class
     {
-        if (!((IMartenSession)session).Options.Projections.TryFindAggregate(typeof(T), out var projection))
+        try
         {
-            throw new InvalidOperationException("Unable to find an Aggregation Projection for type " +
-                                                typeof(T).FullNameInCode());
+            return ((IMartenSession)session).Options.Projections.AggregatorFor<T>();
         }
-
-        var aggregator = projection as IAggregator<T, IQuerySession>;
-        if (aggregator == null)
+        catch (Exception e)
         {
             throw new InvalidOperationException(
-                $"Type {projection!.GetType().FullNameInCode()} does not implement interface " +
-                $"{typeof(IAggregator<T, IDocumentOperations>).FullNameInCode()}");
+                $"Unable to build an aggregation for type {typeof(T).FullNameInCode()} in order to compact this stream. " +
+                "Compaction folds the stream into a single Compacted<T> event and deletes the events it folded, so it " +
+                "cannot proceed without a usable aggregation. Give the type Create/Apply methods for its events, or " +
+                "register an aggregation projection for it.", e);
         }
-
-        return aggregator;
     }
 }
 

--- a/src/Marten/Events/QueryEventStore.cs
+++ b/src/Marten/Events/QueryEventStore.cs
@@ -376,6 +376,17 @@ internal class QueryEventStore: IQueryEventStore, IReadOnlyEventStore
             queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.MatchesSql(tagSql, tagParameters));
         }
 
+        // jasperfx#801: the lossy name/value tag filter. Deliberately NOT expressed by folding into
+        // buildTagConditionsFilter — the two spellings combine differently (entries here AND, the
+        // conditions there OR), so delegating one to the other would answer the union where the
+        // caller asked for the intersection. AssertIsWellFormed, run by AssertFiltersAreSupported
+        // above, has already refused a query carrying both.
+        if (query.TagValues.Count > 0)
+        {
+            var (valuesSql, valuesParameters) = buildTagValuesFilter(query.TagValues);
+            queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.MatchesSql(valuesSql, valuesParameters));
+        }
+
         var totalCount = await queryable.CountAsync(token).ConfigureAwait(false);
 
         var pageNumber = query.PageNumber <= 0 ? 1 : query.PageNumber;
@@ -397,6 +408,99 @@ internal class QueryEventStore: IQueryEventStore, IReadOnlyEventStore
             PageNumber = pageNumber,
             PageSize = query.PageSize
         };
+    }
+
+    /// <summary>
+    /// Translate <see cref="EventQuery.TagValues"/> into a raw SQL fragment over the event query's
+    /// <c>d</c> alias (mt_events), AND'ing the entries. Same per-storage-mode shapes as
+    /// <see cref="buildTagConditionsFilter"/> — a correlated tag-table subquery in TagTables mode,
+    /// an hstore lookup in HStore mode — with two differences that are the whole point of the lossy
+    /// form (jasperfx#801):
+    ///
+    /// <list type="number">
+    /// <item>
+    /// <b>Names resolve through the shared matcher.</b> <c>RequireByTagName</c> accepts either the
+    /// tag type's CLR simple name or its registered table suffix, case-insensitively, and refuses an
+    /// unknown name with an <see cref="ArgumentException"/> listing what IS registered. A caller
+    /// holding only a store descriptor cannot discover which spelling an engine prefers, so the
+    /// matching is contract and lives upstream rather than here. An unknown name must never come
+    /// back as an empty answer: "that tag type does not exist here" and "no event carries that tag"
+    /// would read alike, and a caller with a typo would conclude the events are gone.
+    /// </item>
+    /// <item>
+    /// <b>Values match the STRING form, case-insensitively.</b> The rich form compares the typed CLR
+    /// value; this form exists for text a caller typed or forwarded. Postgres renders a Guid
+    /// lowercase through <c>::text</c> while SQL Server renders it uppercase, so a case-sensitive
+    /// comparison would make an operator's copy-pasted id depend on which store answered. Both sides
+    /// are lowered rather than using ILIKE, which would treat <c>_</c> and <c>%</c> in a tag value as
+    /// wildcards.
+    /// </item>
+    /// </list>
+    ///
+    /// <para>
+    /// Set semantics on both branches (<c>seq_id in (…)</c>, hstore lookup), so an event carrying
+    /// several of the queried tags is still counted and returned once — which is what makes
+    /// <c>TotalCount</c> a count of distinct matching events rather than of condition hits.
+    /// </para>
+    /// </summary>
+    private (string sql, object[] parameters) buildTagValuesFilter(IReadOnlyDictionary<string, string> tagValues)
+    {
+        var events = _store.Events;
+        var schema = events.DatabaseSchemaName;
+        var isHStore = events.DcbStorageMode == DcbStorageMode.HStore;
+        var isConjoined = events.TenancyStyle == TenancyStyle.Conjoined;
+
+        var sb = new System.Text.StringBuilder();
+        var parameters = new List<object>();
+
+        sb.Append('(');
+        var first = true;
+        foreach (var pair in tagValues)
+        {
+            if (!first)
+            {
+                sb.Append(" and ");
+            }
+
+            first = false;
+
+            var registration = events.TagTypes.RequireByTagName(pair.Key,
+                $"{nameof(EventQuery)}.{nameof(EventQuery.TagValues)}");
+
+            sb.Append('(');
+            if (isHStore)
+            {
+                // A missing key yields NULL, and NULL = anything is not true, so an event without
+                // the tag simply fails the predicate.
+                sb.Append("lower(d.tags -> ?) = ?");
+                parameters.Add(registration.TableSuffix);
+                parameters.Add(pair.Value.ToLowerInvariant());
+            }
+            else
+            {
+                // Under conjoined tenancy seq_id is not unique across tenants (per-tenant
+                // sequences), so the correlated subquery must also match tenant_id; the outer event
+                // query is already tenant-scoped. Mirrors HasTagParser / #4645.
+                sb.Append("d.seq_id in (select seq_id from ");
+                sb.Append(schema);
+                sb.Append(".mt_event_tag_");
+                sb.Append(registration.TableSuffix);
+                sb.Append(" where lower(value::text) = ?");
+                if (isConjoined)
+                {
+                    sb.Append(" and tenant_id = d.tenant_id");
+                }
+
+                sb.Append(')');
+                parameters.Add(pair.Value.ToLowerInvariant());
+            }
+
+            sb.Append(')');
+        }
+
+        sb.Append(')');
+
+        return (sb.ToString(), parameters.ToArray());
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #5365. Closes #5366.

Two adoptions on the JasperFx 2.67.0 bump, plus the drift the first one uncovered.

## #5365 — `EventQuery.TagValues` (jasperfx#801)

The lossy name/value tag filter, now on the composable query object: a caller holding a tag *name* rather than a CLR tag type can AND it with the event type, window, stream, metadata and tenant filters instead of choosing between them, and keeps paging and a truthful `TotalCount` doing it.

**Implemented here rather than subtracted.** `TagValues` joined `EventQueryFilters.All` upstream, and `QueryEventStore` declares `All` — so the bump on its own would have Marten silently claim a filter it does not implement. That is precisely the failure the jasperfx#737 guard rail exists to prevent: unfiltered results that read as filtered.

`buildTagValuesFilter` is deliberately **not** expressed by folding into `buildTagConditionsFilter`. The two spellings combine differently — entries in `TagValues` AND, conditions in `TagConditions` OR — so delegating one to the other answers the union where the caller asked for the intersection. Both storage modes get the same treatment as the rich form (correlated tag-table subquery in TagTables mode, hstore lookup in HStore mode), and both are set semantics, so a doubly-tagged event is counted and returned once.

### The drift this exposed

The dictionary `IEventStore.QueryByTagsAsync` overload matched a tag name against the **CLR type name only** and compared the value **case-sensitively**. Polecat accepted either spelling and compared case-insensitively. So the same dictionary answered differently per store, and guessing wrong was an `ArgumentException` at runtime — undiscoverable, since a caller holding a store descriptor has no way to tell which spelling an engine takes. It survived because that overload has no compliance coverage at all.

Both paths now resolve names through the shared `TagTypeRegistrationExtensions.RequireByTagName`, and both lower the two sides of the value comparison. Postgres renders a Guid lowercase through `::text` while SQL Server renders it uppercase, so an operator's copy-pasted id must not depend on which store answered. Lowering rather than `ILIKE`, which would treat `_` and `%` in a tag value as wildcards.

## #5366 — infer the compaction fold (jasperfx#800)

`CompactStreamAsync<T>` called `TryFindAggregate`, the registration-only lookup, and refused anything not already registered as an aggregation projection. Fisher and Polecat both infer. The consequence was a constraint nobody would infer from the API — a compaction policy could only ever target an aggregate the application already snapshots — invisible until runtime, and a portability gap rather than a safety property.

The swap is to `AggregatorFor<T>()`, which sits directly beside `TryFindAggregate` on the shared `ProjectionGraph`: registered projections first, then a live aggregator built from `T`'s own `Create`/`Apply` conventions and cached. Every other aggregation path in Marten already calls it — `AggregateToExtensions`, the fetch plans, `QueryEventStore`, `RehydrateAtVersionAsync` — so compaction was the outlier, most likely by accident.

A type with **no** aggregation conventions at all still fails, and must. Compaction *deletes* the events it folds, so a silently empty snapshot would destroy the stream's history and leave a plausible-looking `Compacted<T>` behind — strictly worse than the refusal it replaces. The message is rephrased to name what is actually missing, since the caller's mistake is now "this type has no Create/Apply" rather than "I forgot to register it".

## Verification

Both new compliance facts are red before and green after, checked by reverting each product file in turn rather than assuming:

| fact | without the change |
|---|---|
| `stream_compacting_compliance.compacting_infers_the_fold_for_an_unregistered_aggregate` | `Unable to find an Aggregation Projection for type ComplianceUnregisteredMeter` |
| `event_query_tag_values_tests.query_by_tags_accepts_either_spelling_of_the_name` | fails on the table-suffix spelling |
| `event_query_tag_values_tests.query_by_tags_matches_a_value_regardless_of_casing` | fails on the uppercase Guid |

New Marten-local coverage for what no shared suite reaches: the **HStore branch** of the `TagValues` filter (the suite only exercises the TagTables translation, since the storage mode is a Marten-only opt-in), the dictionary overload's name and value rules, and the no-conventions refusal.

- `EventSourcingTests` net10.0 — **2219 passed, 20 skipped, 0 failed**, including all 53 `event_query_compliance` facts (11 of them new) and all 13 `stream_compacting_compliance` facts. Checked with `--list-tests` that the new facts are actually present rather than reading the totals.
- `CoreTests` net10.0 — the same 4 order-dependent failures it shows on untouched master (`Bug_4185_codegen_conflict…`, `Bug_4187_ancillary_store_isolation`, `rolling_range_partitioning`, `divergent_application_assembly_reuse_warning_is_buffered_and_logged`), all of which pass in isolation. No new failures.

Also arriving in 2.67.0 and inert for Marten: jasperfx#803/#804 fixes the `event-query --tags` CLI flag, which used to manufacture a `TypeDescriptor` whose `FullName` was the bare tag name and so threw against every real store. Marten gains the working flag through the package with no Marten change, and `EventQueryCompliance` now runs the command's own output through the store — the only place that gap was ever visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDX5UV1He5if9vVo8Bdi7g
