### PR TITLE
Enable Bobcat interceptors in DaemonTests.ManualOnly, unbreaking the Release compile

### DIFF
--- a/src/DaemonTests.ManualOnly/DaemonTests.ManualOnly.csproj
+++ b/src/DaemonTests.ManualOnly/DaemonTests.ManualOnly.csproj
@@ -10,6 +10,16 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
+
+        <!-- #5363 rendered DaemonTests as Bobcat specifications, which brought in the
+             Bobcat.Generators analyzer. It flows through to this project along the
+             ProjectReference to DaemonTests and emits BobcatStepInterceptors.g.cs here too, so
+             this project needs the same per-namespace interceptor opt-in DaemonTests declares.
+             Without it every generated interceptor is CS9137 and the whole Release compile fails,
+             which is what broke the 9.33.0 publish (this project is not built by any CI job).
+             Bobcat.Generated is the constant the generator emits into, identical in every project
+             (JasperFx/bobcat#110). -->
+        <InterceptorsNamespaces>$(InterceptorsNamespaces);Bobcat.Generated</InterceptorsNamespaces>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Bogus" />


### PR DESCRIPTION
**The 9.33.0 NuGet publish failed on this.** [Run 34368113182](https://github.com/JasperFx/marten/actions/runs/34368113182) died in `Run Pack` before packing anything — `Compile` failed, `Pack` was `NotRun`, and `Publish to NuGet` was skipped. Nothing reached nuget.org and the `9.33.0` version string is not burned, so the release can simply be re-run once this lands.

## The failure

240 instances of one error, all in `src/DaemonTests.ManualOnly`, on both net9.0 and net10.0:

```
error CS9137: The 'interceptors' feature is not enabled in this namespace.
Add '<InterceptorsNamespaces>$(InterceptorsNamespaces);Bobcat.Generated</InterceptorsNamespaces>' to your project.
```

#5363 rendered DaemonTests as Bobcat specifications and added the per-namespace interceptor opt-in to `DaemonTests.csproj`. The `Bobcat.Generators` analyzer flows onward to `DaemonTests.ManualOnly` along its `ProjectReference` to DaemonTests and emits `BobcatStepInterceptors.g.cs` there too — so that project needs the same opt-in, and did not get one. This adds it, with the same comment DaemonTests carries.

## Why CI was green through four merges

`DaemonTests.ManualOnly` is built by **no CI job**. It is the manual-only long-running suite, deliberately outside the per-project test matrix from #5096. The only thing that compiles it is the full-solution Release build in the publish workflow — which runs *after* the version bump has already landed on master and the release has been tagged.

So a project no CI job touches took down a release, and did it at the latest possible moment. #5363, #5362, #5367 and #5368 all merged green on top of the break.

That gap is worth a follow-up on its own — either put `ManualOnly` in a compile-only CI job, or run `build.sh compile` as a merge gate — but this PR is deliberately just the unbreak, so the release can go out.

## Verification

- `dotnet build src/DaemonTests.ManualOnly -c Release` clean on net9.0 and net10.0 (its only two TFMs)
- `./build.sh compile` — the exact target the publish workflow runs — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDX5UV1He5if9vVo8Bdi7g
