### PR TITLE
Take Bobcat 0.17.1, and correct what ManualOnly's generator reference is for

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -552,9 +552,9 @@
     <!-- Marker-step specifications (JasperFx/bobcat#110). Bobcat.Xunit is the shipped runner
          adapter, new in 0.17.0; before it, this repo hand-rolled one and it reported every
          scenario as a CleanPass whatever the test actually did. -->
-    <PackageVersion Include="Bobcat" Version="0.17.0" />
-    <PackageVersion Include="Bobcat.Generators" Version="0.17.0" />
-    <PackageVersion Include="Bobcat.Xunit" Version="0.17.0" />
+    <PackageVersion Include="Bobcat" Version="0.17.1" />
+    <PackageVersion Include="Bobcat.Generators" Version="0.17.1" />
+    <PackageVersion Include="Bobcat.Xunit" Version="0.17.1" />
     <PackageVersion Include="JasperFx" Version="2.67.0" />
     <PackageVersion Include="JasperFx.Events" Version="2.67.0" />
     <!--

--- a/src/DaemonTests.ManualOnly/DaemonTests.ManualOnly.csproj
+++ b/src/DaemonTests.ManualOnly/DaemonTests.ManualOnly.csproj
@@ -14,13 +14,16 @@
     <ItemGroup>
         <!-- #5363 rendered DaemonTests as Bobcat specifications. The generator reaches this
              project along the ProjectReference to DaemonTests and emits BobcatStepInterceptors.g.cs
-             here too — but a NuGet package's build/ props are private to the project that
-             references it, so the interceptor opt-in that comes with the package does NOT arrive
-             the same way the analyzer does. Referencing the generator here is what makes this
-             project's opt-in its own, and it is the truthful declaration anyway: this project
-             compiles generated interceptor code. Without one or the other, every interceptor is
-             CS9137 and the whole Release compile fails — which is what broke the 9.33.0 publish,
-             since no CI job builds this project. -->
+             here too, so this project compiles generated interceptor code and declaring the
+             generator is simply the truth about it.
+
+             No longer load-bearing: Bobcat 0.17.1 ships the interceptor opt-in under
+             buildTransitive/ (JasperFx/bobcat#267), so it now reaches a project that gets the
+             generator second-hand and this builds clean without the reference. It was
+             load-bearing on 0.17.0, where the opt-in shipped under build/ and a package's build/
+             assets are private to the project that references it while an analyzer is not — 60
+             CS9137s, and the whole Release compile with them. That is the shape of failure that
+             broke the 9.33.0 publish, and no CI job builds this project to catch it. -->
         <PackageReference Include="Bobcat.Generators" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <PackageReference Include="Bogus" />
         <PackageReference Include="Confluent.Kafka" />


### PR DESCRIPTION
Follow-up to #5370. Two small things.

## The pins move 0.17.0 → 0.17.1

[JasperFx/bobcat#267](https://github.com/JasperFx/bobcat/pull/267) is a fix aimed squarely at this repo's shape, so it is worth taking directly.

0.17.0 shipped the interceptor opt-in under `build/`. A package's `build/` assets are **private to the project that references it**, while **an analyzer flows across a `ProjectReference`** — so `DaemonTests.ManualOnly` received generated interceptors with no opt-in to compile them. 0.17.1 ships it under `buildTransitive/`, which reaches a second-hand consumer too.

Measured on this tree against the published packages, both projects' `obj` cleaned, only the pin changing:

| Bobcat | opt-in ships under | `DaemonTests.ManualOnly` Release build |
|---|---|---|
| 0.17.0 | `build/` | **60 × CS9137**, fails |
| 0.17.1 | `buildTransitive/` | **clean** |

## The comment, corrected

#5370 gave `ManualOnly` its own `PackageReference` to `Bobcat.Generators` and explained it as the thing standing between this repo and a broken Release compile. On 0.17.1 that is no longer true.

The reference stays — it is a truthful declaration, since the project really does compile generated interceptor code — but the comment now says so, and files the 0.17.0 failure as the history that explains the line rather than as live justification. Nobody reading it later should have to work out whether it is still load-bearing.

## Verification

| | Baseline (clean master) | This branch |
|---|---|---|
| DaemonTests, net9.0, Release | 2 failed / 321 passed / 323 | **2 failed / 321 passed / 323** |

Identical, down to the same two test names — `Bug_catching_up_command_errors.should_catch_marten_command_exceptions` and `Bug_catching_up_apply_errors.should_catch_apply_event_exceptions`, both pre-existing and unrelated to test reporting. `DaemonTests.ManualOnly` builds clean in Release, which is the check that matters since no CI job builds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)