### PR TITLE
Mapped concurrency property fails optimistic lock

### DIFF
--- a/src/CoreTests/Storage/Identification/closed_shape_optimistic_concurrency_mapped_member_tests.cs
+++ b/src/CoreTests/Storage/Identification/closed_shape_optimistic_concurrency_mapped_member_tests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Exceptions;
+using Marten.Metadata;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests.Storage.Identification;
+
+/// <summary>
+/// The documented contract for a mapped version member —
+/// Metadata(m => m.Version.MapTo(x => x.Etag)) on a UseOptimisticConcurrency(true)
+/// document — is that Store() passes the version number from the document itself
+/// (docs/documents/concurrency.md), i.e. the mapped member should behave exactly
+/// like the IVersioned marker interface does.
+/// These tests pin the gap where that does not hold today.
+/// </summary>
+public class closed_shape_optimistic_concurrency_mapped_member_tests : BugIntegrationContext
+{
+    private DocumentStore mappedMemberStore()
+        => StoreOptions(opts =>
+        {
+            opts.Schema.For<MappedVersionDoc>().UseOptimisticConcurrency(true)
+                .Metadata(m => m.Version.MapTo(x => x.Etag));
+        });
+
+    private DocumentStore markerInterfaceStore()
+        => StoreOptions(opts =>
+        {
+            opts.Schema.For<MarkerVersionedDoc>().UseOptimisticConcurrency(true);
+        });
+
+    [Fact]
+    public async Task mapped_version_member_should_be_used_as_the_expected_version_on_store()
+    {
+        var store = mappedMemberStore();
+
+        var doc = new MappedVersionDoc { Name = "v1" };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        // The mapped member received the version Marten wrote
+        doc.Etag.ShouldNotBe(Guid.Empty);
+
+        // Re-storing the SAME entity in a fresh session must not be a blind
+        // write: the mapped member carries the expected version.
+        await using (var session = store.LightweightSession())
+        {
+            doc.Name = "v2";
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<MappedVersionDoc>(doc.Id))!.Name.ShouldBe("v2");
+    }
+
+    [Fact]
+    public async Task stale_mapped_version_member_is_rejected()
+    {
+        var store = mappedMemberStore();
+
+        var doc = new MappedVersionDoc { Name = "v1" };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        await using var session2 = store.LightweightSession();
+        doc.Etag = Guid.NewGuid(); // a version that never existed on the row
+        session2.Store(doc);
+        await Should.ThrowAsync<ConcurrencyException>(() => session2.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task mapped_version_member_of_empty_guid_is_rejected_like_a_blind_write()
+    {
+        var store = mappedMemberStore();
+
+        var id = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new MappedVersionDoc { Id = id, Name = "v1" });
+            await session.SaveChangesAsync();
+        }
+
+        // No version on the document = no expected version = rejected, exactly
+        // like the unversioned blind write case
+        await using var session2 = store.LightweightSession();
+        session2.Store(new MappedVersionDoc { Id = id, Name = "blind-write" });
+        await Should.ThrowAsync<ConcurrencyException>(() => session2.SaveChangesAsync());
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<MappedVersionDoc>(id))!.Name.ShouldBe("v1");
+    }
+
+    [Fact]
+    public async Task marker_interface_version_round_trips_in_a_fresh_session()
+    {
+        // Contrast: the same flow through the IVersioned marker interface works
+        // today, because storeEntity() seeds the session's version tracker from
+        // the marker interface. MapTo() members should behave identically.
+        var store = markerInterfaceStore();
+
+        var doc = new MarkerVersionedDoc { Name = "v1" };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        doc.Version.ShouldNotBe(Guid.Empty);
+
+        await using (var session = store.LightweightSession())
+        {
+            doc.Name = "v2";
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<MarkerVersionedDoc>(doc.Id))!.Name.ShouldBe("v2");
+    }
+}
+
+public class MappedVersionDoc
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = "";
+    public Guid Etag { get; set; }
+}
+
+public class MarkerVersionedDoc : IVersioned
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = "";
+    public Guid Version { get; set; }
+}


### PR DESCRIPTION
When mapping the version property using `opts.Schema.For<>().UseOptimisticConcurrency(true).Metadata(m => m.Version.MapTo(x => x.Etag))`, saving the document fails with a ConcurrencyException as demonstrated in the test `closed_shape_optimistic_concurrency_mapped_member_tests.mapped_version_member_should_be_used_as_the_expected_version_on_store` included in this PR.

For a potential fix see this branch:
https://github.com/JurJean/marten/tree/mapped-concurrency-fix
