### PR TITLE
Native AOT: close four generics where the compiler can emit them, so events read from a native binary

### DIFF
--- a/docs/configuration/aot-publishing.md
+++ b/docs/configuration/aot-publishing.md
@@ -98,6 +98,12 @@ builder.Services.AddMarten(opts =>
     opts.Schema.For<Invoice>();
     opts.Events.AddEventType<InvoiceCreated>();
     opts.Projections.Add<InvoiceSummaryProjection>(ProjectionLifecycle.Inline);
+
+    // Say the aggregate's identity type out loud. The single-parameter overloads read it off the
+    // document mapping and close SingleStreamProjection<,> with it at runtime, which a native
+    // binary has no code for.
+    opts.Projections.LiveStreamAggregation<Order, Guid>();
+    opts.Projections.Snapshot<Shipment, string>(SnapshotLifecycle.Inline);
 });
 
 using var host = builder.Build();
@@ -133,8 +139,8 @@ As of Marten 9.0.0-alpha:
 
 - **`UseSystemTextJsonForSerialization`** with the default `JsonSerializerOptions` or a user-supplied one. For best AOT results, pass a source-generated `JsonSerializerContext`.
 - **Document storage** — `Schema.For<TDoc>()` and the entire CRUD / LINQ surface for closed-shape document types (Guid / string / int / long / strong-typed Id strategies).
-- **Event storage** — `StartStream`, `Append`, `FetchStream`, `FetchStreamStateAsync`, the async daemon.
-- **Projections** — `SingleStreamProjection<TDoc, TId>`, `MultiStreamProjection<TDoc, TId>`, `EventProjection`, `CustomProjection`, and `EventApplier` — the JasperFx.Events source generator emits `[GeneratedEvolver]` dispatchers at compile time for each registration. Marten calls `Options.Projections.DiscoverGeneratedEvolvers(...)` at startup (`src/Marten/DocumentStore.cs:84`) to pick them up.
+- **Event storage** — `StartStream`, `Append`, `FetchStream`, `FetchStreamStateAsync`, `AggregateStreamAsync`, `QueryAllRawEvents`, the async daemon. Reading an event needed a JIT until [#5373](https://github.com/JasperFx/marten/issues/5373): the events table closed its per-column reader over the column's member type at runtime.
+- **Projections** — registered either as a projection type (`Projections.Add<T>(...)`) or, for a self-aggregating type, through the identity-typed `LiveStreamAggregation<TDoc, TId>()` / `Snapshot<TDoc, TId>(...)` overloads: `SingleStreamProjection<TDoc, TId>`, `MultiStreamProjection<TDoc, TId>`, `EventProjection`, `CustomProjection`, and `EventApplier` — the JasperFx.Events source generator emits `[GeneratedEvolver]` dispatchers at compile time for each registration. Marten calls `Options.Projections.DiscoverGeneratedEvolvers(...)` at startup (`src/Marten/DocumentStore.cs:84`) to pick them up.
 - **Compiled queries** registered through `Marten.SourceGenerator` in an assembly marked `[JasperFxAssembly]`.
 - **Secondary stores** registered via `services.AddMartenStore<TInterface>()` — Marten 9 builds the implementation type via `System.Reflection.Emit` (PR [#4459](https://github.com/JasperFx/marten/pull/4459)). The trimmer warning at the emit site carries a `[RequiresDynamicCode]` annotation; published apps that use this surface can either suppress or rely on the runtime fall-through to keep working.
 - **`Marten.AspNetCore`** streaming endpoints (`WriteArray`, `StreamMany`, `WriteSingle`, etc.) — clean.
@@ -247,6 +253,28 @@ Two shapes still need runtime code generation and therefore still need a JIT:
 - **A `where` clause whose value comes from a method call** — `x => x.Name == BuildName()`. Constants, captured locals, instance and static members, member chains and array literals are all evaluated reflectively; anything else falls back to expression compilation. Hoist the call into a local before the query.
 
 Compiled queries remain worth using under AOT for their own reasons — reference `Marten.SourceGenerator`, add `[assembly: JasperFx.JasperFxAssembly]`, and call `session.QueryAsync(compiledQueryInstance)` to dispatch through a source-generated handler instead of parsing the expression tree on every call. See [`Marten.SourceGenerator/README.md`](https://github.com/JasperFx/marten/blob/master/src/Marten.SourceGenerator/README.md) for the full surface. They are no longer a *workaround* for LINQ, though.
+
+### A child-collection filter throws `JsonTypeInfo metadata for type 'System.Object[]'`
+
+```text
+NotSupportedException: JsonTypeInfo metadata for type 'System.Object[]' was not provided by
+TypeInfoResolver of type 'MyApp.MyJsonContext'.
+```
+
+A filter over a child collection (`x => x.Debtors.Any(d => d.Number == number)`) becomes a jsonb
+containment query, and Marten serializes that payload — a `Dictionary<string, object>` of member
+names to the values you compared against — through *your* serializer. A source-generated resolver
+does not carry Marten's own shapes, so it throws before the query is ever sent.
+
+Until Marten writes that payload itself ([#5374](https://github.com/JasperFx/marten/issues/5374)),
+declare the shapes on your context, including every enum a filter like this compares:
+
+```csharp
+[JsonSerializable(typeof(object[]))]
+[JsonSerializable(typeof(Dictionary<string, object>))]
+[JsonSerializable(typeof(DebtorType))]
+public partial class MyJsonContext: JsonSerializerContext;
+```
 
 ### Secondary store throws `MissingMethodException` at boot
 

--- a/src/Marten.AotRuntimeSmoke/Program.cs
+++ b/src/Marten.AotRuntimeSmoke/Program.cs
@@ -14,6 +14,12 @@
 //                         reflectively, so it still reached Reflection.Emit (#5361).
 //   compiled query        CompiledQueryPlan.sortMembers closed PropertyQueryMember<T>
 //                         reflectively.
+//   event read            EventColumnReaders.BuildAsync closed BuildAsyncImpl<T> with
+//                         MethodInfo.MakeGenericMethod, so the first event any read brought back
+//                         threw - every AggregateStreamAsync, FetchForWriting and projection.
+//   live aggregation      Projections.LiveStreamAggregation<T>() closed SingleStreamProjection<,>
+//                         on an identity type only known at runtime, and validating it closed
+//                         DocumentMappingBuilder<> over the aggregate.
 //
 // Exits non-zero with the offending stack trace on the first failure, so CI reports the
 // specific read path that regressed.
@@ -22,6 +28,7 @@ using System.Linq.Expressions;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using JasperFx;
+using JasperFx.Events;
 using Marten;
 using Marten.Linq;
 using Weasel.Core;
@@ -40,6 +47,15 @@ var store = DocumentStore.For(o =>
     o.AutoCreateSchemaObjects = AutoCreate.All;
     o.DatabaseSchemaName = "aot_runtime_smoke";
     o.Schema.For<Praktijk>().Index(x => x.AgbCode);
+
+    o.Events.StreamIdentity = StreamIdentity.AsString;
+    o.Events.AddEventType<DossierGeopend>();
+    o.Events.AddEventType<RegelToegevoegd>();
+
+    // The identity type is said out loud: the overload without it has to close
+    // SingleStreamProjection<,> at runtime. Dossier is deliberately not named by a Schema.For<T>()
+    // either, so this also covers the aggregate's mapping being built from a Type.
+    o.Projections.LiveStreamAggregation<Dossier, string>();
 });
 
 var failures = 0;
@@ -61,6 +77,8 @@ try
         {
             Id = Guid.NewGuid(), AgbCode = "01059911", Naam = "Praktijk Pietersen", Soort = Soort.Apotheek
         });
+        writing.Events.StartStream<Dossier>("dossier-1",
+            new DossierGeopend("dossier-1", "Dossier Jansen"), new RegelToegevoegd("12000"));
         await writing.SaveChangesAsync();
     }
 
@@ -142,6 +160,20 @@ try
         var found = await session.QueryAsync(new PraktijkByAgb { AgbCode = "01059910" });
         return found.Count() == 1;
     });
+
+    // Reading an event is a separate path from reading a document: the events table hands its
+    // columns to the event through reader delegates of its own.
+    await Check("event stream read + live aggregation", async () =>
+    {
+        var dossier = await session.Events.AggregateStreamAsync<Dossier>("dossier-1");
+        return dossier?.Naam == "Dossier Jansen" && dossier.Regels == 1;
+    });
+
+    await Check("raw event query", async () =>
+    {
+        var events = await session.Events.QueryAllRawEvents().ToListAsync();
+        return events.Count == 2 && events[0].StreamKey == "dossier-1";
+    });
 }
 catch (Exception e)
 {
@@ -156,7 +188,7 @@ if (failures > 0)
     return 1;
 }
 
-Console.WriteLine("Marten AOT runtime smoke OK — every document read path ran from a native binary.");
+Console.WriteLine("Marten AOT runtime smoke OK — every document and event read path ran from a native binary.");
 return 0;
 
 async Task Check(string description, Func<Task<bool>> check)
@@ -203,5 +235,23 @@ public class PraktijkByAgb: ICompiledListQuery<Praktijk>
         q => q.Where(x => x.AgbCode == AgbCode);
 }
 
+public class Dossier
+{
+    public string Id { get; set; } = "";
+    public string Naam { get; set; } = "";
+    public int Regels { get; set; }
+
+    public static Dossier Create(DossierGeopend geopend) => new() { Id = geopend.Nummer, Naam = geopend.Naam };
+
+    public static void Apply(RegelToegevoegd _, Dossier dossier) => dossier.Regels++;
+}
+
+public record DossierGeopend(string Nummer, string Naam);
+
+public record RegelToegevoegd(string Prestatiecode);
+
 [JsonSerializable(typeof(Praktijk))]
+[JsonSerializable(typeof(Dossier))]
+[JsonSerializable(typeof(DossierGeopend))]
+[JsonSerializable(typeof(RegelToegevoegd))]
 public partial class SmokeJson: JsonSerializerContext;

--- a/src/Marten/Events/Aggregation/SingleStreamProjection.cs
+++ b/src/Marten/Events/Aggregation/SingleStreamProjection.cs
@@ -148,6 +148,11 @@ public class SingleStreamProjection<TDoc, TId>:
     [JasperFxIgnore]
     public IEnumerable<string> ValidateConfiguration(StoreOptions options)
     {
+        // BuilderFor<TDoc>() first, because TDoc is known here and FindMapping is not: without a
+        // builder registered for it, the Type-keyed path closes DocumentMappingBuilder<> at runtime and
+        // a Native AOT build throws for any aggregate that no Schema.For<T>() names.
+        options.Storage.BuilderFor<TDoc>();
+
         var mapping = options.Storage.FindMapping(typeof(TDoc)).Root.As<DocumentMapping>();
 
         foreach (var p in validateDocumentIdentity(options, mapping)) yield return p;

--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -208,6 +208,53 @@ public class ProjectionOptions: ProjectionGraph<IProjection, IDocumentOperations
     }
 
     /// <summary>
+    ///     Register live stream aggregation, naming the aggregate's identity type so nothing has to be
+    ///     closed at runtime. The overload without <typeparamref name="TId" /> infers it from the
+    ///     document mapping, which a Native AOT build cannot do.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TId"></typeparam>
+    /// <param name="asyncConfiguration">Use it to define behaviour during projection rebuilds</param>
+    /// <returns>The extended storage configuration for entity T</returns>
+    public MartenRegistry.DocumentMappingExpression<T> LiveStreamAggregation<T, TId>(
+        Action<AsyncOptions>? asyncConfiguration = null
+    ) where T : notnull where TId : notnull
+    {
+        var expression = register<T>(new SingleStreamProjection<T, TId>(), ProjectionLifecycle.Live, null,
+            asyncConfiguration);
+
+        // Hack to address https://github.com/JasperFx/marten/issues/2610
+        _options.Storage.MappingFor(typeof(T)).SkipSchemaGeneration = true;
+
+        return expression;
+    }
+
+    /// <summary>
+    ///     Perform automated snapshot on each event for selected entity type, naming the aggregate's
+    ///     identity type so nothing has to be closed at runtime. The overload without
+    ///     <typeparamref name="TId" /> infers it from the document mapping, which a Native AOT build
+    ///     cannot do.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TId"></typeparam>
+    /// <param name="lifecycle">Override the snapshot lifecycle. The default is Inline</param>
+    /// <param name="configureProjection">Use it to further customize the projection.</param>
+    /// <param name="asyncConfiguration">
+    ///     Optional configuration including teardown instructions for the usage of this
+    ///     projection within the async projection daemon
+    /// </param>
+    /// <returns>The extended storage configuration for document T</returns>
+    public MartenRegistry.DocumentMappingExpression<T> Snapshot<T, TId>(
+        SnapshotLifecycle lifecycle,
+        Action<ProjectionBase>? configureProjection = null,
+        Action<AsyncOptions>? asyncConfiguration = null
+    ) where T : notnull where TId : notnull
+    {
+        return register<T>(new SingleStreamProjection<T, TId>(), lifecycle.Map(), configureProjection,
+            asyncConfiguration);
+    }
+
+    /// <summary>
     ///     Perform automated snapshot on each event for selected entity type
     /// </summary>
     /// <typeparam name="T"></typeparam>
@@ -257,11 +304,25 @@ public class ProjectionOptions: ProjectionGraph<IProjection, IDocumentOperations
                 $"This registration mechanism can only be used for an aggregate type that is 'self-aggregating'. Please use the Projections.Add() API instead to register {typeof(T).FullNameInCode()}");
         }
 
-        // Make sure there's a DocumentMapping for the aggregate
-        var expression = _options.Schema.For<T>();
+        // Make sure there's a DocumentMapping for the aggregate before its identity is read off one
+        _options.Schema.For<T>();
 
         var identityType = new DocumentMapping(typeof(T), _options).IdType;
         var source = typeof(SingleStreamProjection<,>).CloseAndBuildAs<ProjectionBase>(typeof(T), identityType);
+
+        return register<T>(source, lifecycle, configureProjection, asyncConfiguration);
+    }
+
+    private MartenRegistry.DocumentMappingExpression<T> register<T>(
+        ProjectionBase source,
+        ProjectionLifecycle lifecycle,
+        Action<ProjectionBase>? configureProjection,
+        Action<AsyncOptions>? asyncConfiguration
+    )
+    {
+        // Make sure there's a DocumentMapping for the aggregate
+        var expression = _options.Schema.For<T>();
+
         source.Lifecycle = lifecycle;
 
         configureProjection?.Invoke(source);

--- a/src/Marten/Events/Schema/EventColumnReaders.cs
+++ b/src/Marten/Events/Schema/EventColumnReaders.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -78,9 +79,29 @@ internal static class EventColumnReaders
         var member = MemberFinder.Determine(memberExpression).Single();
         var memberType = member.GetMemberType()!;
 
-        // We call BuildAsyncImpl<T> with the right T via reflection (once,
-        // at startup). BuildAsyncImpl returns a delegate that's strongly
-        // typed and doesn't box.
+        // BuildAsyncImpl<T> is closed here, where the compiler emits the instantiation, rather than
+        // through MakeGenericMethod: every column the events table declares is one of these types, and
+        // under Native AOT a runtime-closed generic method has no native code -- so the reflective
+        // route below throws on the first event read, which is every AggregateStreamAsync,
+        // FetchForWriting and projection. Same shape of fix as #5328.
+        if (memberType == typeof(Guid)) return BuildAsyncImpl<Guid>(member);
+        if (memberType == typeof(Guid?)) return BuildAsyncImpl<Guid?>(member);
+        if (memberType == typeof(string)) return BuildAsyncImpl<string>(member);
+        if (memberType == typeof(long)) return BuildAsyncImpl<long>(member);
+        if (memberType == typeof(int)) return BuildAsyncImpl<int>(member);
+        if (memberType == typeof(bool)) return BuildAsyncImpl<bool>(member);
+        if (memberType == typeof(DateTimeOffset)) return BuildAsyncImpl<DateTimeOffset>(member);
+        if (memberType == typeof(DateTime)) return BuildAsyncImpl<DateTime>(member);
+
+        return BuildAsyncReflectively(memberType, member);
+    }
+
+    /// <summary>The escape hatch for a column type the closed set above does not name. Fine under a
+    /// JIT, and the only thing left that a Native AOT build cannot run.</summary>
+    [RequiresDynamicCode("Closes BuildAsyncImpl<T> with MethodInfo.MakeGenericMethod")]
+    private static Func<DbDataReader, int, IEvent, CancellationToken, Task> BuildAsyncReflectively(
+        Type memberType, MemberInfo member)
+    {
         var helper = typeof(EventColumnReaders)
             .GetMethod(nameof(BuildAsyncImpl), BindingFlags.NonPublic | BindingFlags.Static)!
             .MakeGenericMethod(memberType);

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -934,7 +934,11 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
         // the affected type. Callers that genuinely need every mapping
         // materialized (codegen, full schema migration, type-enumeration
         // APIs) should call Storage.BuildAllMappings() explicitly.
-        Schema.For<DeadLetterEvent>().DatabaseSchemaName(Events.DatabaseSchemaName).SingleTenanted();
+        // The identity is named instead of discovered: DeadLetterEvent is ours, nothing in a
+        // consumer's code mentions its Id, and a trimmed build therefore has no Id member left to
+        // find - so every schema operation on an event store threw InvalidDocumentException.
+        Schema.For<DeadLetterEvent>().Identity(x => x.Id).DatabaseSchemaName(Events.DatabaseSchemaName)
+            .SingleTenanted();
 
         // Validate any mappings that were already materialized during
         // configuration (Schema.For<T>() with eager builder customization


### PR DESCRIPTION
Fixes #5373.

Documents come back from a native binary since #5328 and #5361. Events do not: the first event any read brings back throws, and two of the projection-registration paths throw before that, at store construction. Measured by publishing a Native AOT binary and *running* it against a real PostgreSQL — not by counting IL warnings, which is what let this sit behind a clean publish.

Four sites, one shape: a generic closed at runtime where the compiler could have emitted it — the same fix #5360 made for document reads.

### `EventColumnReaders.BuildAsync`

Closed `BuildAsyncImpl<T>` over the column's member type with `MethodInfo.MakeGenericMethod`:

```text
NotSupportedException: 'Marten.Events.Schema.EventColumnReaders.BuildAsyncImpl[System.Int64](MemberInfo)'
is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation.
   at Marten.Events.QueryEventStore.AggregateStreamAsync[T](...)
```

The columns the events table declares are `Guid`, `string`, `long`, `bool` and `DateTimeOffset`, so those five (plus `Guid?`, `int` and `DateTime`) close at the call site. A column type outside that set keeps the reflective route, now behind `[RequiresDynamicCode]` so it warns rather than surprises.

### `LiveStreamAggregation<T>()` / `Snapshot<T>()`

Both read the identity type off the document mapping and then closed `SingleStreamProjection<,>` with it, which throws while the store is being built. Added `LiveStreamAggregation<T, TId>()` and `Snapshot<T, TId>(…)`, which say the identity type the caller already knows; the single-parameter overloads are untouched for JIT callers. The assembling half both routes shared moved into a private `register<T>(…)`.

### `SingleStreamProjection<TDoc, TId>.ValidateConfiguration`

Knew `TDoc` statically but looked its mapping up by `Type`, so `StorageFeatures.Build(Type, …)` closed `DocumentMappingBuilder<>` for any aggregate that no generic `Schema.For<T>()` also names — the ordinary case for a projection's document. It calls the existing generic `BuilderFor<TDoc>()` first; the `Type`-keyed lookup then finds it.

### `DeadLetterEvent`

`Schema.For<DeadLetterEvent>()` left the identity to be discovered, and nothing in a consumer's code mentions `DeadLetterEvent.Id`, so the trimmer dropped the property:

```text
InvalidDocumentException: Could not determine an 'id/Id' field or property for requested document type
JasperFx.Events.Daemon.DeadLetterEvent
   at Marten.Storage.MartenDatabase.CompletelyRemoveAllAsync(...)
```

Naming it in the expression keeps it alive. This fires on every full-schema operation of an event store — `db-apply`, `AssertDatabaseMatchesConfigurationAsync`, `ResetAllData` — so it stays hidden until the first schema command.

## Coverage

`Marten.AotRuntimeSmoke` gains an event stream, a live aggregation registered through the new identity-typed overload on an aggregate deliberately not named by a `Schema.For<T>()`, and two checks over them. Reverting only the `EventColumnReaders` change:

```text
OK   compiled query
FAIL event stream read + live aggregation
FAIL raw event query
Marten AOT runtime smoke FAILED - 2 read path(s) broken under Native AOT.
```

and with it:

```text
OK   event stream read + live aggregation
OK   raw event query
Marten AOT runtime smoke OK - every document and event read path ran from a native binary.
```

Reverting the other three fails earlier — at store construction and at the smoke's `CompletelyRemoveAllAsync` — which is what a consumer sees today.

The docs page gets the identity-typed registration in the walkthrough, an honest note on the event-storage line, and a troubleshooting entry for the one thing this PR does *not* fix: a child-collection `Any()` filter serializes its jsonb payload through the consumer's `JsonSerializerContext` and throws on `object[]` (#5374).

`EventSourcingTests` on net10.0 was run locally against PostgreSQL 18.
