### PR TITLE
Native AOT: write the containment payload in Marten instead of through the consumer's serializer

### DIFF
--- a/docs/configuration/aot-publishing.md
+++ b/docs/configuration/aot-publishing.md
@@ -138,7 +138,7 @@ As of Marten 9.0.0-alpha:
 ### Works (AOT-clean)
 
 - **`UseSystemTextJsonForSerialization`** with the default `JsonSerializerOptions` or a user-supplied one. For best AOT results, pass a source-generated `JsonSerializerContext`.
-- **Document storage** — `Schema.For<TDoc>()` and the entire CRUD / LINQ surface for closed-shape document types (Guid / string / int / long / strong-typed Id strategies), including the containment and JSONPath filters a child-collection query compiles to (#5376).
+- **Document storage** — `Schema.For<TDoc>()` and the entire CRUD / LINQ surface for closed-shape document types (Guid / string / int / long / strong-typed Id strategies), including the containment and JSONPath filters a child-collection query compiles to (#5377).
 - **Event storage** — `StartStream`, `Append`, `FetchStream`, `FetchStreamStateAsync`, `AggregateStreamAsync`, `QueryAllRawEvents`, the async daemon. Reading an event needed a JIT until [#5373](https://github.com/JasperFx/marten/issues/5373): the events table closed its per-column reader over the column's member type at runtime.
 - **Projections** — registered either as a projection type (`Projections.Add<T>(...)`) or, for a self-aggregating type, through the identity-typed `LiveStreamAggregation<TDoc, TId>()` / `Snapshot<TDoc, TId>(...)` overloads: `SingleStreamProjection<TDoc, TId>`, `MultiStreamProjection<TDoc, TId>`, `EventProjection`, `CustomProjection`, and `EventApplier` — the JasperFx.Events source generator emits `[GeneratedEvolver]` dispatchers at compile time for each registration. Marten calls `Options.Projections.DiscoverGeneratedEvolvers(...)` at startup (`src/Marten/DocumentStore.cs:84`) to pick them up.
 - **Compiled queries** registered through `Marten.SourceGenerator` in an assembly marked `[JasperFxAssembly]`.
@@ -261,7 +261,7 @@ NotSupportedException: JsonTypeInfo metadata for type 'System.Object[]' was not 
 TypeInfoResolver of type 'MyApp.MyJsonContext'.
 ```
 
-Fixed by [#5376](https://github.com/JasperFx/marten/pull/5376) — upgrade rather than working around it.
+Fixed by [#5377](https://github.com/JasperFx/marten/pull/5377) — upgrade rather than working around it.
 A filter over a child collection (`x => x.Debtors.Any(d => d.Number == number)`) becomes a jsonb
 containment query, and Marten used to serialize that payload — its own dictionary of member names to the
 values you compared against — through *your* serializer. A source-generated resolver carries your

--- a/docs/configuration/aot-publishing.md
+++ b/docs/configuration/aot-publishing.md
@@ -138,7 +138,7 @@ As of Marten 9.0.0-alpha:
 ### Works (AOT-clean)
 
 - **`UseSystemTextJsonForSerialization`** with the default `JsonSerializerOptions` or a user-supplied one. For best AOT results, pass a source-generated `JsonSerializerContext`.
-- **Document storage** — `Schema.For<TDoc>()` and the entire CRUD / LINQ surface for closed-shape document types (Guid / string / int / long / strong-typed Id strategies).
+- **Document storage** — `Schema.For<TDoc>()` and the entire CRUD / LINQ surface for closed-shape document types (Guid / string / int / long / strong-typed Id strategies), including the containment and JSONPath filters a child-collection query compiles to (#5376).
 - **Event storage** — `StartStream`, `Append`, `FetchStream`, `FetchStreamStateAsync`, `AggregateStreamAsync`, `QueryAllRawEvents`, the async daemon. Reading an event needed a JIT until [#5373](https://github.com/JasperFx/marten/issues/5373): the events table closed its per-column reader over the column's member type at runtime.
 - **Projections** — registered either as a projection type (`Projections.Add<T>(...)`) or, for a self-aggregating type, through the identity-typed `LiveStreamAggregation<TDoc, TId>()` / `Snapshot<TDoc, TId>(...)` overloads: `SingleStreamProjection<TDoc, TId>`, `MultiStreamProjection<TDoc, TId>`, `EventProjection`, `CustomProjection`, and `EventApplier` — the JasperFx.Events source generator emits `[GeneratedEvolver]` dispatchers at compile time for each registration. Marten calls `Options.Projections.DiscoverGeneratedEvolvers(...)` at startup (`src/Marten/DocumentStore.cs:84`) to pick them up.
 - **Compiled queries** registered through `Marten.SourceGenerator` in an assembly marked `[JasperFxAssembly]`.
@@ -261,20 +261,11 @@ NotSupportedException: JsonTypeInfo metadata for type 'System.Object[]' was not 
 TypeInfoResolver of type 'MyApp.MyJsonContext'.
 ```
 
+Fixed by [#5376](https://github.com/JasperFx/marten/pull/5376) — upgrade rather than working around it.
 A filter over a child collection (`x => x.Debtors.Any(d => d.Number == number)`) becomes a jsonb
-containment query, and Marten serializes that payload — a `Dictionary<string, object>` of member
-names to the values you compared against — through *your* serializer. A source-generated resolver
-does not carry Marten's own shapes, so it throws before the query is ever sent.
-
-Until Marten writes that payload itself ([#5374](https://github.com/JasperFx/marten/issues/5374)),
-declare the shapes on your context, including every enum a filter like this compares:
-
-```csharp
-[JsonSerializable(typeof(object[]))]
-[JsonSerializable(typeof(Dictionary<string, object>))]
-[JsonSerializable(typeof(DebtorType))]
-public partial class MyJsonContext: JsonSerializerContext;
-```
+containment query, and Marten used to serialize that payload — its own dictionary of member names to the
+values you compared against — through *your* serializer. A source-generated resolver carries your
+documents, not that, so the query threw before it was ever sent. Marten now writes the payload itself.
 
 ### Secondary store throws `MissingMethodException` at boot
 

--- a/src/CoreTests/Bug_5374_containment_payload_json.cs
+++ b/src/CoreTests/Bug_5374_containment_payload_json.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Marten.Linq;
+using MartenSystemTextJsonSerializer = Marten.Services.SystemTextJsonSerializer;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace CoreTests;
+
+// #5374: a filter over a child collection handed its jsonb payload — Marten's own dictionary of member
+// names to compared values — to the store's serializer, which under Native AOT is a source-generated
+// resolver that carries the consumer's documents and nothing else. JsonbPayload writes that shape
+// itself, so the query no longer depends on the consumer having declared object[], the dictionary, or
+// the enum it compares.
+//
+// A payload that differs from what the serializer wrote by one character matches nothing and reports it
+// as "no rows", so every test here is the same assertion: byte-identical to the old path.
+public class Bug_5374_containment_payload_json
+{
+    public enum Soort
+    {
+        Huisarts,
+        Apotheek
+    }
+
+    public record Bedrag(decimal Amount, string Currency);
+
+    private static Dictionary<string, object> payload() => new()
+    {
+        ["AgbCode"] = "01059910",
+        ["Naam"] = "Praktijk Jansen & Zonen",
+        ["Soort"] = Soort.Apotheek,
+        ["Actief"] = true,
+        ["Aantal"] = 3,
+        ["Volgnummer"] = 42L,
+        ["Tarief"] = 21.59m,
+        ["Marge"] = 0.5d,
+        ["Id"] = Guid.Parse("6d1a3f8e-5f2a-4f6d-9a7b-0b1c2d3e4f50"),
+        ["Moment"] = new DateTimeOffset(2026, 9, 10, 12, 30, 0, TimeSpan.FromHours(2)),
+        ["Gewijzigd"] = new DateTime(2026, 9, 10, 12, 30, 0, DateTimeKind.Utc),
+        ["Peildatum"] = new DateOnly(2026, 9, 10),
+        ["Aanvang"] = new TimeOnly(12, 30, 15),
+        ["Ontbreekt"] = null,
+        // How a query against a dictionary member renders: the nested dictionary is typed, not
+        // Dictionary<string, object>, and it is still a JSON object rather than a list of pairs.
+        ["Kenmerken"] = new Dictionary<string, string> { ["kleur"] = "blauw", ["maat"] = "L" },
+        ["Aantallen"] = new Dictionary<int, string> { [1] = "een" },
+        ["PerSoort"] = new Dictionary<Soort, decimal> { [Soort.Apotheek] = 21.59m },
+        ["Regels"] = new object[]
+        {
+            new Dictionary<string, object> { ["Prestatiecode"] = "12000", ["Soort"] = Soort.Huisarts }
+        }
+    };
+
+    [Theory]
+    [InlineData(Casing.Default, EnumStorage.AsInteger)]
+    [InlineData(Casing.Default, EnumStorage.AsString)]
+    [InlineData(Casing.CamelCase, EnumStorage.AsInteger)]
+    [InlineData(Casing.CamelCase, EnumStorage.AsString)]
+    [InlineData(Casing.SnakeCase, EnumStorage.AsString)]
+    public void writes_what_system_text_json_wrote(Casing casing, EnumStorage enumStorage)
+    {
+        var serializer = new MartenSystemTextJsonSerializer { Casing = casing, EnumStorage = enumStorage };
+
+        JsonbPayload.ToJson(serializer, payload())
+            .ShouldBe(serializer.ToCleanJson(payload()));
+    }
+
+    // The array wrapper is how ContainmentWhereFilter renders a filter over a child collection, which is
+    // the shape the issue was reported against.
+    [Fact]
+    public void writes_what_system_text_json_wrote_for_a_collection_usage()
+    {
+        var serializer = new MartenSystemTextJsonSerializer { EnumStorage = EnumStorage.AsString };
+
+        JsonbPayload.ToJson(serializer, new object[] { payload() })
+            .ShouldBe(serializer.ToCleanJson(new object[] { payload() }));
+    }
+
+    // A renamed member is the one enum shape where the member's own name is the wrong answer.
+    [Fact]
+    public void writes_what_system_text_json_wrote_for_a_renamed_enum_member()
+    {
+        var serializer = new MartenSystemTextJsonSerializer { EnumStorage = EnumStorage.AsString };
+        var data = new Dictionary<string, object> { ["Soort"] = Hernoemd.Apotheek };
+
+        JsonbPayload.ToJson(serializer, data).ShouldBe(serializer.ToCleanJson(data));
+    }
+
+    // Newtonsoft is the other serializer this payload can be written with, and there the two differ by
+    // escaping alone - System.Text.Json's encoder escapes an ampersand where Newtonsoft leaves it. That
+    // cannot change a result: Postgres parses the parameter into jsonb, where the two are one character.
+    [Fact]
+    public void writes_what_newtonsoft_wrote_apart_from_escaping()
+    {
+        var serializer = new Marten.Services.JsonNetSerializer { EnumStorage = EnumStorage.AsString };
+
+        JsonNode.DeepEquals(
+                JsonNode.Parse(JsonbPayload.ToJson(serializer, payload())),
+                JsonNode.Parse(serializer.ToCleanJson(payload())))
+            .ShouldBeTrue();
+    }
+
+    public enum Hernoemd
+    {
+        Huisarts,
+
+        [JsonStringEnumMemberName("apotheek-houdend")]
+        Apotheek
+    }
+
+    // A value the writer does not render itself falls through to the serializer, which is the only thing
+    // that knows about a converter the consumer registered.
+    [Fact]
+    public void writes_what_system_text_json_wrote_for_a_document_typed_value()
+    {
+        var serializer = new MartenSystemTextJsonSerializer { Casing = Casing.CamelCase };
+        var data = new Dictionary<string, object> { ["Bedrag"] = new Bedrag(21.59m, "EUR") };
+
+        JsonbPayload.ToJson(serializer, data).ShouldBe(serializer.ToCleanJson(data));
+    }
+}

--- a/src/Marten.AotRuntimeSmoke/Program.cs
+++ b/src/Marten.AotRuntimeSmoke/Program.cs
@@ -20,6 +20,9 @@
 //   live aggregation      Projections.LiveStreamAggregation<T>() closed SingleStreamProjection<,>
 //                         on an identity type only known at runtime, and validating it closed
 //                         DocumentMappingBuilder<> over the aggregate.
+//   child collection      a containment filter serialized its jsonb payload through the consumer's
+//                         source-generated resolver, which carries documents and not object[],
+//                         Dictionary<string, object> or the enum being compared (#5374).
 //
 // Exits non-zero with the offending stack trace on the first failure, so CI reports the
 // specific read path that regressed.
@@ -71,7 +74,8 @@ try
         writing.Store(new Praktijk
         {
             Id = id, AgbCode = "01059910", Naam = "Praktijk Jansen", Soort = Soort.Huisarts,
-            OptioneleSoort = Soort.Huisarts
+            OptioneleSoort = Soort.Huisarts,
+            Regels = [new Regel { Prestatiecode = "12000", Soort = Soort.Huisarts }]
         });
         writing.Store(new Praktijk
         {
@@ -174,6 +178,25 @@ try
         var events = await session.Events.QueryAllRawEvents().ToListAsync();
         return events.Count == 2 && events[0].StreamKey == "dossier-1";
     });
+
+    // #5374 — a filter over a child collection is a jsonb containment query, and its payload is
+    // Marten's own dictionary rather than a document the consumer's resolver knows.
+    await Check("child collection filter", async () =>
+    {
+        var prestatiecode = "12000";
+        var found = await session.Query<Praktijk>()
+            .Where(x => x.Regels.Any(r => r.Prestatiecode == prestatiecode)).ToListAsync();
+        return found.Count == 1;
+    });
+
+    await Check("child collection filter over an enum", async () =>
+    {
+        var soort = Soort.Huisarts;
+        var found = await session.Query<Praktijk>()
+            .Where(x => x.Regels.Any(r => r.Soort == soort)).ToListAsync();
+        return found.Count == 1;
+    });
+
 }
 catch (Exception e)
 {
@@ -219,6 +242,13 @@ public class Praktijk
     public string Naam { get; set; } = "";
     public Soort Soort { get; set; }
     public Soort? OptioneleSoort { get; set; }
+    public List<Regel> Regels { get; set; } = [];
+}
+
+public class Regel
+{
+    public string Prestatiecode { get; set; } = "";
+    public Soort Soort { get; set; }
 }
 
 public enum Soort

--- a/src/Marten/Linq/JsonbPayload.cs
+++ b/src/Marten/Linq/JsonbPayload.cs
@@ -1,0 +1,173 @@
+#nullable enable
+using System;
+using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+
+namespace Marten.Linq;
+
+/// <summary>
+///     Writes the jsonb payload of a containment or JSONPath filter: Marten's own dictionary of member
+///     names to the values a query compared against.
+/// </summary>
+/// <remarks>
+///     <para>
+///     Handing that dictionary to the store's serializer is what #5374 was. Under Native AOT the resolver
+///     is a source-generated <c>JsonSerializerContext</c> — what the AOT guide asks for — and it carries
+///     the consumer's documents, not <c>object[]</c>, not the dictionary, and not whichever enum a filter
+///     happens to compare. An ordinary <c>.Any(x =&gt; x.Member == value)</c> therefore threw before the
+///     query was ever sent. The shape is ours, so we write it; only a value we cannot render identically
+///     goes through the serializer, and that is a document type the consumer has already declared.
+///     </para>
+///     <para>
+///     Every branch here has to emit what the serializer emitted, and <c>Bug_5374_containment_payload_json</c>
+///     asserts exactly that, because a payload that differs by one character silently matches nothing.
+///     Two properties of the serializer's options matter and both are honoured: the naming policy is a
+///     <em>property</em> policy and Marten never sets <c>DictionaryKeyPolicy</c>, so these keys are written
+///     verbatim, and any value with a converter of its own — an enum included — goes back through the
+///     serializer. A custom
+///     <c>JavaScriptEncoder</c> is the one thing not carried across, and it cannot matter: Postgres parses
+///     the payload into jsonb, where an escaped and an unescaped character are the same character.
+///     </para>
+/// </remarks>
+internal static class JsonbPayload
+{
+    public static string ToJson(ISerializer serializer, object? payload)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            write(writer, serializer, payload);
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    private static void write(Utf8JsonWriter writer, ISerializer serializer, object? value)
+    {
+        switch (value)
+        {
+            case null:
+                writer.WriteNullValue();
+                return;
+
+            // The payload's own shape, and a nested Dictionary<TKey, TValue> where a query filtered a
+            // dictionary member.
+            case IDictionary dictionary:
+                writer.WriteStartObject();
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    writer.WritePropertyName(key(entry.Key));
+                    write(writer, serializer, entry.Value);
+                }
+
+                writer.WriteEndObject();
+                return;
+
+            case string text:
+                writer.WriteStringValue(text);
+                return;
+
+            case bool flag:
+                writer.WriteBooleanValue(flag);
+                return;
+
+            case int number:
+                writer.WriteNumberValue(number);
+                return;
+
+            case long number:
+                writer.WriteNumberValue(number);
+                return;
+
+            case short number:
+                writer.WriteNumberValue(number);
+                return;
+
+            case byte number:
+                writer.WriteNumberValue(number);
+                return;
+
+            case sbyte number:
+                writer.WriteNumberValue(number);
+                return;
+
+            case uint number:
+                writer.WriteNumberValue(number);
+                return;
+
+            case ulong number:
+                writer.WriteNumberValue(number);
+                return;
+
+            case ushort number:
+                writer.WriteNumberValue(number);
+                return;
+
+            case decimal number:
+                writer.WriteNumberValue(number);
+                return;
+
+            case double number:
+                writer.WriteNumberValue(number);
+                return;
+
+            case float number:
+                writer.WriteNumberValue(number);
+                return;
+
+            case Guid guid:
+                writer.WriteStringValue(guid);
+                return;
+
+            case DateTimeOffset timestamp:
+                writer.WriteStringValue(timestamp);
+                return;
+
+            case DateTime timestamp:
+                writer.WriteStringValue(timestamp);
+                return;
+
+            // "O" is what System.Text.Json writes for a date; a time is not here because its converter
+            // trims the fractional part and the serializer should keep owning that.
+            case DateOnly date:
+                writer.WriteStringValue(date.ToString("O", CultureInfo.InvariantCulture));
+                return;
+
+            // object[] is how a filter over a child collection wraps its dictionary, and a value
+            // collection arrives as whatever list the query held.
+            case IEnumerable enumerable:
+                writer.WriteStartArray();
+                foreach (var item in enumerable)
+                {
+                    write(writer, serializer, item);
+                }
+
+                writer.WriteEndArray();
+                return;
+
+            default:
+                // An enum, a record, a value object, anything carrying its own converter: the serializer
+                // is the only thing that knows how the document was written with it, and it is a type the
+                // consumer's resolver has because it is part of a document. An enum in particular cannot
+                // be rendered from its member name — [JsonStringEnumMemberName] renames it, and the
+                // attribute is not there to be read from a trimmed binary.
+                writer.WriteRawValue(serializer.ToCleanJson(value));
+                return;
+        }
+    }
+
+    /// <summary>A dictionary key is a JSON property name, and System.Text.Json renders a non-string key
+    /// as its invariant text. An enum key is its member name whatever <see cref="ISerializer.EnumStorage" />
+    /// says — that setting is about values, and a key has its own converter.</summary>
+    private static string key(object value) => value switch
+    {
+        string text => text,
+        Enum => value.ToString()!,
+        _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty
+    };
+}

--- a/src/Marten/Linq/Members/ChildCollectionJsonPathCountFilter.cs
+++ b/src/Marten/Linq/Members/ChildCollectionJsonPathCountFilter.cs
@@ -62,7 +62,7 @@ internal class ChildCollectionJsonPathCount: ISqlFragment, ICompiledQueryAwareFi
         else
         {
             builder.Append(")', ");
-            builder.AppendParameter(_serializer.ToCleanJson(_dict), NpgsqlDbType.Jsonb);
+            builder.AppendParameter(JsonbPayload.ToJson(_serializer, _dict), NpgsqlDbType.Jsonb);
             ParameterName = builder.LastParameterName!;
 
             builder.Append(")) ");
@@ -97,7 +97,7 @@ internal class ChildCollectionJsonPathCount: ISqlFragment, ICompiledQueryAwareFi
         {
             var payload = CompiledQueryDictionaryBuilder.Build(dictRef(), usagesRef(), query, default);
             parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
-            parameter.Value = payload is null ? DBNull.Value : serializer.ToCleanJson(payload);
+            parameter.Value = payload is null ? DBNull.Value : JsonbPayload.ToJson(serializer, payload);
         };
     }
 

--- a/src/Marten/Linq/SqlGeneration/Filters/ContainmentWhereFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/ContainmentWhereFilter.cs
@@ -133,8 +133,8 @@ public class ContainmentWhereFilter: ICollectionAwareFilter, ICollectionAware, I
     public void Apply(ICommandBuilder builder)
     {
         var json = Usage == ContainmentUsage.Singular
-            ? _serializer.ToCleanJson(_data)
-            : _serializer.ToCleanJson(new object[] { _data });
+            ? JsonbPayload.ToJson(_serializer, _data)
+            : JsonbPayload.ToJson(_serializer, new object[] { _data });
 
         if (IsNot)
         {
@@ -200,7 +200,7 @@ public class ContainmentWhereFilter: ICollectionAwareFilter, ICollectionAware, I
             var dict = CompiledQueryDictionaryBuilder.Build(data, usages, query);
             var payload = wrapInArray ? (object)new object[] { dict } : dict;
             parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
-            parameter.Value = serializer.ToCleanJson(payload);
+            parameter.Value = JsonbPayload.ToJson(serializer, payload);
         };
     }
 

--- a/src/Marten/Linq/SqlGeneration/Filters/JsonPathExistsFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/JsonPathExistsFilter.cs
@@ -174,7 +174,7 @@ internal class JsonPathExistsFilter: ISqlFragment, ICollectionAwareFilter, IComp
         if (_dict.Count > 0)
         {
             builder.Append(", ");
-            builder.AppendParameter(_serializer.ToCleanJson(_dict), NpgsqlDbType.Jsonb);
+            builder.AppendParameter(JsonbPayload.ToJson(_serializer, _dict), NpgsqlDbType.Jsonb);
             ParameterName = builder.LastParameterName;
         }
 
@@ -351,7 +351,7 @@ internal class JsonPathExistsFilter: ISqlFragment, ICollectionAwareFilter, IComp
         {
             var payload = CompiledQueryDictionaryBuilder.Build(dictRef(), usagesRef(), query, default);
             parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
-            parameter.Value = payload is null ? DBNull.Value : (object)serializer.ToCleanJson(payload);
+            parameter.Value = payload is null ? DBNull.Value : JsonbPayload.ToJson(serializer, payload);
         };
     }
 


### PR DESCRIPTION
Fixes #5374.

A filter over a child collection compiles to a jsonb containment query, and Marten serialized that query's payload through the store's serializer:

```csharp
// ContainmentWhereFilter.Apply
var json = Usage == ContainmentUsage.Singular
    ? _serializer.ToCleanJson(_data)
    : _serializer.ToCleanJson(new object[] { _data });
```

`_data` is Marten's own `Dictionary<string, object>` of member names to compared values. Under Native AOT the serializer's resolver is a source-generated `JsonSerializerContext` — what the AOT guide asks for — and it carries the consumer's documents, not that dictionary, not the `object[]` wrapper, and not whichever enum the filter compares. So an ordinary `.Any(...)` threw before the query was ever sent:

```text
NotSupportedException: JsonTypeInfo metadata for type 'System.Object[]' was not provided by
TypeInfoResolver of type 'MyApp.MyJsonContext'.
```

`JsonbPayload` writes that shape instead — the dictionary, the array wrapper, the scalars whose rendering is fixed — and hands anything with a converter of its own (an enum, a record, a value object) back to the serializer, which is the only thing that knows how the document was written with it and which has the type because it is part of a document. Six call sites move over: `ContainmentWhereFilter`, `JsonPathExistsFilter` and `ChildCollectionJsonPathCountFilter`, each in both its `Apply` and its compiled-query setter.

## Why this is safe to swap under an existing query surface

A payload that differs by one character matches nothing and reports it as "no rows", so the test is byte equality with the old path: `Bug_5374_containment_payload_json` asserts `JsonbPayload.ToJson(serializer, payload) == serializer.ToCleanJson(payload)` across `Casing` × `EnumStorage`, over a payload holding a nested typed dictionary, an `int`-keyed and an enum-keyed one, `DateOnly`, `DateTimeOffset`, decimals, a null and a record.

Two behaviours came out of writing those assertions rather than out of reading the code, and both are in the writer now:

- A nested dictionary is `Dictionary<TKey, TValue>`, not `Dictionary<string, object>` — that is what `DictionaryMember.PlaceValueInDictionaryForContainment` puts there. An earlier cut matched only the latter, so a `Dictionary<string, string>` fell into the array branch and came out as a list of pairs. `LinqTests` caught it (`x => x.StringDict.Contains(kvp)`), which is why the `IDictionary` branch is now the general one.
- An **enum dictionary key** is written as its member name whatever `EnumStorage` says, because that setting is about values and a key has its own converter. `TimeOnly` went back to the serializer for the mirror-image reason: its converter trims the fractional part.

Against Newtonsoft the two differ by escaping alone — System.Text.Json's encoder escapes an ampersand where Newtonsoft leaves it — and that cannot change a result: Postgres parses the parameter into jsonb, where the two are one character. The test states it that way, with `JsonNode.DeepEquals`.

## Coverage

`Marten.AotRuntimeSmoke` gains the query from the issue plus one over an enum. On master both fail with the `object[]` stack; here:

```text
OK   child collection filter
OK   child collection filter over an enum
Marten AOT runtime smoke OK — every document and event read path ran from a native binary.
```

`LinqTests` is green on net10.0 (1481 passed), as is the new `CoreTests` class.

## Not in scope

While testing the enum branch I found something that is not an AOT problem at all: with `EnumStorage.AsString`, a query comparing an enum member renamed with `[JsonStringEnumMemberName]` silently matches nothing, under a JIT as much as under AOT, because `EnumAsStringMember.CreateComparison` renders the value with `Enum.GetName`. Filed separately as #5376 — the fix wants a small `ISerializer` addition, and that interface is yours to decide on rather than mine.
