### PR TITLE
EnumStorage.AsString: ask the serializer for the member name, so a renamed enum member can be queried

### DIFF
--- a/src/CoreTests/Bug_5376_renamed_enum_member.cs
+++ b/src/CoreTests/Bug_5376_renamed_enum_member.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace CoreTests;
+
+// #5376: with EnumStorage.AsString a query rendered the enum with Enum.GetName, which is the declared
+// name. System.Text.Json stores the name from [JsonStringEnumMemberName], so a filter comparing a
+// renamed member matched nothing at all — and said so as "no rows" rather than as an error.
+public class Bug_5376_renamed_enum_member: OneOffConfigurationsContext
+{
+    public enum Zorgvorm
+    {
+        Huisarts,
+
+        [JsonStringEnumMemberName("apotheek-houdend")]
+        Apotheek
+    }
+
+    public class Aanlevering
+    {
+        public Guid Id { get; set; }
+        public Zorgvorm Zorgvorm { get; set; }
+    }
+
+    [Fact]
+    public async Task can_be_found_by_the_member_it_was_stored_as()
+    {
+        StoreOptions(opts =>
+        {
+            opts.UseSystemTextJsonForSerialization(EnumStorage.AsString);
+            opts.Schema.For<Aanlevering>();
+        });
+
+        var id = Guid.NewGuid();
+        theSession.Store(new Aanlevering { Id = id, Zorgvorm = Zorgvorm.Apotheek });
+        await theSession.SaveChangesAsync();
+
+        (await theSession.Json.FindByIdAsync<Aanlevering>(id)).ShouldContain("apotheek-houdend");
+
+        var found = await theSession.Query<Aanlevering>().Where(x => x.Zorgvorm == Zorgvorm.Apotheek).ToListAsync();
+
+        found.ShouldHaveSingleItem().Id.ShouldBe(id);
+    }
+
+    // A duplicated column is written by the document storage rather than by the serializer, so it holds
+    // the declared name - and a query against it has to keep comparing against that, or the column and
+    // the query stop agreeing. The body and the column disagreeing for a renamed member is a wider
+    // change than this one, and it belongs with whatever writes the column.
+    [Fact]
+    public async Task a_duplicated_column_keeps_comparing_against_the_declared_name()
+    {
+        StoreOptions(opts =>
+        {
+            opts.UseSystemTextJsonForSerialization(EnumStorage.AsString);
+            opts.Schema.For<Aanlevering>().Duplicate(x => x.Zorgvorm);
+        });
+
+        var id = Guid.NewGuid();
+        theSession.Store(new Aanlevering { Id = id, Zorgvorm = Zorgvorm.Apotheek });
+        await theSession.SaveChangesAsync();
+
+        var found = await theSession.Query<Aanlevering>().Where(x => x.Zorgvorm == Zorgvorm.Apotheek).ToListAsync();
+
+        found.ShouldHaveSingleItem().Id.ShouldBe(id);
+    }
+}

--- a/src/Marten.AotRuntimeSmoke/Program.cs
+++ b/src/Marten.AotRuntimeSmoke/Program.cs
@@ -17,6 +17,10 @@
 //   event read            EventColumnReaders.BuildAsync closed BuildAsyncImpl<T> with
 //                         MethodInfo.MakeGenericMethod, so the first event any read brought back
 //                         threw - every AggregateStreamAsync, FetchForWriting and projection.
+//   renamed enum          a query rendered the value with Enum.GetName, which is the declared name and
+//                         not what the serializer stored for a [JsonStringEnumMemberName] member. It
+//                         now asks the serializer - and asking reflection instead would pass here and
+//                         fail from a trimmed binary, which is the whole point of this project (#5376).
 //   live aggregation      Projections.LiveStreamAggregation<T>() closed SingleStreamProjection<,>
 //                         on an identity type only known at runtime, and validating it closed
 //                         DocumentMappingBuilder<> over the aggregate.
@@ -161,6 +165,8 @@ try
         return found.Count() == 1;
     });
 
+    await CheckRenamedEnumMemberAsync();
+
     // Reading an event is a separate path from reading a document: the events table hands its
     // columns to the event through reader delegates of its own.
     await Check("event stream read + live aggregation", async () =>
@@ -190,6 +196,39 @@ if (failures > 0)
 
 Console.WriteLine("Marten AOT runtime smoke OK — every document and event read path ran from a native binary.");
 return 0;
+
+// A store of its own, because the renamed member only differs from its declared name when enums are
+// stored as strings.
+async Task CheckRenamedEnumMemberAsync()
+{
+    await using var store = DocumentStore.For(o =>
+    {
+        o.Connection(connection);
+        o.UseSystemTextJsonForSerialization(EnumStorage.AsString,
+            configure: json => json.TypeInfoResolver = SmokeJson.Default);
+        o.AutoCreateSchemaObjects = AutoCreate.All;
+        o.DatabaseSchemaName = "aot_runtime_smoke_strings";
+        o.Schema.For<Aanlevering>();
+    });
+
+    await store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Aanlevering));
+
+    var id = Guid.NewGuid();
+
+    await using (var writing = store.LightweightSession())
+    {
+        writing.Store(new Aanlevering { Id = id, Zorgvorm = Zorgvorm.Apotheek });
+        await writing.SaveChangesAsync();
+    }
+
+    await using var session = store.QuerySession();
+
+    await Check("query a renamed enum member", async () =>
+    {
+        var found = await session.Query<Aanlevering>().Where(x => x.Zorgvorm == Zorgvorm.Apotheek).ToListAsync();
+        return found.Count == 1 && found[0].Id == id;
+    });
+}
 
 async Task Check(string description, Func<Task<bool>> check)
 {
@@ -250,7 +289,22 @@ public record DossierGeopend(string Nummer, string Naam);
 
 public record RegelToegevoegd(string Prestatiecode);
 
+public class Aanlevering
+{
+    public Guid Id { get; set; }
+    public Zorgvorm Zorgvorm { get; set; }
+}
+
+public enum Zorgvorm
+{
+    Huisarts,
+
+    [JsonStringEnumMemberName("apotheek-houdend")]
+    Apotheek
+}
+
 [JsonSerializable(typeof(Praktijk))]
+[JsonSerializable(typeof(Aanlevering))]
 [JsonSerializable(typeof(Dossier))]
 [JsonSerializable(typeof(DossierGeopend))]
 [JsonSerializable(typeof(RegelToegevoegd))]

--- a/src/Marten/Linq/Members/EnumAsStringMember.cs
+++ b/src/Marten/Linq/Members/EnumAsStringMember.cs
@@ -12,8 +12,13 @@ namespace Marten.Linq.Members;
 
 public class EnumAsStringMember: QueryableMember, IComparableMember
 {
-    public EnumAsStringMember(IQueryableMember parent, Casing casing, MemberInfo member): base(parent, casing, member)
+    private readonly ISerializer? _serializer;
+
+    public EnumAsStringMember(IQueryableMember parent, Casing casing, MemberInfo member,
+        ISerializer? serializer = null): base(parent, casing, member)
     {
+        _serializer = serializer;
+
         if (!MemberType.IsEnum)
         {
             throw new ArgumentOutOfRangeException(nameof(member), "Not an Enum type");
@@ -33,7 +38,11 @@ public class EnumAsStringMember: QueryableMember, IComparableMember
             };
         }
 
-        var stringValue = Enum.GetName(MemberType, constant.Value)!;
+        // The name the serializer stored, not the declared one: they differ as soon as the member was
+        // renamed with [JsonStringEnumMemberName] or [EnumMember] (#5376).
+        var stringValue = _serializer is null
+            ? Enum.GetName(MemberType, constant.Value)!
+            : EnumMemberNames.Of(_serializer, MemberType, constant.Value);
         return new MemberComparisonFilter(this, new CommandParameter(stringValue, NpgsqlDbType.Varchar), op);
     }
 

--- a/src/Marten/Linq/Members/EnumMemberNames.cs
+++ b/src/Marten/Linq/Members/EnumMemberNames.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+
+namespace Marten.Linq.Members;
+
+/// <summary>
+///     What the serializer calls an enum member when it stores it as a string.
+/// </summary>
+/// <remarks>
+///     <para>
+///     A query used to render the value with <c>Enum.GetName</c>, which is the member's declared name.
+///     That is the stored name only until somebody renames the member: System.Text.Json honours
+///     <c>[JsonStringEnumMemberName]</c> and Newtonsoft honours <c>[EnumMember]</c>, and a filter
+///     comparing a renamed member against its declared name matches nothing and reports it as no rows
+///     (#5376).
+///     </para>
+///     <para>
+///     The value can arrive as the enum or as its underlying integer — the C# compiler emits
+///     <c>Convert(x.Member, Int32) == 1</c> for a comparison against a literal — so it is converted back
+///     to the enum before the serializer is asked. The answer is cached per member.
+///     </para>
+///     <para>
+///     Reflection over the enum's fields is the obvious alternative and it is a trap: it agrees under a
+///     JIT and returns the declared name from a trimmed Native AOT binary, where the source-generated
+///     converter has the renamed one baked in. <c>Marten.AotRuntimeSmoke</c> is where that is proven.
+///     </para>
+/// </remarks>
+internal static class EnumMemberNames
+{
+    private static readonly ConcurrentDictionary<(Type, string), string> _names = new();
+
+    public static string Of(ISerializer serializer, Type enumType, object value)
+    {
+        var member = Enum.ToObject(enumType, value);
+
+        return _names.GetOrAdd((enumType, member.ToString()!),
+            _ => serializer.ToCleanJson(member).Trim('"'));
+    }
+}

--- a/src/Marten/StoreOptions.MemberFactory.cs
+++ b/src/Marten/StoreOptions.MemberFactory.cs
@@ -68,7 +68,7 @@ public partial class StoreOptions
         {
             return serializer.EnumStorage == Weasel.Core.EnumStorage.AsInteger
                 ? new EnumAsIntegerMember(parent, serializer.Casing, member)
-                : new EnumAsStringMember(parent, serializer.Casing, member);
+                : new EnumAsStringMember(parent, serializer.Casing, member, serializer);
         }
 
         if (memberType == typeof(DateTime) || memberType == FSharpTypeHelper.MakeFSharpOptionType(typeof(DateTime)))


### PR DESCRIPTION
Fixes #5376.

With `EnumStorage.AsString`, a query comparing an enum member renamed with `[JsonStringEnumMemberName]` (or `[EnumMember]` on Newtonsoft) matched nothing. No exception — zero rows, which reads as "no such data":

```csharp
// stored: {"Id": "...", "Zorgvorm": "apotheek-houdend"}
await session.Query<Aanlevering>().Where(x => x.Zorgvorm == Zorgvorm.Apotheek).ToListAsync();
// 0 rows, because the filter went looking for "Apotheek"
```

`EnumAsStringMember.CreateComparison` rendered the value with `Enum.GetName`, and that is the declared name. The serializer is the only component that knows what it actually wrote, so it is now the one asked, through a small cache (`EnumMemberNames`) so it is asked once per member.

Two things worth flagging, because neither is visible from reading the code:

- **The value arrives as the underlying integer as often as the enum.** The C# compiler emits `Convert(x.Member, Int32) == 1` for a comparison against a literal, and `Enum.GetName` happily takes that int. My first cut handed the serializer the boxed `1` and produced `"1"`, which matched nothing at all — the existing `enum_usage` tests caught it. Hence the `Enum.ToObject` before asking.
- **Reflection over the enum's fields is the wrong tool**, though it looks like the obvious one. `field.GetCustomAttribute<JsonStringEnumMemberNameAttribute>()` agrees with the serializer under a JIT and returns *nothing* from a trimmed Native AOT binary, so the query would silently go back to the declared name in exactly the deployment where it is hardest to see. Measured, not assumed: a boxed `JsonSerializer.Serialize<object>(renamed, options)` returns `"apotheek-houdend"` from a native binary while the attribute lookup finds no attribute there.

`Marten.AotRuntimeSmoke` gains the query for that reason. It fails there without this change ("ran, but returned the wrong result") and passes with it.

## Deliberately not in scope: the duplicated column

A duplicated column is written by the document storage, not by the serializer, and it holds the **declared** name. So a query against a duplicated field has to keep comparing against the declared name — changing `DuplicatedField` to match the body would have broken the column, which is why the second test in this PR pins today's behaviour rather than "fixing" it.

That the column and the JSON body disagree for a renamed member is a real inconsistency, and a wider change than this one: it belongs where the column is written. Happy to follow up if you want it, but it is a storage change and not a LINQ one.

## Tests

`LinqTests` green on net10.0 (1481 passed), including the `enum_usage` set that caught the first cut, plus the two new `CoreTests` cases and the native smoke.
