### PR TITLE
Seed the expected version from a mapped version/revision member (supersedes #5372)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -637,7 +637,7 @@
     <PackageVersion Include="Vogen" Version="7.0.0" />
     <!-- 9.16.2: the hold at 9.2.1 (were newer builds actually being published?) is resolved —
          Weasel.EntityFrameworkCore is on nuget.org, so it tracks the rest of the Weasel line. -->
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.31.1" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.32.0" />
     <!-- Weasel.Postgresql 9.1.x: managed LIST partitions under multi-database (sharded) apply.
          9.1.2 (marten#4706): managed-partition tables are no longer destructively rebuilt — the
          out-of-band AddPartitionToAllTables path creates partitions while the generic schema diff
@@ -825,8 +825,18 @@
          only this bump. Bug_5364_concurrent_apply_partition_race is RED on 9.31.0 and GREEN here.
          The same pass covers Weasel.SqlServer's ManagedTenantPartitions, which had the identical
          shape, so Polecat gets it too. -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.31.1" />
-    <PackageVersion Include="Weasel.Storage" Version="9.31.1" />
+    <!-- 9.32.0 (weasel#592, closing weasel#590 and weasel#591, raised from marten#5372 and
+         marten#5376): two additive seams, both defaulting to the previous behaviour, so this bump
+         changes nothing until Marten adopts them. IDocumentStorage&lt;T&gt; gains MappedVersionFor /
+         MappedRevisionFor as default interface members, letting a session seed the expected version
+         off a Metadata.Version.MapTo(...) member through virtual dispatch rather than a runtime type
+         test on the storage; a decorator that forwards is then correct by construction, and one that
+         does not cannot silently answer for its inner storage. EnumIsOneOfWhereFragment and
+         EnumIsNotOneOfWhereFragment gain an optional stored-name renderer, because both rendered an
+         enum value with ToString(), which is the declared member name and stops being the stored name
+         as soon as the member is renamed with [JsonStringEnumMemberName] or [EnumMember]. -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.32.0" />
+    <PackageVersion Include="Weasel.Storage" Version="9.32.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <!-- The whole test suite is on xunit v3. VSTest stays the execution mode, so the
          Nuke targets and the GitHub workflows are unaffected. -->

--- a/src/CoreTests/Storage/Identification/closed_shape_optimistic_concurrency_mapped_member_tests.cs
+++ b/src/CoreTests/Storage/Identification/closed_shape_optimistic_concurrency_mapped_member_tests.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Metadata;
+using Marten.Services;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests.Storage.Identification;
+
+/// <summary>
+/// #5372, reported by JurJean, whose reproduction and the first four tests below this project
+/// adopts verbatim.
+///
+/// The documented contract for a mapped version member —
+/// Metadata(m => m.Version.MapTo(x => x.Etag)) on a UseOptimisticConcurrency(true) document
+/// (docs/documents/metadata.md) — is that Store() carries the version number on the document
+/// itself, i.e. the mapped member behaves exactly like the IVersioned marker interface.
+///
+/// It did not. storeEntity() seeded the session's expected version only from the marker
+/// interfaces, so a mapped member was invisible: the upsert bound DBNull into its
+/// ON CONFLICT ... WHERE mt_version = ? guard, no RETURNING row came back, and every
+/// cross-session write of such a document was reported as a ConcurrencyException.
+/// </summary>
+public class closed_shape_optimistic_concurrency_mapped_member_tests: BugIntegrationContext
+{
+    private DocumentStore mappedMemberStore()
+        => StoreOptions(opts =>
+        {
+            opts.Schema.For<MappedVersionDoc>().UseOptimisticConcurrency(true)
+                .Metadata(m => m.Version.MapTo(x => x.Etag));
+        });
+
+    private DocumentStore markerInterfaceStore()
+        => StoreOptions(opts =>
+        {
+            opts.Schema.For<MarkerVersionedDoc>().UseOptimisticConcurrency(true);
+        });
+
+    [Fact]
+    public async Task mapped_version_member_should_be_used_as_the_expected_version_on_store()
+    {
+        var store = mappedMemberStore();
+
+        var doc = new MappedVersionDoc { Name = "v1" };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        // The mapped member received the version Marten wrote
+        doc.Etag.ShouldNotBe(Guid.Empty);
+
+        // Re-storing the SAME entity in a fresh session must not be a blind
+        // write: the mapped member carries the expected version.
+        await using (var session = store.LightweightSession())
+        {
+            doc.Name = "v2";
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<MappedVersionDoc>(doc.Id))!.Name.ShouldBe("v2");
+    }
+
+    [Fact]
+    public async Task stale_mapped_version_member_is_rejected()
+    {
+        var store = mappedMemberStore();
+
+        var doc = new MappedVersionDoc { Name = "v1" };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        await using var session2 = store.LightweightSession();
+        doc.Etag = Guid.NewGuid(); // a version that never existed on the row
+        session2.Store(doc);
+        await Should.ThrowAsync<ConcurrencyException>(() => session2.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task mapped_version_member_of_empty_guid_is_rejected_like_a_blind_write()
+    {
+        var store = mappedMemberStore();
+
+        var id = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new MappedVersionDoc { Id = id, Name = "v1" });
+            await session.SaveChangesAsync();
+        }
+
+        // No version on the document = no expected version = rejected, exactly
+        // like the unversioned blind write case
+        await using var session2 = store.LightweightSession();
+        session2.Store(new MappedVersionDoc { Id = id, Name = "blind-write" });
+        await Should.ThrowAsync<ConcurrencyException>(() => session2.SaveChangesAsync());
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<MappedVersionDoc>(id))!.Name.ShouldBe("v1");
+    }
+
+    [Fact]
+    public async Task marker_interface_version_round_trips_in_a_fresh_session()
+    {
+        // Contrast: the same flow through the IVersioned marker interface worked all along,
+        // because storeEntity() seeds the session's version tracker from the marker interface.
+        // MapTo() members now behave identically.
+        var store = markerInterfaceStore();
+
+        var doc = new MarkerVersionedDoc { Name = "v1" };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        doc.Version.ShouldNotBe(Guid.Empty);
+
+        await using (var session = store.LightweightSession())
+        {
+            doc.Name = "v2";
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<MarkerVersionedDoc>(doc.Id))!.Name.ShouldBe("v2");
+    }
+
+    [Fact]
+    public async Task concurrency_checks_disabled_still_bypasses_the_mapped_member()
+    {
+        // The no-version Store(session, doc) overload is HOW ConcurrencyChecks.Disabled is
+        // implemented (DocumentSessionBase takes that branch deliberately), so seeding from the
+        // mapped member must not reach it. A stale version has to be ignored here.
+        var store = mappedMemberStore();
+
+        var doc = new MappedVersionDoc { Name = "v1" };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        doc.Etag = Guid.NewGuid(); // stale, and deliberately not to be enforced
+        doc.Name = "forced";
+
+        await using (var session =
+                     store.LightweightSession(new SessionOptions { ConcurrencyChecks = ConcurrencyChecks.Disabled }))
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<MappedVersionDoc>(doc.Id))!.Name.ShouldBe("forced");
+    }
+
+    [Fact]
+    public async Task mapped_version_member_on_a_subclass_uses_the_root_storage()
+    {
+        // SubClassDocumentStorage forwards to the root storage, which owns the mapping. The member
+        // is declared on the root type and readable from the subclass instance.
+        var store = StoreOptions(opts =>
+        {
+            opts.Schema.For<MappedVersionRoot>()
+                .AddSubClass<MappedVersionChild>()
+                .UseOptimisticConcurrency(true)
+                .Metadata(m => m.Version.MapTo(x => x.Etag));
+        });
+
+        var doc = new MappedVersionChild { Name = "v1", Extra = "x" };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        doc.Etag.ShouldNotBe(Guid.Empty);
+
+        await using (var session = store.LightweightSession())
+        {
+            doc.Name = "v2";
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<MappedVersionChild>(doc.Id))!.Name.ShouldBe("v2");
+    }
+
+    [Fact]
+    public async Task stale_mapped_version_member_on_a_subclass_is_rejected()
+    {
+        var store = StoreOptions(opts =>
+        {
+            opts.Schema.For<MappedVersionRoot>()
+                .AddSubClass<MappedVersionChild>()
+                .UseOptimisticConcurrency(true)
+                .Metadata(m => m.Version.MapTo(x => x.Etag));
+        });
+
+        var doc = new MappedVersionChild { Name = "v1", Extra = "x" };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        await using var session2 = store.LightweightSession();
+        doc.Etag = Guid.NewGuid();
+        session2.Store(doc);
+        await Should.ThrowAsync<ConcurrencyException>(() => session2.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task mapped_revision_member_round_trips_in_a_fresh_session()
+    {
+        // The numeric-revision sibling of the same seam. The getter is built whenever
+        // Metadata.Revision.Enabled is set, which Revision.MapTo(...) does on its own.
+        var store = StoreOptions(opts =>
+        {
+            opts.Schema.For<MappedRevisionDoc>().UseNumericRevisions(true)
+                .Metadata(m => m.Revision.MapTo(x => x.Rev));
+        });
+
+        var doc = new MappedRevisionDoc { Name = "v1" };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        doc.Rev.ShouldBeGreaterThan(0);
+
+        await using (var session = store.LightweightSession())
+        {
+            doc.Name = "v2";
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        (await query.LoadAsync<MappedRevisionDoc>(doc.Id))!.Name.ShouldBe("v2");
+    }
+}
+
+public class MappedVersionDoc
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = "";
+    public Guid Etag { get; set; }
+}
+
+public class MarkerVersionedDoc: IVersioned
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = "";
+    public Guid Version { get; set; }
+}
+
+public class MappedVersionRoot
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = "";
+    public Guid Etag { get; set; }
+}
+
+public class MappedVersionChild: MappedVersionRoot
+{
+    public string Extra { get; set; } = "";
+}
+
+public class MappedRevisionDoc
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = "";
+    public int Rev { get; set; }
+}

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -517,11 +517,32 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
             case ILongVersioned longVersioned when longVersioned.Version != 0:
                 storage.Store(this, entity, longVersioned.Version);
                 return;
-            default:
-                // Put it in the identity map -- if necessary
-                storage.Store(this, entity);
-                break;
         }
+
+        // #5372: a member mapped with Metadata.Version.MapTo(...) / Metadata.Revision.MapTo(...)
+        // carries the expected version exactly as the marker interfaces above do, but the session
+        // sees the storage only as IDocumentStorage<T>. Weasel 9.32.0 (weasel#590) puts the question
+        // on that interface as a default member returning null, so this is virtual dispatch and not a
+        // type test on the storage: a decorator that forwards is correct by construction, and one
+        // that does not cannot silently answer on behalf of its inner storage.
+        //
+        // The marker cases stay first and keep their exact behaviour. They cannot disagree with the
+        // mapped member anyway -- VersionedPolicy sets Metadata.Version.Member to the interface's own
+        // property -- so this only reaches documents that map a member without implementing a marker.
+        if (storage.MappedVersionFor(entity) is { } mappedVersion && mappedVersion != Guid.Empty)
+        {
+            storage.Store(this, entity, mappedVersion);
+            return;
+        }
+
+        if (storage.MappedRevisionFor(entity) is { } mappedRevision && mappedRevision != 0)
+        {
+            storage.Store(this, entity, mappedRevision);
+            return;
+        }
+
+        // Put it in the identity map -- if necessary
+        storage.Store(this, entity);
     }
 
     public void EjectPatchedTypes(IUnitOfWork changes)

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -103,6 +103,34 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, ILinqDo
         UseOptimisticConcurrency = document.UseOptimisticConcurrency;
         UseNumericRevisions = document.UseNumericRevisions;
 
+        // #5372: build the mapped version / revision accessors here, off the mapping, so the base
+        // retains no DocumentMapping (#4828). The gating mirrors ClosedShapeBulkLoader rather than
+        // the narrower UseNumericRevisions check: Metadata.Revision.Enabled is also set by
+        // Revision.MapTo(...) on its own, and a mapping cannot have both enabled -- they are the
+        // same physical mt_version column, which DocumentMapping.CompileAndValidate enforces.
+        if (document.UseNumericRevisions || document.Metadata.Revision.Enabled)
+        {
+            if (document.Metadata.Revision.Member is { } revisionMember)
+            {
+                // The column is bigint or integer, but the member is int (IRevisioned) or long
+                // (ILongVersioned). Widen an int member the way DocumentRevisionBinder narrows on
+                // the way back in, rather than relying on the compiler to convert for us.
+                if (revisionMember.GetRawMemberType() == typeof(int))
+                {
+                    var intGetter = LambdaBuilder.Getter<T, int>(revisionMember);
+                    _mappedRevisionGetter = doc => intGetter(doc);
+                }
+                else
+                {
+                    _mappedRevisionGetter = LambdaBuilder.Getter<T, long>(revisionMember);
+                }
+            }
+        }
+        else if (document.Metadata.Version.Member is { } versionMember)
+        {
+            _mappedVersionGetter = LambdaBuilder.Getter<T, Guid>(versionMember);
+        }
+
         _setter = LambdaBuilder.Setter<T, TId>(document.IdMember)!;
         if (typeof(TId) == typeof(Guid))
         {
@@ -288,6 +316,21 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, ILinqDo
 
         return session.Versions.VersionFor<T, TId>(Identity(document));
     }
+
+    // #5372: compiled accessors for a version / revision member mapped with
+    // Metadata.Version.MapTo(...) / Metadata.Revision.MapTo(...). Built once in the ctor off the
+    // mapping (the #4828 pattern: read it there, retain no DocumentMapping) and left null when the
+    // mapping carries no such member. ClosedShapeBulkLoader already builds the same pair for the
+    // COPY path; these answer the Weasel 9.32.0 seam (weasel#590) so a session can seed the expected
+    // version for the write guard without a runtime type test on the storage.
+    private readonly Func<T, Guid>? _mappedVersionGetter;
+    private readonly Func<T, long>? _mappedRevisionGetter;
+
+    /// <inheritdoc />
+    public Guid? MappedVersionFor(T document) => _mappedVersionGetter?.Invoke(document);
+
+    /// <inheritdoc />
+    public long? MappedRevisionFor(T document) => _mappedRevisionGetter?.Invoke(document);
 
     public abstract void Store(IStorageSession session, T document);
     public abstract void Store(IStorageSession session, T document, Guid? version);

--- a/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
@@ -129,6 +129,18 @@ internal class SubClassDocumentStorage<T, TRoot, TId>: IDocumentStorage<T, TId>,
         return _parent.VersionFor(document, session);
     }
 
+    // #5372: the mapped version/revision member is declared on the root document type and is
+    // readable from a subclass instance, so the root storage answers for both.
+    public Guid? MappedVersionFor(T document)
+    {
+        return _parent.MappedVersionFor(document);
+    }
+
+    public long? MappedRevisionFor(T document)
+    {
+        return _parent.MappedRevisionFor(document);
+    }
+
     public void Store(IStorageSession session, T document)
     {
         _parent.Store(session, document);

--- a/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
+++ b/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
@@ -119,6 +119,11 @@ internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: ID
 
     public Guid? VersionFor(TDoc document, IStorageSession session) => Inner.VersionFor(document, session);
 
+    // #5372: the wrapped storage owns the mapping, so it owns the mapped version/revision member too.
+    public Guid? MappedVersionFor(TDoc document) => Inner.MappedVersionFor(document);
+
+    public long? MappedRevisionFor(TDoc document) => Inner.MappedRevisionFor(document);
+
     public void Store(IStorageSession session, TDoc document) => Inner.Store(session, document);
 
     public void Store(IStorageSession session, TDoc document, Guid? version) => Inner.Store(session, document, version);


### PR DESCRIPTION
Closes #5384. Supersedes #5372 — the reproduction, the diagnosis, and the four tests this PR adopts
verbatim are **@JurJean's**; this carries them plus the fix.

## The bug

```csharp
opts.Schema.For<Doc>().UseOptimisticConcurrency(true)
    .Metadata(m => m.Version.MapTo(x => x.Etag));
```

Storing such a document in a *fresh* session threw `ConcurrencyException`, always. The mapped member
is written back on save and repopulated on load, so the mapping looks like it works — but
`DocumentSessionBase.storeEntity` seeded the session's expected version only from the `IVersioned` /
`IRevisioned` / `ILongVersioned` marker interfaces. A `MapTo(...)` member was invisible there, so the
upsert bound `DBNull` into its `ON CONFLICT … WHERE mt_version = ?` guard, no RETURNING row came
back, and a write that should have succeeded was reported as a concurrency violation.

`Metadata.Version.MapTo` is documented (`docs/documents/metadata.md:136`), so this was a documented
feature that could not do the one thing it is named for. Outside the session that loaded the
document, the only way through was an explicit `session.UpdateExpectedVersion(doc, version)` — which
is exactly what `Bug_964_optimistic_concurrency_with_subclass` has always had to do.

## Why the fix needed Weasel

`storeEntity` holds `Weasel.Storage.IDocumentStorage<T>`. Every Marten-only route to the mapped
member cost a runtime type test on the storage plus forwarding in each decorator — and a decorator
that forgets to forward fails *silently*, which is the worst failure mode for a concurrency guard.

So the seam went upstream: JasperFx/weasel#592 (closing JasperFx/weasel#590) adds
`MappedVersionFor` / `MappedRevisionFor` to `IDocumentStorage<T>` as default interface members
returning null. Shipped in **Weasel 9.32.0**, which this PR bumps to.

The result is virtual dispatch rather than a type test, end to end:

- `DocumentStorage<T, TId>` builds the accessors once in its ctor off the mapping and overrides both.
  This follows the #4828 pattern (read the mapping in the ctor, retain no `DocumentMapping`) and
  matches `ClosedShapeBulkLoader`, which already builds the same pair for the COPY path.
- `SubClassDocumentStorage` and `ValueTypeIdentifiedDocumentStorage` forward through their
  already-typed `_parent` / `Inner`.
- `storeEntity` consults the mapped member *after* the marker cases, which keep their exact
  behaviour. The two cannot disagree anyway: `VersionedPolicy` sets `Metadata.Version.Member` to the
  marker interface's own property, so this only reaches documents that map a member without
  implementing a marker.

Two details worth flagging, because both were wrong in the first draft on @JurJean's branch and are
invisible from reading the call site:

- **The revision getter keys off `Metadata.Revision.Enabled`, not just `UseNumericRevisions`.**
  `Revision.MapTo(...)` sets `Enabled` on its own, so the narrower check misses a mapped revision
  member configured without `UseNumericRevisions(true)`. `ClosedShapeBulkLoader` uses the wider
  condition; this now matches it.
- **A revision member is `int` or `long`.** `DocumentRevisionBinder` narrows on the way in, so the
  getter widens on the way out rather than relying on an implicit conversion.

## The behaviour that must NOT change

The no-version `Store(session, doc)` overload is *how* `ConcurrencyChecks.Disabled` is implemented —
`DocumentSessionBase` deliberately calls it to skip version seeding. Seeding from the mapped member
must not reach that path, and a test pins it: a stale mapped version is ignored under
`ConcurrencyChecks.Disabled` and the write goes through.

## Tests

@JurJean's four tests, adopted unchanged (the fourth deliberately contrasts the marker-interface path
that worked all along), plus four more: the `ConcurrencyChecks.Disabled` guard above, two for the
subclass decorator (round-trip and stale-version rejection), and one for a mapped *revision* member.

- `closed_shape_optimistic_concurrency_mapped_member_tests` — 8/8 green. The first of these is the
  test that is red on master by design in #5372.
- `DocumentDbTests` concurrency + metadata + `Bug_964` + `Bug_3778` — **177/177 green**, which covers
  the existing `Version.MapTo`, `Revision.MapTo`, `UpdateExpectedVersion` and versioned-document
  paths this change sits on.
- `EventSourcingTests` `FetchForWriting` — 234 passed, 9 failed. Those 9 are **identical on
  unmodified master**: same tests, same single exception
  (`42883: function pg_current_snapshot() does not exist`), same 234/9/243 split. `pg_current_snapshot()`
  is a PostgreSQL 13+ builtin and my local container came up on 12.8, which is what
  `docker-compose.yml` still defaults to (`ionx/postgres-plv8:12.8`) even though CLAUDE.md requires
  13+ and CI runs `postgres:15-alpine` / `latest`. Unrelated to this change — I ran the baseline to
  confirm rather than assume. The `Revision.MapTo` test in that suite
  (`fetching_inline_aggregates_for_writing`) is among the passing 234.

  Worth a separate issue: the committed compose default cannot run the repo's own async-daemon tests.

## Credit

**@JurJean** reported #5372, built the reproduction, wrote the tests, and prototyped a fix on a
branch. The design here differs only in where the seam lives — on the Weasel interface rather than
behind a runtime type test — and in the two gating details above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01481eiEZg1Bv6pu4DrgPRg3
