### PR TITLE
Containment payload writer: nested dictionary keys, byte[], and its documented limits

### DIFF
--- a/docs/configuration/aot-publishing.md
+++ b/docs/configuration/aot-publishing.md
@@ -267,6 +267,20 @@ containment query, and Marten used to serialize that payload — its own diction
 values you compared against — through *your* serializer. A source-generated resolver carries your
 documents, not that, so the query threw before it was ever sent. Marten now writes the payload itself.
 
+The split is by ownership: Marten writes the shapes that are its own (the payload dictionary, and the
+array a child-collection filter wraps it in) plus the scalar leaves, and hands everything that came out
+of your document — a typed nested dictionary, an enum, a record, a value object — back to your
+serializer, which has those types because they are part of a document.
+
+One consequence worth knowing, because it is the price of not needing your resolver for Marten's own
+shapes: the scalars written here do **not** go through your `JsonSerializerOptions`. A
+`NumberHandling` setting, or a custom converter for one of the scalar types (`decimal`,
+`DateTimeOffset`, `Guid`, …), will not affect how a *filter value* of that type is rendered, even
+though it affects how the document was stored. If you rely on one of those, compare through a member
+whose type Marten hands to the serializer rather than one it renders itself. A custom
+`JavaScriptEncoder` is not a concern: Postgres parses the payload into jsonb, where an escaped and an
+unescaped character are the same character.
+
 ### Secondary store throws `MissingMethodException` at boot
 
 `AddMartenStore<TInterface>` uses `System.Reflection.Emit` to materialize the implementation type at runtime (Marten 9 ripped out the Roslyn-emit subclass path in PR [#4459](https://github.com/JasperFx/marten/pull/4459)). Native AOT supports `Reflection.Emit` only on full-AOT runtimes that include the JIT; some trimming configurations strip it. If a secondary store throws `MissingMethodException` at boot, check:

--- a/src/CoreTests/Bug_5374_containment_payload_json.cs
+++ b/src/CoreTests/Bug_5374_containment_payload_json.cs
@@ -112,6 +112,72 @@ public class Bug_5374_containment_payload_json
         Apotheek
     }
 
+    // #5385: Newtonsoft's contract resolver sets ProcessDictionaryKeys = true for CamelCase and
+    // SnakeCase, so the old ToCleanJson path transformed *dictionary keys* as well as property names.
+    // The payload's own top-level keys survive that unchanged because they are already
+    // member.ToJsonKey(casing) — re-casing them is idempotent — which is exactly why the existing
+    // Newtonsoft test above passes and this gap went unnoticed. A nested dictionary is different: its
+    // keys come from the caller (DictionaryMember.PlaceValueInDictionaryForContainment copies the
+    // KeyValuePair the query supplied), so the serializer would case them and JsonbPayload would not.
+    //
+    // The top-level key here is deliberately already-lowercase so the only thing under test is the
+    // nested one. System.Text.Json is unaffected: Marten never sets DictionaryKeyPolicy.
+    [Theory]
+    [InlineData(Casing.Default)]
+    [InlineData(Casing.CamelCase)]
+    [InlineData(Casing.SnakeCase)]
+    public void writes_what_newtonsoft_wrote_for_a_nested_dictionary_key(Casing casing)
+    {
+        var serializer = new Marten.Services.JsonNetSerializer { Casing = casing };
+        var data = new Dictionary<string, object>
+        {
+            ["kenmerken"] = new Dictionary<string, string> { ["Kleur"] = "blauw" }
+        };
+
+        JsonNode.DeepEquals(
+                JsonNode.Parse(JsonbPayload.ToJson(serializer, data)),
+                JsonNode.Parse(serializer.ToCleanJson(data)))
+            .ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(Casing.Default)]
+    [InlineData(Casing.CamelCase)]
+    [InlineData(Casing.SnakeCase)]
+    public void writes_what_system_text_json_wrote_for_a_nested_dictionary_key(Casing casing)
+    {
+        var serializer = new MartenSystemTextJsonSerializer { Casing = casing };
+        var data = new Dictionary<string, object>
+        {
+            ["kenmerken"] = new Dictionary<string, string> { ["Kleur"] = "blauw" }
+        };
+
+        JsonbPayload.ToJson(serializer, data).ShouldBe(serializer.ToCleanJson(data));
+    }
+
+    // #5385: a byte array is IEnumerable, so without its own branch it came out as a list of numbers
+    // where both serializers write a base64 string.
+    [Fact]
+    public void writes_what_system_text_json_wrote_for_a_byte_array()
+    {
+        var serializer = new MartenSystemTextJsonSerializer();
+        var data = new Dictionary<string, object> { ["Inhoud"] = new byte[] { 1, 2, 3, 250 } };
+
+        JsonbPayload.ToJson(serializer, data).ShouldBe(serializer.ToCleanJson(data));
+    }
+
+    [Fact]
+    public void writes_what_newtonsoft_wrote_for_a_byte_array()
+    {
+        var serializer = new Marten.Services.JsonNetSerializer();
+        var data = new Dictionary<string, object> { ["Inhoud"] = new byte[] { 1, 2, 3, 250 } };
+
+        JsonNode.DeepEquals(
+                JsonNode.Parse(JsonbPayload.ToJson(serializer, data)),
+                JsonNode.Parse(serializer.ToCleanJson(data)))
+            .ShouldBeTrue();
+    }
+
     // A value the writer does not render itself falls through to the serializer, which is the only thing
     // that knows about a converter the consumer registered.
     [Fact]

--- a/src/Marten/Linq/JsonbPayload.cs
+++ b/src/Marten/Linq/JsonbPayload.cs
@@ -19,18 +19,34 @@ namespace Marten.Linq;
 ///     is a source-generated <c>JsonSerializerContext</c> — what the AOT guide asks for — and it carries
 ///     the consumer's documents, not <c>object[]</c>, not the dictionary, and not whichever enum a filter
 ///     happens to compare. An ordinary <c>.Any(x =&gt; x.Member == value)</c> therefore threw before the
-///     query was ever sent. The shape is ours, so we write it; only a value we cannot render identically
-///     goes through the serializer, and that is a document type the consumer has already declared.
+///     query was ever sent.
 ///     </para>
 ///     <para>
-///     Every branch here has to emit what the serializer emitted, and <c>Bug_5374_containment_payload_json</c>
-///     asserts exactly that, because a payload that differs by one character silently matches nothing.
-///     Two properties of the serializer's options matter and both are honoured: the naming policy is a
-///     <em>property</em> policy and Marten never sets <c>DictionaryKeyPolicy</c>, so these keys are written
-///     verbatim, and any value with a converter of its own — an enum included — goes back through the
-///     serializer. A custom
-///     <c>JavaScriptEncoder</c> is the one thing not carried across, and it cannot matter: Postgres parses
-///     the payload into jsonb, where an escaped and an unescaped character are the same character.
+///     So the split is by ownership. Two shapes are <em>Marten's</em> and are written here because the
+///     consumer's resolver has no reason to know them: the <c>Dictionary&lt;string, object&gt;</c> payload
+///     itself, and the <c>object[]</c> a child-collection filter wraps it in. Everything else is a value
+///     out of the consumer's document — including a <em>typed</em> nested dictionary such as the
+///     <c>Dictionary&lt;TKey, TValue&gt;</c> that <c>DictionaryMember</c> builds for a dictionary-member
+///     query — and goes back through the serializer, which both knows how it was written and has the type.
+///     </para>
+///     <para>
+///     Every branch here has to emit what the serializer emitted, because a payload that differs by one
+///     character silently matches nothing; <c>Bug_5374_containment_payload_json</c> asserts exactly that.
+///     Delegating typed dictionaries is #5385: Newtonsoft's contract resolver sets
+///     <c>ProcessDictionaryKeys = true</c> for CamelCase and SnakeCase, so it cases dictionary keys, and a
+///     nested dictionary carries the caller's own key rather than one Marten already cased. Writing those
+///     keys verbatim produced a payload that matched nothing under those two casings. The keys of the
+///     payload's own shape are safe precisely because they are already <c>member.ToJsonKey(casing)</c>, so
+///     re-casing them is idempotent. (System.Text.Json is unaffected either way: Marten never sets
+///     <c>DictionaryKeyPolicy</c>.)
+///     </para>
+///     <para>
+///     What this deliberately does <strong>not</strong> honour, because rendering the primitives here is
+///     the whole point under AOT: a consumer-configured <c>NumberHandling</c>, a custom converter for one
+///     of the scalar types written below, or a custom <c>JavaScriptEncoder</c>. The encoder cannot matter —
+///     Postgres parses the payload into jsonb, where an escaped and an unescaped character are the same
+///     character. The other two would, and a document relying on them should compare through a member
+///     Marten hands to the serializer instead.
 ///     </para>
 /// </remarks>
 internal static class JsonbPayload
@@ -55,21 +71,34 @@ internal static class JsonbPayload
                 writer.WriteNullValue();
                 return;
 
-            // The payload's own shape, and a nested Dictionary<TKey, TValue> where a query filtered a
-            // dictionary member.
-            case IDictionary dictionary:
+            // Marten's own payload shape, including the nested one a child-collection filter builds.
+            // The keys are already cased member names, so they are written as they stand.
+            case Dictionary<string, object> payload:
                 writer.WriteStartObject();
-                foreach (DictionaryEntry entry in dictionary)
+                foreach (var pair in payload)
                 {
-                    writer.WritePropertyName(key(entry.Key));
-                    write(writer, serializer, entry.Value);
+                    writer.WritePropertyName(pair.Key);
+                    write(writer, serializer, pair.Value);
                 }
 
                 writer.WriteEndObject();
                 return;
 
+            // #5385: any other dictionary is a typed member off the consumer's document, whose keys the
+            // serializer may case (Newtonsoft does) and whose key type it may have a converter for. It
+            // owns the whole shape, and its resolver has the type because it is part of a document.
+            case IDictionary:
+                writer.WriteRawValue(serializer.ToCleanJson(value));
+                return;
+
             case string text:
                 writer.WriteStringValue(text);
+                return;
+
+            // #5385: before IEnumerable, which would otherwise write a byte array as a list of numbers
+            // where both serializers write a base64 string.
+            case byte[] bytes:
+                writer.WriteBase64StringValue(bytes);
                 return;
 
             case bool flag:
@@ -160,14 +189,4 @@ internal static class JsonbPayload
                 return;
         }
     }
-
-    /// <summary>A dictionary key is a JSON property name, and System.Text.Json renders a non-string key
-    /// as its invariant text. An enum key is its member name whatever <see cref="ISerializer.EnumStorage" />
-    /// says — that setting is about values, and a key has its own converter.</summary>
-    private static string key(object value) => value switch
-    {
-        string text => text,
-        Enum => value.ToString()!,
-        _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty
-    };
 }


### PR DESCRIPTION
Closes #5385 — the three follow-ups from reviewing #5377, now that the containment payload writer is
on master.

## 1. Newtonsoft + non-default casing silently broke nested dictionary keys

This is the one with teeth, and it was a live bug rather than a tidy-up.

`JsonNetContractResolver` sets `ProcessDictionaryKeys = true` for `Casing.CamelCase` and
`Casing.SnakeCase`, so Newtonsoft cases **dictionary keys**, not just property names. `JsonbPayload`
wrote every key verbatim. The payload's own top-level keys survive that unchanged because they are
already `member.ToJsonKey(casing)` — re-casing them is idempotent — which is exactly why the existing
Newtonsoft test passed and this went unnoticed. A *nested* dictionary is different: its keys come
straight from the caller, since `DictionaryMember.PlaceValueInDictionaryForContainment` copies the
`KeyValuePair` the query supplied.

So under Newtonsoft + CamelCase, a query like
`x => x.Kenmerken.Contains(new KeyValuePair<string,string>("Kleur","blauw"))` asked for `"Kleur"`
against a document stored with `"kleur"`. Zero rows, no error.

**The fix splits the writer by ownership.** Two shapes are Marten's and stay in the writer, because a
consumer's source-generated resolver has no reason to know them: the `Dictionary<string, object>`
payload, and the `object[]` a child-collection filter wraps it in. Everything else came out of the
consumer's document — including a typed `Dictionary<TKey, TValue>` — and goes back through the
serializer, which both knows how it was written and has the type. That keeps #5374 fixed while
handing key rendering back to the component that owns the rules.

System.Text.Json was never affected: Marten does not set `DictionaryKeyPolicy`.

## 2. `byte[]` came out as a list of numbers

`case IEnumerable` caught byte arrays, so a `byte[]` filter value rendered as `[1,2,3,250]` where both
serializers write a base64 string. It now has its own branch ahead of the enumerable case. Theoretical
in the sense that nothing in the test suite compares a `byte[]` member, but it is one line.

## 3. Saying what the writer deliberately does not honour

The class remarks claimed a custom `JavaScriptEncoder` was the only thing not carried across, and that
dictionary keys are written verbatim because `DictionaryKeyPolicy` is never set. The first understated
it and the second was only true for System.Text.Json — it is precisely what made (1) invisible. Both
the remarks and the AOT guide now state the real trade: the scalars written here bypass your
`JsonSerializerOptions`, so a `NumberHandling` setting or a custom converter for `decimal` /
`DateTimeOffset` / `Guid` affects how a document was stored but not how a filter value is rendered.
That is the price of not needing your resolver for Marten's own shapes, and it is worth writing down
rather than discovering.

## Tests

- `Bug_5374_containment_payload_json` — **17/17 green**. The two new
  `writes_what_newtonsoft_wrote_for_a_nested_dictionary_key` cases **fail on master** for CamelCase and
  SnakeCase and pass for Default, which is the bug pinned exactly; the System.Text.Json twin passes
  throughout, pinning that it was never affected. Two `byte[]` cases added, one per serializer.
- The 13 pre-existing byte-equality assertions still hold, which is the assertion that matters most
  here: `payload()` carries three typed dictionaries (`Dictionary<string,string>`,
  `Dictionary<int,string>`, `Dictionary<Soort,decimal>`) that now route through the serializer instead
  of the writer, and they still match `ToCleanJson` exactly.
- `LinqTests` dictionary / child-collection / containment / casing — **264/264 green**. That is the
  real regression surface: this changes how a nested dictionary renders for every dictionary-member
  query, not only the renamed-casing ones.

## Credit

The writer, and the byte-equality-against-the-old-path test design that made all three of these easy
to state and prove, are **@erdtsieck's** from #5377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01481eiEZg1Bv6pu4DrgPRg3
