### PR TITLE
PostgreSQL setup docs describe a Marten that no longer exists (corrects #5387)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,28 +24,23 @@ We try to limit the number of necessary setup to a minimum, but few steps are st
 
 Available [here](https://dotnet.microsoft.com/download)
 
-**2. PostgreSQL 12 or above database**
+**2. PostgreSQL 13 or above database**
+
+13 is a hard floor rather than a recommendation: the async daemon calls `pg_current_snapshot()`, which
+arrived in PostgreSQL 13, so an older server fails those tests with
+`42883: function pg_current_snapshot() does not exist`. CI runs `postgres:15-alpine` and
+`postgres:latest`.
 
 The fastest possible way to develop with Marten is to run PostgreSQL in a Docker container. Assuming that you have Docker running on your local box, type:
-`docker-compose up`
-or
-`dotnet run --framework net6.0 -- init-db`
-at the command line to spin up a Postgresql database withThe default Marten test configuration tries to find this database if no
-PostgreSQL database connection string is explicitly configured following the steps below:
+`docker compose up`
+at the command line to spin up a PostgreSQL database. `docker-compose.yml` builds its image from
+`docker/postgres/Dockerfile`, which layers PostGIS 3 and pgvector onto the official `postgres:17`
+image so the extension test projects have what they need.
 
-**PLV8**
-
-If you'd like to use [Patching Api](https://martendb.io/documents/plv8.html#the-patching-api) you need to enable the PLV8 extension inside of PostgreSQL for running JavaScript stored procedures for the nascent projection support.
-
-Ensure the following:
-
-- The login you are using to connect to your database is a member of the `postgres` role
-- An environment variable of `marten_testing_database` is set to the connection string for the database you want to use as a testbed. (See the [Npgsql documentation](http://www.npgsql.org/doc/connection-string-parameters.html) for more information about PostgreSQL connection strings ).
-
-_Help with PSQL/PLV8_
-
-- On Windows, see [this link](http://www.postgresonline.com/journal/archives/360-PLV8-binaries-for-PostgreSQL-9.5-windows-both-32-bit-and-64-bit.html) for pre-built binaries of PLV8
-- On *nix, check [marten-local-db](https://github.com/eouw0o83hf/marten-local-db) for a Docker based PostgreSQL instance including PLV8.
+The default Marten test configuration finds that database automatically. To use a different one, set
+the `marten_testing_database` environment variable to its connection string (see the
+[Npgsql documentation](http://www.npgsql.org/doc/connection-string-parameters.html) for the format),
+and make sure the login you connect with is a member of the `postgres` role.
 
 Once you have the codebase and the connection string file, run the [build command](https://github.com/JasperFx/marten#build-commands) or use the dotnet CLI to restore and build the solution.
 

--- a/README.md
+++ b/README.md
@@ -63,29 +63,30 @@ PostgreSQL database connection string is explicitly configured following the ste
 
 Marten supports native patching since v7.x. you can refer to [patching api](https://martendb.io/documents/partial-updates-patching.html) for more details.
 
-### PLV8
-
-If you'd like to use [PLV8 Patching Api](https://martendb.io/documents/plv8.html#the-patching-api) you need to enable the PLV8 extension inside of PostgreSQL for running JavaScript stored procedures for the nascent projection support.
-
-Note that PLV8 patching will be deprecated in future versions and native patching is the drop in replacement for it. You can easily migrate to native patching, refer [here](https://martendb.io/documents/partial-updates-patching.html#patching-api) for more details.
+### Database Setup
 
 Ensure the following:
 
 - The login you are using to connect to your database is a member of the `postgres` role
 - An environment variable of `marten_testing_database` is set to the connection string for the database you want to use as a testbed. (See the [Npgsql documentation](http://www.npgsql.org/doc/connection-string-parameters.html) for more information about PostgreSQL connection strings ).
 
-_Help with PSQL/PLV8_
-
-- On Windows, see [this link](http://www.postgresonline.com/journal/archives/360-PLV8-binaries-for-PostgreSQL-9.5-windows-both-32-bit-and-64-bit.html) for pre-built binaries of PLV8
-- On *nix, check [marten-local-db](https://github.com/eouw0o83hf/marten-local-db) for a Docker based PostgreSQL instance including PLV8.
+PLV8 is no longer part of developing Marten: the patching API it once backed was replaced by the
+native implementation linked above, and the compose image dropped the extension. If you are
+maintaining an older application that still uses it, it lives in the separate `Marten.PLv8` package.
 
 ### Test Config Customization
 
-Some of our tests are run against a particular PostgreSQL version. If you'd like to run different database versions, you can do it by setting `POSTGRES_IMAGE` env variables, for instance:
+`docker-compose.yml` builds its PostgreSQL image from `docker/postgres/Dockerfile`, which layers
+PostGIS 3 and pgvector onto the official `postgres:17` image so the Marten.PostGIS and Marten.PgVector
+test projects have the extensions they need. Both Debian packages are multi-arch, so this builds on
+Apple-silicon hosts without emulation.
 
-```bash
-POSTGRES_IMAGE=postgres:15.3-alpine docker compose up
-```
+To run against a different PostgreSQL version, point the test suite at your own database with the
+`marten_testing_database` environment variable rather than overriding the compose image — the service
+uses `build:`, so it has no image tag to override.
+
+Note that the async daemon requires **PostgreSQL 13 or later** (it calls `pg_current_snapshot()`); CI
+runs `postgres:15-alpine` and `postgres:latest`.
 
 Tests explorer should be able to detect database version automatically, but if it's not able to do it, you can enforce it by setting `postgresql_version` to a specific one (e.g.)
 
@@ -164,16 +165,19 @@ Refer to build commands section to look up the commands to open the StoryTeller 
 
 ### Current Build Matrix
 
-| CI              | .NET | Postgres  |        plv8        | Serializer | 
-|-----------------|:----:|:---------:|:------------------:|:----------:|
-| GitHub Actions  |  8   |   12.8    | :white_check_mark: |    STJ     | 
-| GitHub Actions  |  8   | 15-alpine |        :x:         | Newtonsoft | 
-| GitHub Actions  |  7   |   12.8    | :white_check_mark: |  JSON.NET  | 
-| GitHub Actions  |  7   |  latest   |        :x:         |    STJ     | 
-| Azure Pipelines |  6   |   12.8    | :white_check_mark: |  JSON.NET  | 
-| Azure Pipelines |  6   |   12.8    | :white_check_mark: |    STJ     | 
-| Azure Pipelines |  6   | 15-alpine |        :x:         |    STJ     | 
-| Azure Pipelines |  6   |  latest   |        :x:         | Newtonsoft | 
+CI is GitHub Actions only (`.github/workflows/tests.yml`). Each test suite is its own job, run
+against one of these two pairings:
+
+| .NET | Postgres           | Serializer |
+|:----:|:-------------------|:-----------|
+|  9   | `postgres:15-alpine` | Newtonsoft |
+|  10  | `postgres:latest`  | System.Text.Json |
+
+plv8 is no longer used or installed anywhere in CI.
+
+A few suites run against purpose-built images instead: PostGIS (`postgis:17-3.5`), PgVector
+(`pgvector:pg17`) and TimescaleDB (`timescaledb-ha:pg17`), plus a native `PublishAot` smoke run and a
+two-node replication pair for the multi-host tests.
 
 ## Documentation
 


### PR DESCRIPTION
Closes #5387 — though not in the way that issue was originally written. **I filed it wrong**, and the
correction is worth stating plainly before the diff.

I reported that `docker-compose.yml` defaults to PostgreSQL 12.8 and therefore cannot run the repo's
own async-daemon tests. That is true of the **8.0** branch, which is the checkout I ran
`docker compose up` from. On master the compose file has already been modernized: it builds
`docker/postgres/Dockerfile`, which layers PostGIS 3 and pgvector onto the official multi-arch
`postgres:17` image, with PLv8 deliberately dropped and a `shm_size` bump for parallel queries. There
is no version to raise here.

What survives is that **the setup docs describe a Marten that no longer exists**, and one of those
inaccuracies sends a new contributor directly into the failure I hit.

## What was wrong, each verified against master

- **`README.md` — Test Config Customization.** Told you to run
  `POSTGRES_IMAGE=postgres:15.3-alpine docker compose up`. That variable does nothing now: the service
  uses `build:`, not `image:`, so the override is silently ignored and you get postgres:17 regardless.
  Replaced with what actually works — point `marten_testing_database` at your own server.
- **`CONTRIBUTING.md` — "PostgreSQL 12 or above".** The real floor is 13: the async daemon calls
  `pg_current_snapshot()`, which arrived in 13. Follow the old text literally, install 12, run the
  daemon tests, and you get nine failures reading `42883: function pg_current_snapshot() does not
  exist` — which looks like a Marten bug rather than a setup problem. It now says 13, and says why.
- **PLV8 instructions in both files**, including a link to pre-built PLV8 binaries for PostgreSQL 9.5
  on Windows. PLV8 moved to the separate `Marten.PLv8` package and was superseded by native patching;
  the compose image no longer ships the extension.
- **`README.md` — the build matrix table.** Listed Postgres 12.8 with plv8 checkmarks across .NET 6/7/8
  and four Azure Pipelines rows. There is no Azure Pipelines on master (four GitHub Actions workflows,
  no `azure-pipelines*` file), and the real matrix is net9 + `postgres:15-alpine` + Newtonsoft against
  net10 + `postgres:latest` + System.Text.Json, with no plv8 anywhere.

A few incidental repairs came along with the rewritten paragraphs: the deprecated `docker-compose`
hyphen form, an obsolete `dotnet run --framework net6.0 -- init-db` instruction, and a garbled
sentence ("spin up a Postgresql database withThe default Marten test configuration...").

## Deliberately not here

The **8.0 branch** genuinely does still default to `ionx/postgres-plv8:12.8`, and its compose cannot
run its own daemon tests either. It is still taking fixes, but it has no CI triggers, so whether to
touch it is a judgement call rather than an obvious yes — left in #5387's comments for a decision
rather than bundled in here.

Docs only; no code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01481eiEZg1Bv6pu4DrgPRg3
