### PR TITLE
Enroll GuidOptimisticConcurrencyCompliance (#5393)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -555,15 +555,15 @@
     <PackageVersion Include="Bobcat" Version="0.17.1" />
     <PackageVersion Include="Bobcat.Generators" Version="0.17.1" />
     <PackageVersion Include="Bobcat.Xunit" Version="0.17.1" />
-    <PackageVersion Include="JasperFx" Version="2.67.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.67.0" />
+    <PackageVersion Include="JasperFx" Version="2.69.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.69.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.67.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.69.0" />
     <!--
       No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
       whole family moves together, and this note is kept for the history below. This package is
@@ -582,11 +582,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.67.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.69.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.67.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.69.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/Compliance/marten_document_storage_compliance.cs
+++ b/src/EventSourcingTests/Compliance/marten_document_storage_compliance.cs
@@ -85,6 +85,29 @@ public class pending_stream_actions_compliance
 public class document_commit_listener_compliance
     : DocumentCommitListenerCompliance<MartenDocumentComplianceFixture>;
 
+/*
+ * jasperfx#819 (#5393). The eighth suite, and the first shared coverage of Guid optimistic
+ * concurrency on ANY store -- the whole shared story of document concurrency was
+ * NumericRevisionCompliance, and grepping the 2.68.0 suites for IVersioned returned nothing.
+ *
+ * marten#5372 is what lived in that gap on this side: a member mapped with Metadata.Version.MapTo(...)
+ * was invisible to the session, so the upsert bound DBNull into its guard and reported every
+ * cross-session write as a violation. fisher#245 is the same field one route over. Two stores, the
+ * same failure mode, found independently and neither caught by anything shared.
+ *
+ * Gated on MartenDocumentComplianceFixture.SupportsOptimisticConcurrency, which also has to replay
+ * DocumentComplianceConfig.OptimisticConcurrencyTypes -- see the comment on that loop in the fixture
+ * for why dropping it fails every guard fact rather than skipping.
+ *
+ * In the collection like the rest even though it pins its own schema (compliance_concurrency) and so
+ * could safely run beside them: the fixture's CleanDocumentDataAsync is a store-wide document wipe
+ * called before every test, and keeping every document suite serialized locally is cheaper than
+ * reasoning about which ones happen not to share a schema today.
+ */
+[Collection(DocumentComplianceCollection.Name)]
+public class guid_optimistic_concurrency_compliance
+    : GuidOptimisticConcurrencyCompliance<MartenDocumentComplianceFixture>;
+
 public static class DocumentComplianceCollection
 {
     public const string Name = "document storage compliance";

--- a/src/Marten.Testing/Harness/MartenDocumentComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenDocumentComplianceFixture.cs
@@ -32,6 +32,17 @@ public class MartenDocumentComplianceFixture: DocumentStorageComplianceFixture
 
     public override IDocumentSessionFactory Sessions => _store;
 
+    /// <summary>
+    /// jasperfx#819 (#5393). Marten implements Guid optimistic concurrency through the IVersioned
+    /// marker and <c>Schema.For&lt;T&gt;().UseOptimisticConcurrency(true)</c>, so
+    /// GuidOptimisticConcurrencyCompliance runs rather than skips.
+    /// </summary>
+    /// <remarks>
+    /// Flipping this is only half of the opt-in: the fixture must also replay
+    /// <c>DocumentComplianceConfig.OptimisticConcurrencyTypes</c>, which BuildStoreAsync below does.
+    /// </remarks>
+    public override bool SupportsOptimisticConcurrency => true;
+
     protected override async Task BuildStoreAsync(DocumentComplianceConfig config)
     {
         var options = new StoreOptions();
@@ -65,6 +76,21 @@ public class MartenDocumentComplianceFixture: DocumentStorageComplianceFixture
         foreach (var valueType in config.ValueTypes)
         {
             options.RegisterValueType(valueType);
+        }
+
+        // jasperfx#819 (#5393). Load-bearing in the strongest sense, and NOT belt-and-braces like the
+        // two loops above: GuidOptimisticConcurrencyCompliance's document implements IVersioned *and*
+        // declares config.UseOptimisticConcurrency<T>(), because the stores disagree about whether the
+        // marker is itself the opt-in or merely supplies the member to guard on. A fixture that drops
+        // this does not make the suite skip -- on a store where the marker alone is not the opt-in,
+        // every guard fact fails instead.
+        //
+        // Set on the mapping rather than through Schema.For<T>() because the config hands over a Type
+        // and the fluent entry point is generic; Policies.ForAllDocuments(m => m.UseOptimisticConcurrency
+        // = true) is the same move one level up.
+        foreach (var type in config.OptimisticConcurrencyTypes)
+        {
+            options.Storage.MappingFor(type).UseOptimisticConcurrency = true;
         }
 
         // jasperfx#672 (#5249). The suite states the stream identity it needs and the fixture


### PR DESCRIPTION
Closes #5393. Downstream of jasperfx#819, shipped in **JasperFx 2.69.0**.

## Why the suite exists

There was no shared suite for `Guid` optimistic concurrency **on any store**. The whole shared
coverage of document concurrency was `NumericRevisionCompliance`; every other "optimistic" fact in the
suite set is about the *event* store. Grepping the 2.68.0 suites for `IVersioned` returned nothing at
all.

**marten#5372 is what lived in that gap on this side** — a member mapped with
`Metadata.Version.MapTo(...)` was invisible to the session, so the upsert bound `DBNull` into its
guard and reported *every* cross-session write as a concurrency violation. JasperFx/fisher#245 is the
same field one route over: Fisher's guard was fed from the session's own version tracker, so a
document loaded in one session and stored through another failed its guard every time. Two stores,
the same field, the same failure mode, found independently and neither caught by anything shared.

## Enrollment only — no product change was needed

All five facts pass as they stand, **including the one jasperfx#819 called out as unverified here**:

> Fact 4 is the one to watch. It holds on Fisher and is unverified on Marten … If Marten does not
> write back, that is the fact that will say so.

It writes back. `DocumentVersionBinder.BindParameter` projects the freshly generated version onto the
mapped member during command configuration, and `VersionedPolicy` binds that member to
`IVersioned.Version` — so `mutate → store → mutate → store` works without a reload in between, which
is the consequence the fact exists to protect.

```
Passed!  -  Failed: 0, Passed: 5, Skipped: 0, Total: 5
```

## The two fixture changes

`SupportsOptimisticConcurrency` flips true, and `BuildStoreAsync` replays
`DocumentComplianceConfig.OptimisticConcurrencyTypes`.

**The replay is load-bearing rather than belt-and-braces**, unlike the `DocumentTypes` and
`ValueTypes` loops above it in the same method. The suite's document declares `IVersioned` *and* the
config member, because the stores disagree about whether the marker is itself the opt-in or merely
supplies the member to guard on — a suite declaring only the marker would be testing that
disagreement rather than the concurrency behaviour. A fixture that drops the replay does not make the
suite skip: on a store where the marker alone is not the opt-in, every guard fact fails.

It is spelled on the mapping (`options.Storage.MappingFor(type).UseOptimisticConcurrency = true`)
rather than through `Schema.For<T>()`, because the config hands over a `Type` and the fluent entry
point is generic. `Policies.ForAllDocuments(m => m.UseOptimisticConcurrency = true)` is the same move
one level up.

## Also here

The JasperFx family moves 2.67.0 → 2.69.0, which is where the suite ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01481eiEZg1Bv6pu4DrgPRg3
