### PR TITLE
Report the real shard state when a daemon is reachable (#5392)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -555,15 +555,15 @@
     <PackageVersion Include="Bobcat" Version="0.17.1" />
     <PackageVersion Include="Bobcat.Generators" Version="0.17.1" />
     <PackageVersion Include="Bobcat.Xunit" Version="0.17.1" />
-    <PackageVersion Include="JasperFx" Version="2.67.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.67.0" />
+    <PackageVersion Include="JasperFx" Version="2.69.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.69.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.67.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.69.0" />
     <!--
       No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
       whole family moves together, and this note is kept for the history below. This package is
@@ -582,11 +582,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.67.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.69.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.67.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.69.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/Compliance/marten_projection_status_compliance.cs
+++ b/src/EventSourcingTests/Compliance/marten_projection_status_compliance.cs
@@ -1,0 +1,31 @@
+using JasperFx.Events.ComplianceTests;
+using Marten;
+using Marten.Testing.Harness;
+
+namespace EventSourcingTests.Compliance;
+
+/*
+ * jasperfx#818 (#5392). GetProjectionStatusesAsync is the snapshot a monitoring console's projections
+ * page renders before it subscribes to ShardStatesChanged. Marten, Polecat and Fisher all implement
+ * it, nothing shared held any of them to it, and the three stores had each decided independently --
+ * and reasonably -- what the same five ShardStatus fields meant.
+ *
+ * Eight of the nine facts passed here as they stood, including the two that cost Polecat work:
+ * EventStoreSequence is the head of the event store rather than the high-water row (sourcing it from
+ * that row makes every shard on a stopped daemon look caught up, which is the opposite of what a
+ * projections page is opened to find out), and the State slot never carries a lifecycle.
+ *
+ * The ninth is a_reachable_running_daemon_reports_the_real_shard_state, and it is the one that needed
+ * a product change: Marten answered Unknown unconditionally, never reading a daemon at all, so the
+ * field carried no information. State is now read from whichever daemons are running against this
+ * store -- see DocumentStore.EventStoreExplorer.readAgentStatesAsync for why it goes through
+ * AllDaemonsAsync() rather than DaemonForDatabase, and why daemons are matched by StoreUri.
+ *
+ * Note the suite does NOT require an empty shard list for an Inline projection. jasperfx#818 proposed
+ * it; Marten reports SignalBoard:All / Unknown / 0 / 0, which is a coherent answer of a different
+ * kind -- a shard name is a registry fact, Projections.All has one for an inline registration, and
+ * "here is the shard, nothing is running it" is the same reading of Unknown used everywhere else.
+ * Marten's behaviour stands and the requirement was dropped.
+ */
+public class marten_projection_status_compliance
+    : ProjectionStatusCompliance<MartenComplianceFixture, IDocumentOperations, IQuerySession>;

--- a/src/Marten.Testing/Harness/MartenComplianceFixture.cs
+++ b/src/Marten.Testing/Harness/MartenComplianceFixture.cs
@@ -463,6 +463,20 @@ public class MartenComplianceFixture: EventStoreComplianceFixture<IDocumentOpera
         public IDocumentOperations OpenSession()
             => _host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
 
+        /// <summary>
+        ///     jasperfx#818 (#5392). The hosted store as IEventStore -- the one store in the suite set
+        ///     with a genuinely discoverable running daemon, which is what makes the daemon-visible half
+        ///     of ProjectionStatusCompliance testable at all. The fixture's own store is built by hand
+        ///     and registers no coordinator, so asking it what state its shards are in can only ever
+        ///     answer "no daemon here", which is the case Unknown describes.
+        ///
+        ///     Cannot be resolved generically from <see cref="Services" />: no store registers itself as
+        ///     IEventStore under that name for a suite to find -- Marten registers IDocumentStore, and
+        ///     AddMarten's IEventStore registration is an adapter over it.
+        /// </summary>
+        public JasperFx.Events.IEventStore EventStore
+            => (JasperFx.Events.IEventStore)_host.Services.GetRequiredService<IDocumentStore>();
+
         public async ValueTask DisposeAsync()
         {
             // IHost.Dispose alone does not call StopAsync, and an abandoned daemon host leaks

--- a/src/Marten/DocumentStore.EventStoreExplorer.cs
+++ b/src/Marten/DocumentStore.EventStoreExplorer.cs
@@ -459,6 +459,12 @@ public partial class DocumentStore
         var headSequence = await readHeadSequenceAsync(session, schema, ct).ConfigureAwait(false);
         var progression = await readProgressionAsync(session, schema, ct).ConfigureAwait(false);
 
+        // #5392 (jasperfx#818). ShardStatus.State is a fact about the RUNNING DAEMON, which no
+        // progression table knows. A store that can reach one reports what it says; a store that
+        // cannot reports Unknown, which means "there is no daemon here to ask" and is a genuinely
+        // different operational situation from Stopped -- the reading an operator acts on.
+        var agentStates = await readAgentStatesAsync().ConfigureAwait(false);
+
         var statuses = new List<ProjectionStatus>();
         foreach (var source in Options.Projections.All)
         {
@@ -477,7 +483,9 @@ public partial class DocumentStore
                 var processed = progression.TryGetValue(effectiveName.Identity, out var seq) ? seq : 0L;
                 shardStatuses.Add(new ShardStatus(
                     effectiveName.Identity,
-                    State: "Unknown",
+                    State: agentStates.TryGetValue(effectiveName.Identity, out var agentState)
+                        ? ShardStatusState.From(agentState)
+                        : ShardStatusState.Unknown,
                     ProcessedSequence: processed,
                     EventStoreSequence: headSequence,
                     Error: null));
@@ -487,6 +495,91 @@ public partial class DocumentStore
         }
 
         return statuses;
+    }
+
+    /// <summary>
+    /// #5392 (jasperfx#818): the per-shard <c>AgentStatus</c> of whichever daemons are running against
+    /// THIS store, keyed by shard identity. Empty when no daemon is visible, which is why the caller
+    /// falls back to <see cref="ShardStatusState.Unknown" />.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Read through <c>IProjectionCoordinator.AllDaemonsAsync()</c> and never through
+    /// <c>DaemonForDatabase</c>, which is contractually allowed to go looking and <em>start</em> a
+    /// daemon. A projections page that starts one by being opened is a monitoring tool with a side
+    /// effect on the system it monitors — pinned upstream by
+    /// <c>reading_the_statuses_does_not_start_a_daemon</c>.
+    /// </para>
+    /// <para>
+    /// No coordinator means no daemon to ask, and that is the common case rather than an edge:
+    /// <c>DaemonMode.ExternallyManaged</c>, a monitoring console in another process, and a store built
+    /// by hand (<c>new DocumentStore(options)</c>, where Options.Services is null) all land here. The
+    /// answer for it is Unknown, which is a genuinely different operational situation from Stopped —
+    /// answering Stopped sends an operator looking for why a projection was stopped that was never
+    /// started.
+    /// </para>
+    /// <para>
+    /// Daemons are matched to this store by <c>IProjectionDaemon.StoreUri</c> against
+    /// <see cref="Subject" /> rather than by trusting whichever coordinator the container hands back.
+    /// An application with an ancillary store registers a coordinator per store and the non-generic
+    /// IProjectionCoordinator resolves the primary one, so without the check an ancillary store would
+    /// report the PRIMARY store's shard states as its own.
+    /// </para>
+    /// </remarks>
+    private async Task<Dictionary<string, AgentStatus>> readAgentStatesAsync()
+    {
+        var states = new Dictionary<string, AgentStatus>();
+
+        var services = Options.Services;
+        if (services == null)
+        {
+            return states;
+        }
+
+        var subject = Subject.ToString();
+
+        foreach (var coordinator in Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions
+                     .GetServices<JasperFx.Events.Daemon.IProjectionCoordinator>(services))
+        {
+            IReadOnlyList<JasperFx.Events.Daemon.IProjectionDaemon> daemons;
+
+            try
+            {
+                daemons = await coordinator.AllDaemonsAsync().ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // A coordinator that cannot enumerate its daemons is the same operational situation as
+                // there being none, and a diagnostics read must not throw on the way to saying so.
+                continue;
+            }
+
+            foreach (var daemon in daemons)
+            {
+                // A daemon built without a store reports no StoreUri (test scaffolding); anything with
+                // one that is not ours belongs to another store in the same host.
+                if (daemon.StoreUri != null && daemon.StoreUri != subject)
+                {
+                    continue;
+                }
+
+                foreach (var source in Options.Projections.All)
+                {
+                    foreach (var shard in source.Shards())
+                    {
+                        var identity = shard.Name.Identity;
+
+                        // StatusFor answers Stopped for a shard it has no agent for, which is a
+                        // daemon's own answer and legitimate once a daemon has been reached. It is
+                        // only wrong as a stand-in for "no daemon", which is why nothing calls this
+                        // when none was found.
+                        states[identity] = daemon.StatusFor(identity);
+                    }
+                }
+            }
+        }
+
+        return states;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Closes #5392. Downstream of jasperfx#818, shipped in **JasperFx 2.69.0**.

## The ruling

`IEventStore.GetProjectionStatusesAsync` is the snapshot a monitoring console's projections page
renders before it subscribes to `ShardStatesChanged`. Marten, Polecat and Fisher all implement it,
nothing shared held any of them to it, and the three stores each decided independently — and
reasonably — what the same five `ShardStatus` fields meant.

**`ShardStatus.State` is a fact about the running daemon.** A store that can reach one reports what it
says; a store that cannot reports `Unknown`, which means "there is no daemon here to ask" and is a
genuinely different operational situation from `Stopped`. Marten answered `Unknown` unconditionally,
never reading a daemon at all, so the field carried no information at all.

## What changed

`readAgentStatesAsync()` collects the per-shard `AgentStatus` of whichever daemons are running against
this store, and the `State` slot is filled from it — falling back to `ShardStatusState.Unknown` when
no daemon is visible.

Three constraints shape it, and each one is a way to get this wrong:

- **`AllDaemonsAsync()`, never `DaemonForDatabase`.** This is a diagnostics read, and
  `DaemonForDatabase` is contractually allowed to go looking and *start* a daemon. A projections page
  that starts one by being opened is a monitoring tool with a side effect on the system it monitors.
  The suite pins this separately with `reading_the_statuses_does_not_start_a_daemon`.
- **No coordinator means `Unknown`, and that is the common case** rather than an edge —
  `DaemonMode.ExternallyManaged`, a console in another process, and a hand-built
  `new DocumentStore(options)` (where `Options.Services` is null) all land there.
- **Daemons are matched to this store by `IProjectionDaemon.StoreUri` against `Subject`.** This one is
  not in the issue and is the trap I hit designing it: an application with an ancillary store
  registers a coordinator *per store*, and the non-generic `IProjectionCoordinator` resolves the
  primary one — so without the check, an ancillary store would cheerfully report the **primary**
  store's shard states as its own.

Worth recording: `StatusFor` answers `Stopped` for a shard it has no agent for. That is a daemon's own
answer and legitimate once a daemon has been reached; it is only wrong as a stand-in for "no daemon",
which is why nothing calls it when none was found.

## What Marten already got right

The other eight facts pass as they stand, including the two that cost Polecat work: `EventStoreSequence`
is the head of the event store rather than the high-water row (sourcing it from that row makes every
shard on a stopped daemon look caught up — the opposite of what a projections page is opened to find
out), and the `State` slot never carries a lifecycle.

The suite deliberately does **not** require an empty shard list for an Inline projection. jasperfx#818
proposed it; Marten reports `SignalBoard:All / Unknown / 0 / 0`, which is a coherent answer of a
different kind — a shard name is a registry fact, `Projections.All` has one for an inline
registration, and "here is the shard, nothing is running it" is the same reading of `Unknown` used
everywhere else. Marten's behaviour stands and the requirement was dropped upstream.

## Fixture

`MartenCoordinatorHost` gains `IComplianceCoordinatorHost.EventStore` — a default-throwing interface
member upstream, so nothing broke until it was implemented. It exists because the daemon-visible half
of the ruling is otherwise untestable: every other daemon suite drives a daemon the fixture built by
hand, and a hand-built daemon is precisely the case `Unknown` describes.

## Tests

```
marten_projection_status_compliance — Passed! Failed: 0, Passed: 9, Skipped: 0, Total: 9
```

Including `a_reachable_running_daemon_reports_the_real_shard_state`, which is the fact this PR exists
for.

Two notes on how that was verified, because both matter:

- **The failing baseline is the issue's, not mine.** #5392 records 8/9 against `origin/master` with a
  local 2.69.0 pack, failing exactly that fact. I did not re-derive it on a separate worktree — the
  claim is specific and was checked before the release, and my change is targeted at precisely it. Say
  the word if you want it re-proven independently.
- **That fact could not run here at all until the database moved.** It needs a real running daemon,
  so it needs `pg_current_snapshot()` — PostgreSQL 13+. This machine's Marten container was still on
  the old 12.8 image and had to be rebuilt on master's `postgres:17` Dockerfile first, including
  dropping the stale PG12 data directory the container had carried forward (`FATAL: database files
  are incompatible with server`).

Also bumps the JasperFx family 2.67.0 → 2.69.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01481eiEZg1Bv6pu4DrgPRg3
