### PR TITLE
Register ProjectionEventModelSource from AddMarten (#5394)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -555,15 +555,15 @@
     <PackageVersion Include="Bobcat" Version="0.17.1" />
     <PackageVersion Include="Bobcat.Generators" Version="0.17.1" />
     <PackageVersion Include="Bobcat.Xunit" Version="0.17.1" />
-    <PackageVersion Include="JasperFx" Version="2.67.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.67.0" />
+    <PackageVersion Include="JasperFx" Version="2.69.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.69.0" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.67.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.69.0" />
     <!--
       No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
       whole family moves together, and this note is kept for the history below. This package is
@@ -582,11 +582,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.67.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.69.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.67.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.69.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/CoreTests/projection_event_model_source_registration.cs
+++ b/src/CoreTests/projection_event_model_source_registration.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.EventModeling;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests;
+
+/*
+ * #5394 (jasperfx#825). The store-derived Event Model rung: one SlicePattern.View slice per
+ * registered projection -- the projection, the document it produces, and the events its Apply /
+ * Create methods take -- read straight out of the store's own registry.
+ *
+ * Before this, nothing derived from the store. Bobcat declares slices, Wolverine derives Command and
+ * Automation slices from its chains, CritterWatch observes a running system, and a View slice
+ * appeared on a canvas only when a human had written one down -- grepping marten/src for
+ * EventModelSource returned zero hits.
+ *
+ * These tests pin the REGISTRATION rather than the mapping. The mapping is JasperFx's and is tested
+ * upstream against a substitute store; what only Marten can get wrong is whether AddMarten and
+ * AddMartenStore<T> each hand ProjectionEventModelSource a resolver pointing at the right store --
+ * which is exactly the thing a resolver-taking API exists to let a store get wrong.
+ */
+public interface IEventModelAncillaryStore: IDocumentStore;
+
+public class projection_event_model_source_registration: HostedStoreContext
+{
+    private static async Task<EventModelSliceDescriptor[]> slicesFrom(IServiceProvider services)
+    {
+        var models = await EventModelDiscovery.AssembleAsync(services, CancellationToken.None);
+        return models.SelectMany(x => x.Slices).ToArray();
+    }
+
+    [Fact]
+    public async Task add_marten_derives_a_view_slice_for_a_registered_projection()
+    {
+        var host = await StartHostAsync(opts => opts.Projections.Snapshot<SignalTally>(SnapshotLifecycle.Inline));
+
+        var slices = await slicesFrom(host.Services);
+
+        var slice = slices.ShouldHaveSingleItem();
+
+        // Named after the DOCUMENT, not the projection class: that is what makes a store-derived
+        // slice merge by name with a Bobcat-declared one instead of showing up as a second sticky
+        // saying the same thing.
+        slice.Name.ShouldBe(nameof(SignalTally));
+        slice.Pattern.ShouldBe(SlicePattern.View);
+        slice.ReadModelTypes.Select(x => x.Name).ShouldContain(nameof(SignalTally));
+        slice.ConsumedEvents.Select(x => x.Name).ShouldContain(nameof(SignalRaised));
+    }
+
+    /// <summary>
+    /// The half that only a store can get wrong. An ancillary store registers under a marker type, so
+    /// the resolver AddMartenStore&lt;T&gt; supplies has to name T -- a registration that reached for
+    /// IDocumentStore instead would describe the primary store twice and never mention this one.
+    /// </summary>
+    [Fact]
+    public async Task an_ancillary_store_derives_its_own_view_slices()
+    {
+        var host = await StartHostAsync(
+            opts => opts.Projections.Snapshot<SignalTally>(SnapshotLifecycle.Inline),
+            configureServices: services => services.AddMartenStore<IEventModelAncillaryStore>(opts =>
+            {
+                opts.Connection(ConnectionSource.ConnectionString);
+                opts.DatabaseSchemaName = $"{SchemaName}_ancillary";
+                opts.Projections.Snapshot<AncillaryTally>(SnapshotLifecycle.Inline);
+            }));
+
+        var slices = await slicesFrom(host.Services);
+
+        slices.Select(x => x.Name)
+            .ShouldContain(nameof(AncillaryTally),
+                "The ancillary store contributed no View slice, so AddMartenStore<T> either did not register a source or registered one pointing at the primary store.");
+
+        var ancillary = slices.Single(x => x.Name == nameof(AncillaryTally));
+        ancillary.Pattern.ShouldBe(SlicePattern.View);
+        ancillary.ConsumedEvents.Select(x => x.Name).ShouldContain(nameof(SignalLowered));
+
+        // And the primary store is still described -- two stores in one host, two slices, neither
+        // one swallowing the other.
+        slices.Select(x => x.Name).ShouldContain(nameof(SignalTally));
+    }
+}
+
+public record SignalRaised(string Flag);
+
+public record SignalLowered(string Flag);
+
+public class SignalTally
+{
+    public Guid Id { get; set; }
+    public int Raised { get; set; }
+
+    public void Apply(SignalRaised e) => Raised++;
+}
+
+public class AncillaryTally
+{
+    public Guid Id { get; set; }
+    public int Lowered { get; set; }
+
+    public void Apply(SignalLowered e) => Lowered++;
+}

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using JasperFx.CommandLine.Descriptions;
 using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.EventModeling;
 using JasperFx.Events.Projections;
 using JasperFx.Events.Subscriptions;
 using Marten.Events.Daemon.Coordination;
@@ -214,6 +215,16 @@ public static class MartenServiceCollectionExtensions
         services.EnsureAsyncConfigureMartenApplicationIsRegistered();
         services.AddSingleton<ISystemPart, MartenSystemPart>();
         services.AddSingleton<IEventStore>(s => (IEventStore)s.GetRequiredService<IDocumentStore>());
+
+        // #5394 (jasperfx#825): the store-derived Event Model rung. One SlicePattern.View slice per
+        // registered projection -- the projection, the document it produces, and the events its
+        // Apply/Create/Evolve methods take -- so a View slice appears on an Event Model canvas without
+        // a human having written one down.
+        //
+        // The resolver is the whole reason this call exists here rather than in JasperFx: a store
+        // registers itself under its own interface, and AddMarten is the only place that knows the
+        // primary store's is IDocumentStore. AddMartenStore<T> registers its own with T.
+        services.AddProjectionEventModelSource(s => [(IEventStore)s.GetRequiredService<IDocumentStore>()]);
         services.AddSingleton<IDocumentStoreUsageSource>(s =>
             (IDocumentStoreUsageSource)s.GetRequiredService<IDocumentStore>());
         services.AddSingleton<IDocumentStoreDiagnostics>(s =>
@@ -354,6 +365,13 @@ public static class MartenServiceCollectionExtensions
         services.AddSingleton<IEventStore>(s => (IEventStore)s.GetRequiredService<T>());
         services.AddSingleton<IDocumentStoreUsageSource>(s => (IDocumentStoreUsageSource)s.GetRequiredService<T>());
         services.AddSingleton<IDocumentStoreDiagnostics>(s => (IDocumentStoreDiagnostics)s.GetRequiredService<T>());
+
+        // #5394 (jasperfx#825): an ancillary store derives its own View slices, resolved through its
+        // marker type. Registered per store rather than once over every IEventStore in the container
+        // for the same reason AddMarten's is: the marker is what says WHICH store, and only this
+        // method knows it. Two sources emitting a slice for the same document type is harmless --
+        // slices merge by name, which is what naming them after the document is for.
+        services.AddProjectionEventModelSource(s => [(IEventStore)s.GetRequiredService<T>()]);
 
         var instrument = new SetEventStoreInstrumentation<T>();
         services.AddSingleton<IConfigureMarten<T>>(instrument);


### PR DESCRIPTION
Closes #5394. Downstream of jasperfx#825, shipped in **JasperFx 2.69.0**.

## The gap

Bobcat declares slices, Wolverine derives Command and Automation slices from its chains, CritterWatch
observes a running system — and **nobody derived from the store**. Grepping `marten/src` for
`EventModelDescriptor|EventModelSource|IEventModelDefinitionSource` returned zero hits, so a View
slice — event → projection → read model — appeared on an Event Model canvas only when a human had
written one down.

Yet the store knows this exactly: every registered projection, its lifecycle, the document it
produces, and the event types its `Apply` / `Create` / `Evolve` methods take. That is the whole role
set of a State View slice, derivable with no guessing.

## What Marten does

Two registrations, one line each:

```csharp
// AddMarten
services.AddProjectionEventModelSource(s => [(IEventStore)s.GetRequiredService<IDocumentStore>()]);

// AddMartenStore<T>
services.AddProjectionEventModelSource(s => [(IEventStore)s.GetRequiredService<T>()]);
```

The mapping itself is JasperFx's `ProjectionEventModelSource` and is tested upstream against a
substitute store. **The resolver is the part only Marten can get wrong**, and it is why the upstream
API takes one at all: a store registers itself under its own interface — `IDocumentStore` for the
primary, a marker type for an ancillary — and `AddMarten` / `AddMartenStore<T>` are the only places
that know which.

Registered per store rather than once over every `IEventStore` in the container, for the same reason.
Two sources emitting a slice for the same document type is harmless: slices merge by name, which is
what naming them after the document is for.

## Tests

`projection_event_model_source_registration` pins the registration rather than the mapping — the
mapping has upstream coverage, and what a store can get wrong is which store its resolver points at.

- **The primary store** yields one View slice, named after the *document* rather than the projection
  class (that naming is what makes a store-derived slice merge with a Bobcat-declared one instead of
  becoming a second sticky saying the same thing), carrying the document as its read model and the
  applied event in `ConsumedEvents`.
- **An ancillary store registered with `AddMartenStore<T>`** contributes its *own* View slice, and the
  primary store's is still there beside it. This is the half that would silently fail a registration
  reaching for `IDocumentStore` instead of `T` — it would describe the primary store twice and never
  mention the ancillary one. The assertion message says exactly that, so a future regression reads as
  a sentence rather than as a count mismatch.

```
projection_event_model_source_registration — Passed! Failed: 0, Passed: 2, Total: 2
```

Also bumps the JasperFx family 2.67.0 → 2.69.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01481eiEZg1Bv6pu4DrgPRg3
