### PR TITLE
Bump the JasperFx family to 2.69.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -555,15 +555,28 @@
     <PackageVersion Include="Bobcat" Version="0.17.1" />
     <PackageVersion Include="Bobcat.Generators" Version="0.17.1" />
     <PackageVersion Include="Bobcat.Xunit" Version="0.17.1" />
-    <PackageVersion Include="JasperFx" Version="2.69.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.69.0" />
+    <!--
+      2.69.1 (jasperfx#828 and jasperfx#830): two fixes on top of 2.69.0, and the first lands
+      directly on what marten#5394 registered a release earlier. ProjectionEventModelSource no
+      longer counts a stream's lifecycle events among a read model's ConsumedEvents, so a
+      store-derived View slice lists the events its Apply / Create methods actually take rather
+      than events the stream merely underwent. The second hands SubscriptionExecution the store
+      instead of the database from the ILoggerFactory overload.
+
+      No shared compliance suite changed across this bump, which is the thing worth checking
+      rather than assuming: the EventSourcingTests inventory is identical either side of it
+      (2219 test names before and after, nothing added or removed). A suite that quietly stops
+      enrolling costs nothing in a run total, so the enrollment is diffed by name.
+    -->
+    <PackageVersion Include="JasperFx" Version="2.69.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.69.1" />
     <!--
       The shared cross-store event sourcing compliance suites (#5116). Source-only package: the
       suites compile inside EventSourcingTests so JasperFx's aggregate source generator can bind
       Marten's own session types. Marten.Testing needs it too because MartenComplianceFixture,
       which closes the seam, lives beside the rest of the harness.
     -->
-    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.69.0" />
+    <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.69.1" />
     <!--
       No longer ahead of the rest of the JasperFx line. As of the 2.59.0 bump (marten#5305) the
       whole family moves together, and this note is kept for the history below. This package is
@@ -582,11 +595,11 @@
       which does not care how the instance was constructed. The generator is otherwise byte-identical
       from 2.38.0 through 2.42.0, so this is an isolated swap of that one fix.
     -->
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.69.0">
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.69.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.69.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.69.1" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Moves the JasperFx family 2.69.0 → 2.69.1, across all five pinned packages.

## What is in 2.69.1

Two fixes, and the first is the reason this bump is worth taking promptly rather than waiting for the
next feature release:

- **[jasperfx#830](https://github.com/JasperFx/jasperfx/pull/830) (gh-829) — stream lifecycle events
  are not a read model's consumed events.** This lands directly on `ProjectionEventModelSource`, which
  **#5394 registered from `AddMarten` and `AddMartenStore<T>` one release ago**. Without it, a
  store-derived View slice can list events the *stream* underwent alongside the events the read model's
  `Apply` / `Create` methods actually take — so the slice on an Event Model canvas overstates what the
  projection consumes. Marten is the store that just started emitting those slices, so it is the store
  that would show the overstatement.
- **[jasperfx#828](https://github.com/JasperFx/jasperfx/pull/828) (gh-827)** — `SubscriptionExecution`
  is handed the store rather than the database from the `ILoggerFactory` overload.

## Verification

**The enrollment was diffed by name, not by run total.** A compliance bump can silently drop a suite —
or fail to enroll a new one — while the pass count still looks healthy, which is exactly the failure a
totals check cannot see. So the full `--list-tests` inventory was captured on 2.69.0, the pins were
bumped, and it was captured again:

```
before: 2219 test names      after: 2219 test names
removed: 0                   added: 0
```

Identical either side. Nothing dropped, and 2.69.1 introduces no new shared suite for Marten to enroll
— its new tests live in JasperFx's own test project rather than in `JasperFx.Events.ComplianceTests`.

Then the two changed surfaces, plus the shared suites as a whole:

| run | result |
|---|---|
| `projection_event_model_source_registration` — gh-829's half | **2 / 2** |
| subscription tests — gh-827's half | **13 / 13** |
| the full shared compliance set | **537 passed, 13 skipped, 0 failed** (550) |

The 13 skips are pre-existing capability gates rather than anything this bump caused: the
`unarchiving_*` facts of `StreamArchivingCompliance` (Marten has no `UnArchiveStream`, so
`SupportsUnarchiveStream` is false), `upcasting_compliance` wholesale (Marten's upcasting is its own
implementation rather than the shared `JasperFx.Events.Upcasting` registry, so `SupportsUpcasting` is
false), and one tenant-slicing gate. All three are documented as deliberate divergences on
`MartenComplianceFixture`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01481eiEZg1Bv6pu4DrgPRg3
