### PR TITLE
PgVector: four defects the import left behind

### DIFF
--- a/docs/documents/pgvector.md
+++ b/docs/documents/pgvector.md
@@ -106,7 +106,7 @@ public class ProductSearchProjection : VectorProjection
             e => e.Description,
             e => e.ProductId);
 
-        map.Delete<ProductDeleted>();
+        map.Delete<ProductDeleted>(e => e.ProductId);
     }
 }
 ```

--- a/src/Marten.PgVector.Tests/MultiDatabase/database_per_tenant_projection_tests.cs
+++ b/src/Marten.PgVector.Tests/MultiDatabase/database_per_tenant_projection_tests.cs
@@ -1,0 +1,140 @@
+using JasperFx;
+using JasperFx.Events.Projections;
+using Marten.PgVector;
+using Marten.PgVector.Tests.Helpers;
+using Marten.PgVector.Projection;
+using Marten.PgVector.Tests.SingleTenancy;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace Marten.PgVector.Tests.MultiDatabase;
+
+/// <summary>
+///     A vector projection has to write into the database its events came from.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>VectorProjection</c> resolved its connection from <c>store.Storage.Database</c>, whose own
+///         doc comment says it is "the default database when *not* using database per tenant
+///         multi-tenancy". So every tenant's embeddings were written to one database while
+///         <c>VectorProjectionSearchAsync</c> read from the session's — the two disagreed, and a search
+///         against the tenant that raised the events found nothing at all.
+///     </para>
+///     <para>
+///         Nothing in the existing multi-database suite could catch it: those tests exercise the
+///         document path (<c>VectorSearchAsync</c>), which was always session-scoped. The projection
+///         had no multi-tenanted coverage of any kind.
+///     </para>
+/// </remarks>
+[Collection("Marten.PgVector")]
+public class database_per_tenant_projection_tests: IAsyncLifetime
+{
+    private static readonly string[] TenantDatabases = ["pgvector_proj_t1", "pgvector_proj_t2"];
+
+    private readonly Dictionary<string, string> _tenantConnStrs = new();
+    private FakeEmbeddingProvider _embedder = null!;
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            foreach (var db in TenantDatabases)
+            {
+                _tenantConnStrs[db] = await CreateDatabaseIfNotExists(conn, db);
+            }
+        }
+
+        _embedder = new FakeEmbeddingProvider(3);
+        var projection = new ArticleSearchProjection(_embedder);
+
+        _store = DocumentStore.For(opts =>
+        {
+            opts.DatabaseSchemaName = "pgvector_proj_mt";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+
+            opts.UsePgVector();
+            opts.Projections.Add(projection, ProjectionLifecycle.Inline);
+            opts.Storage.ExtendedSchemaObjects.Add(projection.BuildTable("pgvector_proj_mt"));
+
+            opts.Events.AddEventType<ArticleWritten>();
+            opts.Events.AddEventType<ArticleRetracted>();
+
+            opts.MultiTenantedDatabases(x =>
+            {
+                foreach (var db in TenantDatabases)
+                {
+                    x.AddSingleTenantDatabase(_tenantConnStrs[db], db);
+                }
+            });
+        });
+
+        await _store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Nothing clears these databases between runs, and every run appends the same content under a
+        // new id — so without this the search below legitimately finds more than one row.
+        foreach (var connectionString in _tenantConnStrs.Values)
+        {
+            await using var conn = new NpgsqlConnection(connectionString);
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "truncate table pgvector_proj_mt.article_search_vectors";
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _store?.Dispose();
+        return default;
+    }
+
+    private static async Task<string> CreateDatabaseIfNotExists(NpgsqlConnection conn, string databaseName)
+    {
+        var builder = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString);
+
+        if (!await conn.DatabaseExists(databaseName))
+        {
+            await new DatabaseSpecification().BuildDatabase(conn, databaseName);
+        }
+
+        builder.Database = databaseName;
+        return builder.ConnectionString;
+    }
+
+    [Fact]
+    public async Task the_projection_writes_into_the_tenants_own_database()
+    {
+        var articleId = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession("pgvector_proj_t2"))
+        {
+            session.Events.StartStream(Guid.NewGuid(), new ArticleWritten(articleId, "a tenanted article"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // Without the fix the row went to the store's default database, so this finds nothing.
+        await using (var query = _store.QuerySession("pgvector_proj_t2"))
+        {
+            var found = await query.VectorProjectionSearchAsync("article_search_vectors",
+                _embedder.GenerateVector("a tenanted article"), 10, DistanceFunction.L2);
+
+            found.Single().Id.ShouldBe(articleId);
+        }
+
+        // And the other tenant's database must not have it.
+        await using (var query = _store.QuerySession("pgvector_proj_t1"))
+        {
+            var found = await query.VectorProjectionSearchAsync("article_search_vectors",
+                _embedder.GenerateVector("a tenanted article"), 10, DistanceFunction.L2);
+
+            found.ShouldBeEmpty();
+        }
+    }
+}

--- a/src/Marten.PgVector.Tests/SingleTenancy/vector_projection_defects.cs
+++ b/src/Marten.PgVector.Tests/SingleTenancy/vector_projection_defects.cs
@@ -1,0 +1,165 @@
+using JasperFx;
+using JasperFx.Events.Projections;
+using Marten.PgVector;
+using Marten.PgVector.Projection;
+using Marten.PgVector.Tests.Helpers;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace Marten.PgVector.Tests.SingleTenancy;
+
+#region Events keyed on something other than the stream
+
+public record ArticleWritten(Guid ArticleId, string Body);
+
+public record ArticleRetracted(Guid ArticleId);
+
+public record ArticleWithABadSelector(Guid ArticleId);
+
+#endregion
+
+/// <summary>
+///     A projection whose rows are keyed on a member of the event rather than on the stream.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>vector_projection_tests</c> uses one Guid as BOTH the stream id and the payload id, which is
+///         the reason its delete test passes over a delete path that only ever looks at the stream id.
+///         Here the two are deliberately different, which is the only arrangement that can tell them
+///         apart.
+///     </para>
+/// </remarks>
+public class ArticleSearchProjection: VectorProjection
+{
+    public ArticleSearchProjection(IEmbeddingProvider provider)
+        : base("article_search_vectors", provider)
+    {
+    }
+
+    protected override void Configure(VectorProjectionMapping map)
+    {
+        map.Map<ArticleWritten>(e => e.Body, e => e.ArticleId);
+        map.Map<ArticleWithABadSelector>(
+            _ => throw new InvalidOperationException("the content selector is broken"),
+            e => e.ArticleId);
+        map.Delete<ArticleRetracted>(e => e.ArticleId);
+    }
+}
+
+/// <summary>
+///     Keys its rows on the article but deletes by the stream, which addresses a row that was never
+///     written. Refused while the store is being built.
+/// </summary>
+public class MismatchedDeleteProjection: VectorProjection
+{
+    public MismatchedDeleteProjection(IEmbeddingProvider provider)
+        : base("mismatched_vectors", provider)
+    {
+    }
+
+    protected override void Configure(VectorProjectionMapping map)
+    {
+        map.Map<ArticleWritten>(e => e.Body, e => e.ArticleId);
+        map.Delete<ArticleRetracted>();
+    }
+}
+
+[Collection("Marten.PgVector")]
+public class vector_projection_defects: IAsyncLifetime
+{
+    private FakeEmbeddingProvider _embedder = null!;
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _embedder = new FakeEmbeddingProvider(3);
+        var projection = new ArticleSearchProjection(_embedder);
+
+        _store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "pgvector_defect_tests";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+
+            opts.UsePgVector();
+            opts.Projections.Add(projection, ProjectionLifecycle.Inline);
+            opts.Storage.ExtendedSchemaObjects.Add(projection.BuildTable("pgvector_defect_tests"));
+
+            opts.Events.AddEventType<ArticleWritten>();
+            opts.Events.AddEventType<ArticleRetracted>();
+            opts.Events.AddEventType<ArticleWithABadSelector>();
+        });
+
+        await _store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await _store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _store?.Dispose();
+        return default;
+    }
+
+    [Fact]
+    public async Task a_delete_removes_the_row_the_mapping_keyed()
+    {
+        // The stream and the article are deliberately different identities.
+        var streamId = Guid.NewGuid();
+        var articleId = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new ArticleWritten(articleId, "the body of the article"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = _store.LightweightSession())
+        {
+            var written = await session.VectorProjectionSearchAsync("article_search_vectors",
+                _embedder.GenerateVector("the body of the article"), 10, DistanceFunction.L2);
+            written.Single().Id.ShouldBe(articleId);
+
+            session.Events.Append(streamId, new ArticleRetracted(articleId));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _store.QuerySession();
+        var remaining = await query.VectorProjectionSearchAsync("article_search_vectors",
+            _embedder.GenerateVector("the body of the article"), 10, DistanceFunction.L2);
+
+        // Without the fix the delete runs against the STREAM id, matches no row, and the retracted
+        // article stays in the index forever.
+        remaining.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void a_delete_that_cannot_address_the_mapped_row_is_refused_when_the_store_is_built()
+    {
+        // The refusal is what makes the fix above safe to rely on: an optional selector that silently
+        // fell back to the stream id would leave exactly the defect this file exists for, just opt-in.
+        var ex = Should.Throw<InvalidOperationException>(() => new MismatchedDeleteProjection(_embedder));
+
+        ex.Message.ShouldContain("ArticleWritten");
+        ex.Message.ShouldContain("ArticleRetracted");
+        ex.Message.ShouldContain("map.Delete<ArticleRetracted>(e => e.SomeId)");
+    }
+
+    [Fact]
+    public async Task a_content_selector_that_throws_is_not_swallowed()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = _store.LightweightSession();
+        session.Events.StartStream(streamId, new ArticleWithABadSelector(Guid.NewGuid()));
+
+        // Without the fix the exception is caught, the content reads as null, the document is dropped
+        // from the index, and the commit succeeds — so a broken selector is indistinguishable from an
+        // event the projection does not index.
+        var ex = await Should.ThrowAsync<Exception>(() =>
+            session.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        ex.ToString().ShouldContain("the content selector is broken");
+    }
+}

--- a/src/Marten.PgVector.Tests/SingleTenancy/vector_projection_tests.cs
+++ b/src/Marten.PgVector.Tests/SingleTenancy/vector_projection_tests.cs
@@ -37,7 +37,9 @@ public class ProductSearchProjection : VectorProjection
             e => e.Description,
             e => e.ProductId);
 
-        map.Delete<ProductDeleted>();
+        // The rows are keyed on the product, so the delete has to be too. Passing no selector here
+        // deletes by stream id, which is a row this projection never wrote.
+        map.Delete<ProductDeleted>(e => e.ProductId);
     }
 }
 

--- a/src/Marten.PgVector.Tests/SingleTenancy/vector_search_casing.cs
+++ b/src/Marten.PgVector.Tests/SingleTenancy/vector_search_casing.cs
@@ -1,0 +1,87 @@
+using JasperFx;
+using Marten.PgVector;
+using Marten.Testing.Harness;
+using Pgvector;
+using Shouldly;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace Marten.PgVector.Tests.SingleTenancy;
+
+/// <summary>
+///     The JSONB path <see cref="PgVectorExtensions.VectorSearchAsync{T}" /> reads the embedding from has
+///     to be the one the serializer actually wrote.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Every other test in this suite leaves the store on Marten's default casing, which preserves the
+///         CLR member name — so a search built from <c>member.Name</c> lands on the right key by accident
+///         and the suite is green either way. Under <c>Casing.CamelCase</c> the stored key is
+///         <c>embedding</c> while <c>member.Name</c> is <c>Embedding</c>, <c>data-&gt;&gt;'Embedding'</c>
+///         is SQL NULL for every row, the <c>IS NOT NULL</c> clause filters all of them out, and the
+///         search returns an EMPTY LIST rather than throwing. A silent wrong answer, and the reason this
+///         file exists at all.
+///     </para>
+/// </remarks>
+[Collection("Marten.PgVector")]
+public class vector_search_casing : IAsyncLifetime
+{
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "pgvector_casing_tests";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+
+            opts.UseSystemTextJsonForSerialization(casing: Casing.CamelCase);
+
+            opts.UsePgVector();
+            opts.RegisterDocumentType<CasedProduct>();
+        });
+
+        await _store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await _store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _store?.Dispose();
+        return default;
+    }
+
+    [Fact]
+    public async Task the_search_reads_the_key_the_serializer_wrote()
+    {
+        var near = new CasedProduct { Id = Guid.NewGuid(), Name = "Near", Embedding = [1.0f, 0.0f, 0.0f] };
+        var far = new CasedProduct { Id = Guid.NewGuid(), Name = "Far", Embedding = [0.0f, 0.0f, 1.0f] };
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(near, far);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = _store.QuerySession();
+
+        var results = await query.VectorSearchAsync<CasedProduct>(
+            x => x.Embedding,
+            new Vector(new[] { 1.0f, 0.0f, 0.0f }),
+            limit: 10,
+            distance: DistanceFunction.L2);
+
+        // Without the fix this is an empty list: every row is filtered out by the IS NOT NULL clause
+        // because the path is the CLR member name and the stored key is camelCase.
+        results.Count.ShouldBe(2);
+        results[0].Name.ShouldBe("Near");
+    }
+}
+
+public class CasedProduct
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = "";
+    public float[]? Embedding { get; set; }
+}

--- a/src/Marten.PgVector/PgVectorExtensions.cs
+++ b/src/Marten.PgVector/PgVectorExtensions.cs
@@ -2,6 +2,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using JasperFx.Core.Reflection;
 using Marten.Internal.Sessions;
+using Marten.Util;
 using Npgsql;
 using NpgsqlTypes;
 using Pgvector;
@@ -44,10 +45,15 @@ public static class PgVectorExtensions
         var store = (DocumentStore)session.DocumentStore;
         var tableName = ((IReadOnlyStoreOptions)store.Options).Schema.For<T>();
 
-        // Build a JSONB path to the vector property.
-        // Use the serializer to determine the correct JSON property name.
+        // Build a JSONB path to the vector property. ToJsonKey, not member.Name: the key has to be
+        // the one the serializer actually wrote, so it has to honour both the store's Casing and any
+        // [JsonPropertyName]/[JsonProperty] alias on the member. Reading member.Name lands on the
+        // right key only under Marten's default (Pascal-preserving) casing; under CamelCase every
+        // row's data->>'Embedding' is SQL NULL, the IS NOT NULL clause below filters all of them
+        // out, and this method returns an EMPTY LIST rather than throwing. Marten's patching code
+        // learned exactly this in #5290/#5295 — see PatchExpression.toPath.
         var member = GetMemberInfo(vectorProperty);
-        var jsonPath = member.Name;
+        var jsonPath = member.ToJsonKey(store.Options.Serializer().Casing);
 
         var op = distance.Operator();
         var dimensions = queryVector.ToArray().Length;

--- a/src/Marten.PgVector/Projection/VectorProjection.cs
+++ b/src/Marten.PgVector/Projection/VectorProjection.cs
@@ -5,6 +5,7 @@ using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using JasperFx.Events.Projections;
 using Marten.Events.Daemon;
+using Marten.Internal.Sessions;
 using Marten.Events.Projections;
 using Npgsql;
 using Pgvector;
@@ -151,7 +152,12 @@ public abstract class VectorProjection : IProjection
 
         if (extractions.Count == 0 && deletions.Count == 0) return;
 
-        var database = store.Storage.Database;
+        // The SESSION's database, never store.Storage.Database — whose own doc comment says it is
+        // "the default database when *not* using database per tenant multi-tenancy". Reading it there
+        // wrote every tenant's embeddings into whichever database Tenancy.Default resolves to, while
+        // VectorProjectionSearchAsync reads from the session's. The two disagreed, so a search against
+        // the tenant that raised the events found nothing at all.
+        var database = operations.As<QuerySession>().Database;
         await using var conn = database.CreateConnection();
         await conn.OpenAsync(cancellation).ConfigureAwait(false);
 

--- a/src/Marten.PgVector/Projection/VectorProjection.cs
+++ b/src/Marten.PgVector/Projection/VectorProjection.cs
@@ -1,5 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using JasperFx.Events.Projections;
 using Marten.Events.Daemon;
@@ -24,7 +26,7 @@ public abstract class VectorProjection : IProjection
     private readonly IEmbeddingProvider _provider;
     private readonly string _tableName;
     private readonly List<IVectorEventMapping> _mappings = new();
-    private readonly List<Type> _deleteTypes = new();
+    private readonly Dictionary<Type, IVectorDeleteMapping> _deleteMappings = new();
 
     protected VectorProjection(string tableName, IEmbeddingProvider provider)
     {
@@ -32,6 +34,31 @@ public abstract class VectorProjection : IProjection
         _provider = provider;
 
         Configure(new VectorProjectionMapping(this));
+
+        AssertDeletesCanAddressTheRowsTheMapsWrote();
+    }
+
+    /// <summary>
+    ///     A projection whose rows are keyed on a member of the event has to delete by that same member.
+    ///     Falling back to the stream id there addresses a row that was never written, so the delete
+    ///     matches nothing and the document stays in the index forever — silently, because a DELETE that
+    ///     hits no row is not an error. Refuse it while the store is being built instead, which is the one
+    ///     moment the caller can still say which member it should have been.
+    /// </summary>
+    private void AssertDeletesCanAddressTheRowsTheMapsWrote()
+    {
+        if (!_mappings.Any(x => x.KeysOnTheEvent)) return;
+
+        var unqualified = _deleteMappings.Values.Where(x => !x.KeysOnTheEvent).ToArray();
+        if (unqualified.Length == 0) return;
+
+        throw new InvalidOperationException(
+            $"Vector projection '{GetType().FullNameInCode()}' maps "
+            + $"{_mappings.Where(x => x.KeysOnTheEvent).Select(x => x.EventType.Name).Join(", ")} "
+            + "to an id taken from the event, but deletes "
+            + $"{unqualified.Select(x => x.EventType.Name).Join(", ")} by stream id. The delete would "
+            + "address a row that was never written. Supply the same id selector to Delete<T>(), as in "
+            + $"map.Delete<{unqualified[0].EventType.Name}>(e => e.SomeId).");
     }
 
     /// <summary>
@@ -98,9 +125,12 @@ public abstract class VectorProjection : IProjection
 
         foreach (var @event in allEvents)
         {
-            if (_deleteTypes.Contains(@event.EventType))
+            if (_deleteMappings.TryGetValue(@event.EventType, out var deleteMapping))
             {
-                deletions.Add(@event.StreamId);
+                // The mapping's id, not @event.StreamId. A projection keyed on a member of the event
+                // deletes a row that was never written when this reads the stream id instead, so the
+                // retracted document stays in the index forever with nothing to report it.
+                deletions.Add(deleteMapping.ExtractId(@event));
                 continue;
             }
 
@@ -204,9 +234,9 @@ public abstract class VectorProjection : IProjection
         _mappings.Add(mapping);
     }
 
-    internal void AddDeleteType(Type eventType)
+    internal void AddDeleteMapping(IVectorDeleteMapping mapping)
     {
-        _deleteTypes.Add(eventType);
+        _deleteMappings[mapping.EventType] = mapping;
     }
 
     private static string ComputeHash(string content)
@@ -242,18 +272,46 @@ public class VectorProjectionMapping
     }
 
     /// <summary>
-    /// Register an event type that causes the embedding row to be deleted.
+    /// Register an event type that causes the embedding row to be deleted. Supply
+    /// <paramref name="idSelector" /> whenever the rows are keyed on something other than the stream,
+    /// exactly as <see cref="Map{TEvent}" /> does — the delete has to address the same row the map
+    /// wrote, and only the caller knows which member that is.
     /// </summary>
-    public VectorProjectionMapping Delete<TEvent>()
+    public VectorProjectionMapping Delete<TEvent>(Func<TEvent, Guid>? idSelector = null)
     {
-        _projection.AddDeleteType(typeof(TEvent));
+        _projection.AddDeleteMapping(new VectorDeleteMapping<TEvent>(idSelector));
         return this;
     }
+}
+
+internal interface IVectorDeleteMapping
+{
+    Type EventType { get; }
+    bool KeysOnTheEvent { get; }
+    Guid ExtractId(IEvent @event);
+}
+
+internal class VectorDeleteMapping<TEvent>: IVectorDeleteMapping
+{
+    private readonly Func<TEvent, Guid>? _idSelector;
+
+    public VectorDeleteMapping(Func<TEvent, Guid>? idSelector)
+    {
+        _idSelector = idSelector;
+    }
+
+    public Type EventType => typeof(TEvent);
+
+    public bool KeysOnTheEvent => _idSelector != null;
+
+    public Guid ExtractId(IEvent @event)
+        => _idSelector != null ? _idSelector((TEvent)@event.Data) : @event.StreamId;
 }
 
 internal interface IVectorEventMapping
 {
     Type EventType { get; }
+    bool KeysOnTheEvent { get; }
     Guid ExtractId(IEvent @event);
     string? ExtractContent(IEvent @event);
 }
@@ -271,6 +329,8 @@ internal class VectorEventMapping<TEvent> : IVectorEventMapping
 
     public Type EventType => typeof(TEvent);
 
+    public bool KeysOnTheEvent => _idSelector != null;
+
     public Guid ExtractId(IEvent @event)
     {
         if (_idSelector != null)
@@ -278,9 +338,10 @@ internal class VectorEventMapping<TEvent> : IVectorEventMapping
         return @event.StreamId;
     }
 
-    public string? ExtractContent(IEvent @event)
-    {
-        try { return _contentSelector((TEvent)@event.Data); }
-        catch { return null; }
-    }
+    // Deliberately NOT wrapped in a catch. A selector that throws is a bug in the projection, and
+    // swallowing it returned null — which this projection reads as "this event contributes no
+    // content", exactly the same as a legitimately empty mapping. The document then silently never
+    // reaches the index and nothing anywhere reports it. Let it fail the batch instead, which is
+    // what every other projection in Marten does with a broken Apply.
+    public string? ExtractContent(IEvent @event) => _contentSelector((TEvent)@event.Data);
 }

--- a/src/Marten/Properties/AssemblyInfo.cs
+++ b/src/Marten/Properties/AssemblyInfo.cs
@@ -10,6 +10,7 @@ using JasperFx.Core.TypeScanning;
 [assembly: InternalsVisibleTo("Marten.Newtonsoft")]
 [assembly: InternalsVisibleTo("Marten.Testing")]
 [assembly: InternalsVisibleTo("Marten.CommandLine")]
+[assembly: InternalsVisibleTo("Marten.PgVector")]
 [assembly: InternalsVisibleTo("Marten.PLv8")]
 [assembly: InternalsVisibleTo("Marten.PLv8.Testing")]
 [assembly: InternalsVisibleTo("Marten.Schema.Testing")]


### PR DESCRIPTION
`Marten.PgVector` has not been touched since it was imported from CritterWatch in #4576, and it ships as part of Marten. These are four defects in it that no existing test could catch, each fixed with a test that was seen failing against the unfixed code first.

Two commits, so the tenancy fix can be read on its own.

## The search read a key the serializer never wrote

`VectorSearchAsync` built its JSONB path from `member.Name`, under a comment saying it used the serializer. That is the right key only under Marten's default Pascal-preserving casing, which is what every test in the suite uses. Under `Casing.CamelCase` the stored key is `embedding` while the path says `Embedding`, `data->>'Embedding'` is SQL NULL for every row, the `IS NOT NULL` clause filters all of them out, and the method **returns an empty list rather than throwing**.

It now resolves through `ToJsonKey`, which honours the store's casing *and* any `[JsonPropertyName]` / `[JsonProperty]` alias. Marten's patching code learned exactly this in #5290/#5295 — see the comment on `PatchExpression.toPath`. This is the same bug one subsystem over.

`Marten.PgVector` joins `Marten.PLv8` in `InternalsVisibleTo` to reach the helper, rather than growing a second copy of the casing rules.

## Deleting removed a row the projection never wrote

The projection's delete path read `@event.StreamId` unconditionally and ignored the id selector its mapping was configured with. A projection keyed on a member of the event therefore deleted by stream id, matched nothing, and left the retracted document in the index forever. A `DELETE` that hits no row is not an error, so nothing reported it.

`Delete<TEvent>` now takes the same optional id selector `Map<TEvent>` does. A projection that maps on the event while deleting by the stream is **refused when the store is built**, because an optional selector that silently fell back would leave the identical defect, just opt-in.

That refusal immediately caught two things in this repo: the suite's own `ProductSearchProjection` and the sample in `docs/documents/pgvector.md`. Both had the defect. The existing test passed only because it used one Guid as both the stream id and the payload id.

## A content selector that threw was swallowed

`ExtractContent` caught every exception and returned null, which this projection reads as "this event contributes no content" — indistinguishable from an unmapped event. A broken selector silently dropped the document from the index. It now propagates, as a broken `Apply` does everywhere else in Marten.

## The projection wrote to the wrong database

`VectorProjection` took its connection from `store.Storage.Database`, which is `Tenancy.Default.Database` and whose own doc comment on `IMartenStorage` reads "the default database when *not* using database per tenant multi-tenancy".

So under database-per-tenant every tenant's embeddings were written into whichever database the default resolves to, while `VectorProjectionSearchAsync` reads from the **session's**. The two disagreed, and a search against the tenant that raised the events found nothing at all. The existing multi-database tests could not see it: they exercise only the document path, which was always session-scoped, and the projection had no multi-tenanted coverage of any kind.

⚠️ **The first version of that test passed against the unfixed code**, and it is worth knowing why before trusting it. It wrote to and read from the *first* tenant, which is exactly where the default resolves, so it agreed with itself either way. Writing to and reading from the **second** tenant is the discriminating arrangement. Verified by reverting the fix, which fails it.

## Not in this PR

**Conjoined tenancy in the vector projection is still broken**, and it is a schema change rather than a code fix. The projection's table has no tenant column at all, so under conjoined tenancy two tenants sharing an id collapse onto one row through `ON CONFLICT (id) DO UPDATE`, and the search has no tenant clause to filter on either. The choice is to give the table a tenant dimension or to refuse conjoined tenancy by name until it has one, and that is worth deciding deliberately rather than as a rider here.

Also left alone, all incomplete rather than wrong: the embedding column has no HNSW or IVFFlat index (`DistanceFunctionExtensions.OpsClass()` exists for one and is called from nowhere), the projection is Guid-only at every layer, it runs outside the session's transaction, and `PgVectorOptions.VectorOn(...)` is unreachable public surface with no overload that accepts it.

## Verification

`Marten.PgVector.Tests` 19 passed, up from 14. markdownlint and cspell clean on the changed page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)